### PR TITLE
#80 Fix SonarCloud workflow for Dependabot + Node 24 upgrade

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,6 +20,9 @@ on:
   schedule:
     - cron: '39 8 * * 4'
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -7,6 +7,10 @@ on:
       - develop
   pull_request:
     types: [opened, synchronize, reopened]
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   build:
     name: Build and analyze
@@ -33,6 +37,7 @@ jobs:
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
           restore-keys: ${{ runner.os }}-m2
       - name: Build and analyze
+        if: ${{ github.actor != 'dependabot[bot]' }}
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=holiday-calendar_holiday-calendar-java

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish-release:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,6 +7,9 @@ on:
     types:
       - completed
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest


### PR DESCRIPTION
### Fix SonarCloud workflow for Dependabot + Node 24 upgrade

**Description**

- Skip SonarCloud analysis step in `maven-build.yml` when triggered by Dependabot, as Dependabot PRs cannot access repository secrets (`SONAR_TOKEN`) due to GitHub's security restrictions
- Added `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to all four workflow files (`maven-build.yml`, `codeql-analysis.yml`, `publish-release.yml`, `publish-snapshot.yml`) to suppress Node.js 16/20 deprecation warnings

**Related Issue**

- [#80 Fix SonarCloud issue in GitHub Actions workflow](https://github.com/holiday-calendar/holiday-calendar-java/issues/80)

**Type of Change**

- [x] Other (please describe): CI/CD workflow fix — no production code changes

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [x] Screenshots or additional notes added, if needed

Closes #80