### PR TITLE
#73 Publish source and Javadoc JARs; host API docs on GitHub Pages

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -1,0 +1,50 @@
+name: "Publish Javadoc to GitHub Pages"
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  publish-javadoc:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup JDK 21
+        uses: actions/setup-java@v4
+        with:
+          java-version: 21
+          distribution: 'adopt'
+      - name: Get project version
+        id: get_version
+        run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
+      - name: Generate aggregate Javadoc
+        if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
+        run: mvn -B --no-transfer-progress javadoc:aggregate
+      - name: Setup Pages
+        if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
+        uses: actions/configure-pages@v5
+      - name: Upload Pages artifact
+        if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: target/reports/apidocs/
+      - name: Deploy to GitHub Pages
+        if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -23,6 +23,6 @@ jobs:
         run: echo "version=$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)" >> $GITHUB_OUTPUT
       - name: Publish release version to GitHub Packages
         if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
-        run: mvn -B --no-transfer-progress deploy -DskipTests
+        run: mvn -B --no-transfer-progress deploy -DskipTests -Prelease
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Holiday Calendar (Java)
 
 [![Build](https://github.com/holiday-calendar/holiday-calendar-java/actions/workflows/maven-build.yml/badge.svg)](https://github.com/holiday-calendar/holiday-calendar-java/actions/workflows/maven-build.yml)
-[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=holiday-calendar_holiday-calendar-java&branch=develop&metric=alert_status)](https://sonarcloud.io/summary/new_code?id=holiday-calendar_holiday-calendar-java&branch=develop)
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=holiday-calendar_holiday-calendar-java&metric=alert_status)](https://sonarcloud.io/project/overview?id=holiday-calendar_holiday-calendar-java)
 [![License: LGPL v2.1](https://img.shields.io/badge/License-LGPL_v2.1-blue.svg)](https://www.gnu.org/licenses/old-licenses/lgpl-2.1.html)
 
 A Java library for defining and calculating holiday calendars. Provides an extensible foundation for generating the calendars used to determine when holidays occur and when they are observed worldwide.

--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,7 @@
         <maven-jacoco-plugin.version>0.8.14</maven-jacoco-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
+        <maven-source-plugin.version>3.3.1</maven-source-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <sonar-maven-plugin.version>5.5.0.6356</sonar-maven-plugin.version>
@@ -180,6 +181,14 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>${maven-javadoc-plugin.version}</version>
+                    <configuration>
+                        <doclint>all,-missing</doclint>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>${maven-source-plugin.version}</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -235,6 +244,37 @@
                                 <id>prepare-agent</id>
                                 <goals>
                                     <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+        <profile>
+            <id>release</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-sources</id>
+                                <goals>
+                                    <goal>jar-no-fork</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>attach-javadocs</id>
+                                <goals>
+                                    <goal>jar</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -24,16 +24,31 @@
 </head>
 <body>
   <p>A library for definition and calculation of holiday calendars. This API
-      provides an extensible base for generating the calendars used to determine
-      when holidays occur and are observed worldwide.</p>
+      provides an extensible, service-loader-based framework for generating the
+      calendars used to determine when holidays occur and are observed worldwide.
+      Consumers can use only the regional modules they need, and third parties
+      can contribute new calendars by implementing
+      {@link org.holiday.calendar.HolidayCalendarService}.</p>
 
-  <h2>Modules</h2>
-  <p>This API is divided into modules to enable client software to use only the
-      functionality it requires.</p>
-  <ul>
-    <li>Base API</li>
-    <li>European</li>
-    <li>Non-European</li>
-  </ul>
+  <h1>Modules</h1>
+  <p>This API is divided into three modules to enable client software to depend
+      only on the regions it requires.</p>
+  <dl>
+    <dt><strong>holiday-calendar-core</strong></dt>
+    <dd>Core abstractions and API: {@link org.holiday.calendar.Holiday},
+        {@link org.holiday.calendar.HolidayCalendar},
+        {@link org.holiday.calendar.HolidayDate},
+        {@link org.holiday.calendar.HolidayCalendarFactory}, and the
+        functional interfaces {@link org.holiday.calendar.function.Observance}
+        and {@link org.holiday.calendar.function.DateRoll}.</dd>
+    <dt><strong>holiday-calendar-western</strong></dt>
+    <dd>Holiday calendars for Western markets: United States (US), Canada (CA),
+        United Kingdom (UK), Switzerland (CH), Germany (DE), France (FR),
+        Australia (AU), and the Euro Area / ECB (EUR).</dd>
+    <dt><strong>holiday-calendar-apac</strong></dt>
+    <dd>Holiday calendars for Asia-Pacific markets: Singapore (SGX). Uses
+        Time4J for accurate non-Gregorian date calculations such as Chinese
+        New Year.</dd>
+  </dl>
 </body>
 </html>


### PR DESCRIPTION
### #73 Publish source and Javadoc JARs; host API docs on GitHub Pages

**Description**

- Added `maven-source-plugin` (v3.3.1) to `pluginManagement` in root `pom.xml`
- Added `<doclint>all,-missing</doclint>` to `maven-javadoc-plugin` configuration to suppress missing-comment warnings on existing code
- Added `release` profile to root `pom.xml` binding `maven-source-plugin:jar-no-fork` and `maven-javadoc-plugin:jar` to the `package` phase — produces `-sources.jar` and `-javadoc.jar` for each of the three library modules
- Updated `publish-release.yml` to activate the `release` profile (`-Prelease`) during deployment
- Added `publish-javadoc.yml` workflow: generates aggregate Javadoc via `mvn javadoc:aggregate` and deploys to GitHub Pages on release (non-SNAPSHOT) pushes to `main`
- Fixed heading order in `src/main/javadoc/overview.html` (`<h2>` → `<h1>`) that blocked `javadoc:aggregate`
- Updated `overview.html` content: accurate module names, descriptions, country/market coverage, and `{@link}` references to core API types

**Related Issue**

- Closes #73

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed