### PR TITLE
#67 Added USD (Federal Reserve) holiday calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Key design goals:
 | Code | Region |
 |------|--------|
 | `US` | United States National Holidays |
+| `USD` | United States (Federal Reserve) Holidays |
 | `CA` | Canada National Holidays |
 | `CAD` | Bank of Canada (Lynx) Holidays |
 | `UK` | United Kingdom National Holidays |

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -45,5 +45,6 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceFR,
         org.holiday.calendar.impl.HolidayCalendarServiceGBP,
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
-        org.holiday.calendar.impl.HolidayCalendarServiceUS;
+        org.holiday.calendar.impl.HolidayCalendarServiceUS,
+        org.holiday.calendar.impl.HolidayCalendarServiceUSD;
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUSD.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUSD.java
@@ -1,0 +1,157 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.us.*;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of USD (Federal Reserve) holiday calendar.
+ *
+ * <p>Covers the 11 federal holidays observed by the US Federal Reserve System
+ * for Fedwire Funds Service (USD RTGS) settlement. Distinct from the US (NYSE)
+ * calendar: includes Columbus Day and Veterans Day; excludes Good Friday and
+ * Day After Thanksgiving (NYSE-only market conventions).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ * @see <a href="https://www.federalreserve.gov/aboutthefed/k8.htm">Federal Reserve Holiday Schedule (K.8)</a>
+ */
+public class HolidayCalendarServiceUSD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "USD";
+    private static final String NAME = "United States (Federal Reserve) Holidays";
+
+    public HolidayCalendarServiceUSD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday newYearsDay = Holiday.builder()
+                                           .name("New Year's Day")
+                                           .description("First day of new year in the Common Era (CE)")
+                                           .type(Holiday.Type.FIXED)
+                                           .rollable(true)
+                                           .monthDay(Month.JANUARY, 1)
+                                           .build();
+        final Holiday mlkDay = Holiday.builder()
+                                      .name("Martin Luther King Jr. Day")
+                                      .description("Observed birthday of Martin Luther King, Jr.")
+                                      .type(Holiday.Type.FLOATING)
+                                      .rollable(false)
+                                      .observance(new MartinLutherKingJrDay())
+                                      .build();
+        final Holiday presidentsDay = Holiday.builder()
+                                             .name("Presidents' Day")
+                                             .description("Commemoration of Presidents of the United States")
+                                             .type(Holiday.Type.FLOATING)
+                                             .rollable(false)
+                                             .observance(new PresidentsDay())
+                                             .build();
+        final Holiday memorialDay = Holiday.builder()
+                                           .name("Memorial Day")
+                                           .description("Commemoration of fallen service members of US armed forces")
+                                           .type(Holiday.Type.FLOATING)
+                                           .rollable(false)
+                                           .observance(new MemorialDay())
+                                           .build();
+        // Juneteenth became a federal holiday on June 17, 2021. Implemented as
+        // FLOATING so the Observance can return null for years before 2021,
+        // causing HolidayCalendar.calculate() to silently omit it.
+        // rollable(true) applies the Saturday→Friday / Sunday→Monday roll
+        // (e.g., June 19, 2021 was Saturday → observed Friday June 18, 2021).
+        final Holiday juneteenth = Holiday.builder()
+                                          .name("Juneteenth")
+                                          .description("Commemoration of emancipation of African-American slaves")
+                                          .type(Holiday.Type.FLOATING)
+                                          .rollable(true)
+                                          .observance(year -> year < 2021 ? null : LocalDate.of(year, Month.JUNE, 19))
+                                          .build();
+        final Holiday independenceDay = Holiday.builder()
+                                               .name("Independence Day")
+                                               .description("Celebration of US Declaration of Independence")
+                                               .type(Holiday.Type.FIXED)
+                                               .rollable(true)
+                                               .monthDay(Month.JULY, 4)
+                                               .build();
+        final Holiday laborDay = Holiday.builder()
+                                        .name("Labor Day")
+                                        .description("US Labor Day")
+                                        .type(Holiday.Type.FLOATING)
+                                        .rollable(false)
+                                        .observance(new LaborDay())
+                                        .build();
+        // Columbus Day: observed by the Federal Reserve; NOT observed by NYSE.
+        final Holiday columbusDay = Holiday.builder()
+                                           .name("Columbus Day")
+                                           .description("Anniversary of the arrival of Christopher Columbus in the Americas")
+                                           .type(Holiday.Type.FLOATING)
+                                           .rollable(false)
+                                           .observance(new ColumbusDay())
+                                           .build();
+        // Veterans Day: observed by the Federal Reserve; NOT observed by NYSE.
+        final Holiday veteransDay = Holiday.builder()
+                                           .name("Veterans Day")
+                                           .description("Commemoration of all US veterans of foreign wars")
+                                           .type(Holiday.Type.FIXED)
+                                           .rollable(true)
+                                           .monthDay(Month.NOVEMBER, 11)
+                                           .build();
+        final Holiday thanksgiving = Holiday.builder()
+                                            .name("Thanksgiving")
+                                            .description("Day to give thanks")
+                                            .type(Holiday.Type.FLOATING)
+                                            .rollable(false)
+                                            .observance(new Thanksgiving())
+                                            .build();
+        final Holiday christmasDay = Holiday.builder()
+                                            .name("Christmas Day")
+                                            .description("Celebration of traditional Christmas holiday")
+                                            .type(Holiday.Type.FIXED)
+                                            .rollable(true)
+                                            .monthDay(Month.DECEMBER, 25)
+                                            .build();
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.previousFridayOrFollowingMonday())
+                .weekendDays(STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(mlkDay)
+                .holiday(presidentsDay)
+                .holiday(memorialDay)
+                .holiday(juneteenth)
+                .holiday(independenceDay)
+                .holiday(laborDay)
+                .holiday(columbusDay)
+                .holiday(veteransDay)
+                .holiday(thanksgiving)
+                .holiday(christmasDay)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -9,3 +9,4 @@ org.holiday.calendar.impl.HolidayCalendarServiceFR
 org.holiday.calendar.impl.HolidayCalendarServiceGBP
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS
+org.holiday.calendar.impl.HolidayCalendarServiceUSD

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSDTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSDTest.java
@@ -1,0 +1,123 @@
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceUSDTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "USD";
+
+    public HolidayCalendarServiceUSDTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        // Columbus Day and Veterans Day distinguish USD (Federal Reserve) from US (NYSE)
+        final Object[] columbusDay = {"Columbus Day"};
+        final Object[] veteransDay = {"Veterans Day"};
+        return Arrays.asList(columbusDay, veteransDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // Juneteenth 2021: Jun 19 is Saturday → rolls to Friday Jun 18
+        final Object[] juneteenth21   = {2021, "Juneteenth",       LocalDate.of(2021, Month.JUNE,     18)};
+        // Juneteenth 2022: Jun 19 is Sunday → rolls to Monday Jun 20
+        final Object[] juneteenth22   = {2022, "Juneteenth",       LocalDate.of(2022, Month.JUNE,     20)};
+        // Juneteenth 2023: Jun 19 is Monday → no roll
+        final Object[] juneteenth23   = {2023, "Juneteenth",       LocalDate.of(2023, Month.JUNE,     19)};
+        // Independence Day 2021: Jul 4 is Sunday → rolls to Monday Jul 5
+        final Object[] independence21 = {2021, "Independence Day", LocalDate.of(2021, Month.JULY,      5)};
+        // Independence Day 2020: Jul 4 is Saturday → rolls to Friday Jul 3
+        final Object[] independence20 = {2020, "Independence Day", LocalDate.of(2020, Month.JULY,      3)};
+        // Veterans Day 2018: Nov 11 is Sunday → rolls to Monday Nov 12
+        final Object[] veteransDay18  = {2018, "Veterans Day",     LocalDate.of(2018, Month.NOVEMBER, 12)};
+        // Veterans Day 2023: Nov 11 is Saturday → rolls to Friday Nov 10
+        final Object[] veteransDay23  = {2023, "Veterans Day",     LocalDate.of(2023, Month.NOVEMBER, 10)};
+        // Christmas 2021: Dec 25 is Saturday → rolls to Friday Dec 24
+        final Object[] christmas21    = {2021, "Christmas Day",    LocalDate.of(2021, Month.DECEMBER, 24)};
+        // Christmas 2022: Dec 25 is Sunday → rolls to Monday Dec 26
+        final Object[] christmas22    = {2022, "Christmas Day",    LocalDate.of(2022, Month.DECEMBER, 26)};
+        // New Year's 2021: Jan 1 is Friday → no roll
+        final Object[] newYears21     = {2021, "New Year's Day",   LocalDate.of(2021, Month.JANUARY,   1)};
+        // New Year's 2022: Jan 1 is Saturday → rolls to Friday Dec 31 of prior year
+        final Object[] newYears22     = {2022, "New Year's Day",   LocalDate.of(2021, Month.DECEMBER, 31)};
+        // Columbus Day 2021: Oct 11 is Monday → no roll
+        final Object[] columbusDay21  = {2021, "Columbus Day",     LocalDate.of(2021, Month.OCTOBER,  11)};
+        return Arrays.asList(
+                juneteenth21, juneteenth22, juneteenth23,
+                independence21, independence20,
+                veteransDay18, veteransDay23,
+                christmas21, christmas22,
+                newYears21, newYears22,
+                columbusDay21
+        ).listIterator();
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testHolidayCount() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        assertEquals(calendar.getHolidays().size(), 11,
+                "USD calendar must define exactly 11 Federal Reserve holidays");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testNYSEOnlyHolidaysAbsent() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Set<String> names = calendar.getHolidays().stream()
+                .map(Holiday::getName)
+                .collect(Collectors.toSet());
+        assertFalse(names.contains("Good Friday"),
+                "USD calendar must not contain 'Good Friday' (NYSE-only closure)");
+        assertFalse(names.contains("Day After Thanksgiving"),
+                "USD calendar must not contain 'Day After Thanksgiving' (NYSE-only closure)");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testFederalReserveSpecificHolidaysPresent() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Set<String> names = calendar.getHolidays().stream()
+                .map(Holiday::getName)
+                .collect(Collectors.toSet());
+        assertTrue(names.contains("Columbus Day"),
+                "USD calendar must contain 'Columbus Day'");
+        assertTrue(names.contains("Veterans Day"),
+                "USD calendar must contain 'Veterans Day'");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testJuneteenthYearBounds() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        // Juneteenth was not a federal holiday before June 17, 2021
+        assertEquals(calendar.calculate(2020).size(), 10,
+                "2020 should yield 10 holidays (Juneteenth not yet in effect)");
+        final long juneteenth2020 = calendar.calculate(2020).stream()
+                .filter(hd -> "Juneteenth".equals(hd.getHoliday().getName()))
+                .count();
+        assertEquals(juneteenth2020, 0L,
+                "Juneteenth must not appear in calculate(2020)");
+        // Juneteenth became effective in 2021
+        assertEquals(calendar.calculate(2021).size(), 11,
+                "2021 should yield 11 holidays (Juneteenth now a federal holiday)");
+        final long juneteenth2021 = calendar.calculate(2021).stream()
+                .filter(hd -> "Juneteenth".equals(hd.getHoliday().getName()))
+                .count();
+        assertEquals(juneteenth2021, 1L,
+                "Juneteenth must appear exactly once in calculate(2021)");
+    }
+
+}


### PR DESCRIPTION
### #67 Added USD (Federal Reserve) holiday calendar

**Description**

- Added `HolidayCalendarServiceUSD` with 11 Federal Reserve holidays (Fedwire Funds Service / USD RTGS settlement calendar)
- Distinct from the existing `US` (NYSE) calendar: includes Columbus Day and Veterans Day; excludes Good Friday and Day After Thanksgiving (NYSE-only market conventions)
- Juneteenth implemented as a year-bounded `FLOATING` holiday (valid from 2021 only) so `calculate()` correctly omits it for years prior to the holiday's enactment
- Reuses all existing `us/` observances — no new observance classes added
- Uses `DateRolls.previousFridayOrFollowingMonday()` (Saturday→Friday, Sunday→Monday) per Regulation D
- Added `HolidayCalendarServiceUSDTest` with 19 tests, including Juneteenth 2021 Saturday→Friday roll, cross-year New Year's roll, absence assertions for Good Friday and Day After Thanksgiving, and Juneteenth year-bounds verification
- Updated `README.md` to list `USD` in the Supported Calendars table, installation comment, and `listAvailableCodes()` example

**Related Issue**

- [#67 — [New Market] United States — Federal Reserve](https://github.com/holiday-calendar/holiday-calendar-java/issues/67)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed