### PR TITLE
#68 Added AUD holiday calendar with NSW bank holiday

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,8 @@ Key design goals:
 | `CH` | Switzerland National Holidays |
 | `DE` | Germany National Holidays |
 | `FR` | France National Holidays |
-| `AU` | Australia National Holidays |
+| `AU` | Australian Securities Exchange (ASX) Holidays |
+| `AUD` | Australia (RBA) Holidays |
 | `SG` | Singapore Exchange (SGX) Holidays |
 
 ## Installation

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -36,6 +36,7 @@ module org.holiday.calendar.western {
 
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceAU,
+        org.holiday.calendar.impl.HolidayCalendarServiceAUD,
         org.holiday.calendar.impl.HolidayCalendarServiceCA,
         org.holiday.calendar.impl.HolidayCalendarServiceCH,
         org.holiday.calendar.impl.HolidayCalendarServiceDE,

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
@@ -40,7 +40,7 @@ import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
 
     private static final String CODE = "AU";
-    private static final String NAME = "Australia (ASX) Holidays";
+    private static final String NAME = "Australian Securities Exchange (ASX) Holidays";
 
     public HolidayCalendarServiceAU() {
         super(CODE, NAME);

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAUD.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAUD.java
@@ -1,0 +1,135 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.au.BankHoliday;
+import org.holiday.calendar.observance.au.KingsBirthday;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+
+import java.time.Month;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of Australia (RBA) holiday calendar.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceAUD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "AUD";
+    private static final String NAME = "Australia (RBA) Holidays";
+
+    public HolidayCalendarServiceAUD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final EasterObservance easter = new WesternEaster();
+
+        final Holiday newYearsDay = Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JANUARY, 1)
+                .build();
+        final Holiday australiaDay = Holiday.builder()
+                .name("Australia Day")
+                .description("Australia Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JANUARY, 26)
+                .build();
+        final Holiday goodFriday = Holiday.builder()
+                .name("Good Friday")
+                .description("Friday before Easter Sunday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new GoodFriday(easter))
+                .build();
+        final Holiday easterMonday = Holiday.builder()
+                .name("Easter Monday")
+                .description("Monday after Easter Sunday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EasterMonday(easter))
+                .build();
+        final Holiday anzacDay = Holiday.builder()
+                .name("ANZAC Day")
+                .description("ANZAC Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.APRIL, 25)
+                .build();
+        final Holiday kingsBirthday = Holiday.builder()
+                .name("King's Birthday")
+                .description("King's Birthday (RBA; 2nd Monday in June)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new KingsBirthday())
+                .build();
+        final Holiday bankHoliday = Holiday.builder()
+                .name("Bank Holiday")
+                .description("NSW Bank Holiday (1st Monday in August)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new BankHoliday())
+                .build();
+        final Holiday christmasDay = Holiday.builder()
+                .name("Christmas Day")
+                .description("Celebration of traditional Christmas holiday")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 25)
+                .build();
+        final Holiday boxingDay = Holiday.builder()
+                .name("Boxing Day")
+                .description("Day after Christmas")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 26)
+                .build();
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.previousFridayOrFollowingMonday())
+                .weekendDays(STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(australiaDay)
+                .holiday(goodFriday)
+                .holiday(easterMonday)
+                .holiday(anzacDay)
+                .holiday(kingsBirthday)
+                .holiday(bankHoliday)
+                .holiday(christmasDay)
+                .holiday(boxingDay)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/BankHoliday.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/BankHoliday.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Observance of the Bank Holiday public holiday in New South Wales, Australia,
+ * observed on the first Monday in August.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class BankHoliday extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return Year.of(year)
+                   .atMonth(Month.AUGUST)
+                   .atDay(1)
+                   .with(TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.MONDAY));
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,4 +1,5 @@
 org.holiday.calendar.impl.HolidayCalendarServiceAU
+org.holiday.calendar.impl.HolidayCalendarServiceAUD
 org.holiday.calendar.impl.HolidayCalendarServiceCA
 org.holiday.calendar.impl.HolidayCalendarServiceCH
 org.holiday.calendar.impl.HolidayCalendarServiceDE

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUDTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUDTest.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.testng.annotations.DataProvider;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+
+public class HolidayCalendarServiceAUDTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "AUD";
+
+    public HolidayCalendarServiceAUDTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        final Object[] bankHoliday = {"Bank Holiday"};
+        final Object[] anzacDay = {"ANZAC Day"};
+        return Arrays.asList(bankHoliday, anzacDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // Christmas Day 2021: Dec 25 is Saturday -> rolls to Friday Dec 24
+        final Object[] christmas21 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 24)};
+        // Christmas Day 2022: Dec 25 is Sunday -> rolls to Monday Dec 26
+        final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // Christmas Day 2023: Dec 25 is Monday -> no roll
+        final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // Boxing Day 2021: Dec 26 is Sunday -> rolls to Monday Dec 27
+        final Object[] boxingDay21 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 27)};
+        // Boxing Day 2022: Dec 26 is Monday -> no roll
+        final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // Boxing Day 2023: Dec 26 is Tuesday -> no roll
+        final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        // Australia Day 2020: Jan 26 is Sunday -> rolls to Monday Jan 27
+        final Object[] australiaDay20 = {2020, "Australia Day", LocalDate.of(2020, Month.JANUARY, 27)};
+        // Australia Day 2023: Jan 26 is Thursday -> no roll
+        final Object[] australiaDay23 = {2023, "Australia Day", LocalDate.of(2023, Month.JANUARY, 26)};
+        // Bank Holiday 2024: 1st Monday in August = Aug 5
+        final Object[] bankHoliday24 = {2024, "Bank Holiday", LocalDate.of(2024, Month.AUGUST, 5)};
+        // Bank Holiday 2025: 1st Monday in August = Aug 4
+        final Object[] bankHoliday25 = {2025, "Bank Holiday", LocalDate.of(2025, Month.AUGUST, 4)};
+        return Arrays.asList(christmas21, christmas22, christmas23,
+                             boxingDay21, boxingDay22, boxingDay23,
+                             australiaDay20, australiaDay23,
+                             bankHoliday24, bankHoliday25).listIterator();
+    }
+
+}


### PR DESCRIPTION
### #68 Added AUD holiday calendar with NSW bank holiday

**Description**

- Added `BankHoliday` observance (1st Monday in August) for the NSW Bank Holiday
- Added `HolidayCalendarServiceAUD` implementing the RBA holiday calendar (code `AUD`)
- Registered `AUD` calendar in `module-info.java` and `META-INF/services`
- Added `HolidayCalendarServiceAUDTest` with 13 test cases covering rolling and observance correctness

**Related Issue**

Closes #68

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed