### PR TITLE
#64 Added EUR (TARGET2) holiday calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Key design goals:
 | `UK` | United Kingdom National Holidays |
 | `CH` | Switzerland National Holidays |
 | `DE` | Germany National Holidays |
+| `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France National Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
 | `AUD` | Australia (RBA) Holidays |
@@ -58,7 +59,7 @@ Then add the modules you need:
   <version>0.0.1</version>
 </dependency>
 
-<!-- Western calendars: US, CA, UK, CH, DE, FR, AU -->
+<!-- Western calendars: US, USD, CA, UK, CH, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>com.github.davejoyce.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
@@ -112,7 +113,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "CA", "DE", "FR", "JP", "JPY", "SG", "CH", "UK", "US"]
+// ["AU", "AUD", "CA", "DE", "EUR", "FR", "JP", "JPY", "SG", "CH", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -40,6 +40,7 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceCA,
         org.holiday.calendar.impl.HolidayCalendarServiceCH,
         org.holiday.calendar.impl.HolidayCalendarServiceDE,
+        org.holiday.calendar.impl.HolidayCalendarServiceEUR,
         org.holiday.calendar.impl.HolidayCalendarServiceFR,
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
         org.holiday.calendar.impl.HolidayCalendarServiceUS;

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEUR.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEUR.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+
+import java.time.Month;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of Euro (TARGET2) holiday calendar.
+ *
+ * <p>TARGET2 (Trans-European Automated Real-time Gross settlement Express
+ * Transfer) publishes six fixed closure dates per year. No date-substitution
+ * convention applies; closures are observed on the stated calendar date only.
+ * If a closure date falls on a weekend, no compensatory weekday closure is
+ * designated — the system is already non-operating on weekends.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ * @see <a href="https://www.ecb.europa.eu/paym/target/target2/profuse/calendar/html/index.en.html">ECB TARGET2 Calendar</a>
+ */
+public class HolidayCalendarServiceEUR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "EUR";
+    private static final String NAME = "Euro (TARGET2) Holidays";
+
+    public HolidayCalendarServiceEUR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final EasterObservance easter = new WesternEaster();
+
+        final Holiday newYearsDay = Holiday.builder()
+                                           .name("New Year's Day")
+                                           .description("First day of new year in the Common Era (CE)")
+                                           .type(Holiday.Type.FIXED)
+                                           .rollable(false)
+                                           .monthDay(Month.JANUARY, 1)
+                                           .build();
+        final Holiday goodFriday = Holiday.builder()
+                                          .name("Good Friday")
+                                          .description("Friday before Easter Sunday")
+                                          .type(Holiday.Type.FLOATING)
+                                          .rollable(false)
+                                          .observance(new GoodFriday(easter))
+                                          .build();
+        final Holiday easterMonday = Holiday.builder()
+                                            .name("Easter Monday")
+                                            .description("Monday after Easter Sunday")
+                                            .type(Holiday.Type.FLOATING)
+                                            .rollable(false)
+                                            .observance(new EasterMonday(easter))
+                                            .build();
+        final Holiday labourDay = Holiday.builder()
+                                         .name("Labour Day")
+                                         .description("International Workers' Day")
+                                         .type(Holiday.Type.FIXED)
+                                         .rollable(false)
+                                         .monthDay(Month.MAY, 1)
+                                         .build();
+        final Holiday christmasDay = Holiday.builder()
+                                            .name("Christmas Day")
+                                            .description("Celebration of traditional Christmas holiday")
+                                            .type(Holiday.Type.FIXED)
+                                            .rollable(false)
+                                            .monthDay(Month.DECEMBER, 25)
+                                            .build();
+        final Holiday boxingDay = Holiday.builder()
+                                         .name("Boxing Day")
+                                         .description("Second day of Christmas")
+                                         .type(Holiday.Type.FIXED)
+                                         .rollable(false)
+                                         .monthDay(Month.DECEMBER, 26)
+                                         .build();
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(goodFriday)
+                .holiday(easterMonday)
+                .holiday(labourDay)
+                .holiday(christmasDay)
+                .holiday(boxingDay)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -3,6 +3,7 @@ org.holiday.calendar.impl.HolidayCalendarServiceAUD
 org.holiday.calendar.impl.HolidayCalendarServiceCA
 org.holiday.calendar.impl.HolidayCalendarServiceCH
 org.holiday.calendar.impl.HolidayCalendarServiceDE
+org.holiday.calendar.impl.HolidayCalendarServiceEUR
 org.holiday.calendar.impl.HolidayCalendarServiceFR
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEURTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEURTest.java
@@ -1,0 +1,68 @@
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+
+import static org.testng.Assert.assertEquals;
+
+public class HolidayCalendarServiceEURTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "EUR";
+
+    public HolidayCalendarServiceEURTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        // Good Friday: absent from FR (Euronext Paris) — proves EUR ≠ FR
+        // Boxing Day: absent from FR — confirms both TARGET2-specific holidays are present
+        final Object[] goodFriday = {"Good Friday"};
+        final Object[] boxingDay  = {"Boxing Day"};
+        return Arrays.asList(goodFriday, boxingDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // Good Friday and Easter Monday always land on weekdays — noRoll() is irrelevant for these
+        // 2022: Easter Sunday Apr 17 -> Good Friday Apr 15, Easter Monday Apr 18
+        final Object[] goodFriday22   = {2022, "Good Friday",   LocalDate.of(2022, Month.APRIL,    15)};
+        final Object[] easterMonday22 = {2022, "Easter Monday", LocalDate.of(2022, Month.APRIL,    18)};
+        // 2024: Easter Sunday Mar 31 -> Good Friday Mar 29, Easter Monday Apr 1
+        final Object[] goodFriday24   = {2024, "Good Friday",   LocalDate.of(2024, Month.MARCH,    29)};
+        final Object[] easterMonday24 = {2024, "Easter Monday", LocalDate.of(2024, Month.APRIL,     1)};
+        // Labour Day: weekend cases prove noRoll() — TARGET2 records May 1 as-is, no weekday displacement
+        final Object[] labourDay21    = {2021, "Labour Day",    LocalDate.of(2021, Month.MAY,       1)}; // Saturday → stays May 1
+        final Object[] labourDay22    = {2022, "Labour Day",    LocalDate.of(2022, Month.MAY,       1)}; // Sunday   → stays May 1
+        final Object[] labourDay23    = {2023, "Labour Day",    LocalDate.of(2023, Month.MAY,       1)}; // Monday   → no roll
+        // Christmas + Boxing Day 2021: Dec 25 Sat, Dec 26 Sun — both stay on their actual dates
+        final Object[] christmas21    = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 25)}; // Saturday → stays Dec 25
+        final Object[] boxingDay21    = {2021, "Boxing Day",    LocalDate.of(2021, Month.DECEMBER, 26)}; // Sunday   → stays Dec 26
+        // Christmas + Boxing Day 2022: Dec 25 Sun, Dec 26 Mon — both stay on their actual dates
+        final Object[] christmas22    = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 25)}; // Sunday   → stays Dec 25
+        final Object[] boxingDay22    = {2022, "Boxing Day",    LocalDate.of(2022, Month.DECEMBER, 26)}; // Monday   → no roll
+        return Arrays.asList(
+                goodFriday22, easterMonday22,
+                goodFriday24, easterMonday24,
+                labourDay21, labourDay22, labourDay23,
+                christmas21, boxingDay21,
+                christmas22, boxingDay22
+        ).listIterator();
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testHolidayCount() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        assertEquals(calendar.getHolidays().size(), 6,
+                "EUR calendar must define exactly 6 TARGET2 closure days");
+    }
+
+}


### PR DESCRIPTION
### #64 Added EUR (TARGET2) holiday calendar

**Description**

- Added `HolidayCalendarServiceEUR` — Euro (TARGET2) holiday calendar with 6 ECB-published closure dates
- All holidays marked `rollable(false)` with `DateRolls.noRoll()` — TARGET2 publishes exact calendar dates with no date-substitution convention (closures observed on the stated date regardless of day of week)
- Reuses existing `GoodFriday`, `EasterMonday`, and `WesternEaster` observances from `observance.christian`
- Labour Day declared as `FIXED` (May 1) consistent with DE/CH/FR pattern
- Registered in `module-info.java` and `META-INF/services` (alphabetical order, between DE and FR)
- Updated README: Supported Calendars table, installation comment, and `listAvailableCodes()` example

**Related Issue**

- Closes #64

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed