### PR TITLE
#90 Added CAD (Bank of Canada Lynx) holiday calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Key design goals:
 |------|--------|
 | `US` | United States National Holidays |
 | `CA` | Canada National Holidays |
+| `CAD` | Bank of Canada (Lynx) Holidays |
 | `UK` | United Kingdom National Holidays |
 | `CH` | Switzerland National Holidays |
 | `DE` | Germany National Holidays |
@@ -113,7 +114,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "DE", "EUR", "FR", "JP", "JPY", "SG", "CH", "UK", "US", "USD"]
+// ["AU", "AUD", "CA", "CAD", "DE", "EUR", "FR", "JP", "JPY", "SG", "CH", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -38,6 +38,7 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceAU,
         org.holiday.calendar.impl.HolidayCalendarServiceAUD,
         org.holiday.calendar.impl.HolidayCalendarServiceCA,
+        org.holiday.calendar.impl.HolidayCalendarServiceCAD,
         org.holiday.calendar.impl.HolidayCalendarServiceCH,
         org.holiday.calendar.impl.HolidayCalendarServiceDE,
         org.holiday.calendar.impl.HolidayCalendarServiceEUR,

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCAD.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCAD.java
@@ -1,0 +1,189 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.observance.ca.BoxingDayCAD;
+import org.holiday.calendar.observance.ca.CivicHoliday;
+import org.holiday.calendar.observance.ca.FamilyDayCAD;
+import org.holiday.calendar.observance.ca.LabourDay;
+import org.holiday.calendar.observance.ca.NationalDayForTruthAndReconciliation;
+import org.holiday.calendar.observance.ca.Thanksgiving;
+import org.holiday.calendar.observance.ca.VictoriaDay;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of the Bank of Canada (Lynx) holiday calendar.
+ *
+ * <p>The Lynx Real-Time Gross Settlement (RTGS) system is the authoritative
+ * settlement calendar for CAD high-value payments in Canada. This calendar
+ * models the statutory holiday schedule under the <em>Bank Act</em> (Canada)
+ * that governs Lynx settlement days.</p>
+ *
+ * <p>This calendar is distinct from the general {@code CA} (Canada National
+ * Holidays) calendar in the following respects:</p>
+ * <ul>
+ *   <li>Easter Monday is <strong>not</strong> included — it is not a Bank Act
+ *       statutory holiday.</li>
+ *   <li>Family Day is gated from 2013, reflecting its federal (Bank Act)
+ *       adoption date, not the earlier provincial origin.</li>
+ *   <li>National Day for Truth and Reconciliation is included from 2021 and
+ *       is a rollable holiday (following-Monday substitution).</li>
+ *   <li>All fixed holidays roll to the <strong>following Monday</strong> when
+ *       they fall on either Saturday or Sunday.</li>
+ *   <li>Boxing Day is computed as a floating observance to correctly handle
+ *       date collisions when Christmas Day consumes 26 December as its own
+ *       observed substitute.</li>
+ * </ul>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceCAD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "CAD";
+    private static final String NAME = "Bank of Canada (Lynx) Holiday Schedule";
+
+    public HolidayCalendarServiceCAD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final EasterObservance easter = new WesternEaster();
+
+        final Holiday newYearsDay = Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JANUARY, 1)
+                .build();
+        final Holiday familyDay = Holiday.builder()
+                .name("Family Day")
+                .description("Federal statutory Family Day (Bank Act)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new FamilyDayCAD())
+                .build();
+        final Holiday goodFriday = Holiday.builder()
+                .name("Good Friday")
+                .description("Friday before Easter Sunday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new GoodFriday(easter))
+                .build();
+        final Holiday victoriaDay = Holiday.builder()
+                .name("Victoria Day")
+                .description("Official celebration of birthday of Canada's Sovereign")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new VictoriaDay())
+                .build();
+        final Holiday canadaDay = Holiday.builder()
+                .name("Canada Day")
+                .description("Anniversary of Canadian Confederation")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JULY, 1)
+                .build();
+        final Holiday civicHoliday = Holiday.builder()
+                .name("Civic Holiday")
+                .description("Civic Holiday (first Monday in August)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new CivicHoliday())
+                .build();
+        final Holiday labourDay = Holiday.builder()
+                .name("Labour Day")
+                .description("Celebration of workers in Canada")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new LabourDay())
+                .build();
+        final Holiday ndtr = Holiday.builder()
+                .name("National Day For Truth and Reconciliation")
+                .description("Recognition of the legacy of the Canadian Indian residential school system")
+                .type(Holiday.Type.FLOATING)
+                .rollable(true)
+                .observance(new NationalDayForTruthAndReconciliation())
+                .build();
+        final Holiday thanksgiving = Holiday.builder()
+                .name("Thanksgiving Day")
+                .description("National day for giving thanks")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new Thanksgiving())
+                .build();
+        final Holiday remembranceDay = Holiday.builder()
+                .name("Remembrance Day")
+                .description("Commemoration of armed forces members who have died in the line of duty")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.NOVEMBER, 11)
+                .build();
+        final Holiday christmas = Holiday.builder()
+                .name("Christmas Day")
+                .description("Christmas Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 25)
+                .build();
+        final Holiday boxingDay = Holiday.builder()
+                .name("Boxing Day")
+                .description("Day after Christmas (observed)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new BoxingDayCAD())
+                .build();
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(dateToRoll -> {
+                    final DayOfWeek dow = dateToRoll.getDayOfWeek();
+                    if (dow == DayOfWeek.SATURDAY) return dateToRoll.plusDays(2L);
+                    if (dow == DayOfWeek.SUNDAY)   return dateToRoll.plusDays(1L);
+                    return dateToRoll;
+                })
+                .weekendDays(STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(familyDay)
+                .holiday(goodFriday)
+                .holiday(victoriaDay)
+                .holiday(canadaDay)
+                .holiday(civicHoliday)
+                .holiday(labourDay)
+                .holiday(ndtr)
+                .holiday(thanksgiving)
+                .holiday(remembranceDay)
+                .holiday(christmas)
+                .holiday(boxingDay)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/BoxingDayCAD.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/BoxingDayCAD.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.function.Observance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Boxing Day for the Bank of Canada (Lynx) settlement calendar.
+ *
+ * <p>Boxing Day (26 December) must be computed in tandem with Christmas Day
+ * (25 December) because the two holidays can collide when Christmas falls on a
+ * weekend. The framework's {@code DateRoll} mechanism operates independently per
+ * holiday and cannot detect when Christmas Day has already consumed 26 December
+ * as its observed Monday substitute. This observance therefore encapsulates the
+ * full substitution logic for the Christmas/Boxing Day pair:</p>
+ *
+ * <ul>
+ *   <li><strong>Dec 25 = Saturday</strong> &rarr; Christmas observed Mon 27;
+ *       Boxing Day (Dec 26 = Sunday) observed Tue 28.</li>
+ *   <li><strong>Dec 25 = Sunday</strong> &rarr; Christmas observed Mon 26;
+ *       Boxing Day displaced to Tue 27.</li>
+ *   <li><strong>Dec 26 = Saturday</strong> (Christmas is Friday) &rarr;
+ *       Christmas not rolled; Boxing Day observed Mon 28.</li>
+ *   <li><strong>Dec 26 = Sunday</strong> (Christmas is Saturday &mdash; covered
+ *       by first case above; or Christmas is a different weekday) &rarr;
+ *       Boxing Day observed Mon 27.</li>
+ *   <li>All other cases &rarr; Boxing Day observed on its natural date, 26
+ *       December.</li>
+ * </ul>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class BoxingDayCAD implements Observance {
+
+    @Override
+    public LocalDate apply(Integer year) {
+        final LocalDate christmas = LocalDate.of(year, Month.DECEMBER, 25);
+        final LocalDate boxingDay = LocalDate.of(year, Month.DECEMBER, 26);
+        final DayOfWeek christmasDow = christmas.getDayOfWeek();
+        final DayOfWeek boxingDow    = boxingDay.getDayOfWeek();
+
+        if (christmasDow == DayOfWeek.SATURDAY) return boxingDay.plusDays(2L); // Dec 28 (Tue)
+        if (christmasDow == DayOfWeek.SUNDAY)   return boxingDay.plusDays(1L); // Dec 27 (Tue)
+        if (boxingDow    == DayOfWeek.SATURDAY) return boxingDay.plusDays(2L); // Dec 28 (Mon)
+        if (boxingDow    == DayOfWeek.SUNDAY)   return boxingDay.plusDays(1L); // Dec 27 (Mon)
+        return boxingDay;
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/FamilyDayCAD.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/FamilyDayCAD.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.function.Observance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.Year;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Observance of Family Day as a federal Bank Act statutory holiday - the third
+ * Monday in February. This observance reflects the federal adoption of Family
+ * Day, which was first observed by federally regulated institutions (including
+ * the Bank of Canada) on <strong>11 February 2013</strong>.
+ *
+ * <p>This class is distinct from {@link FamilyDay}, which models the earlier
+ * provincial Alberta adoption (1990). For the Bank of Canada Lynx settlement
+ * calendar, the 2013 federal start date is authoritative.</p>
+ *
+ * @see FamilyDay
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class FamilyDayCAD implements Observance {
+
+    @Override
+    public LocalDate apply(Integer year) {
+        if (!test(year)) return null;
+        return Year.of(year)
+                   .atMonth(Month.FEBRUARY)
+                   .atDay(1)
+                   .with(TemporalAdjusters.dayOfWeekInMonth(3, DayOfWeek.MONDAY));
+    }
+
+    @Override
+    public boolean test(Integer year) {
+        return year != null && year >= 2013;
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/NationalDayForTruthAndReconciliation.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/NationalDayForTruthAndReconciliation.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.function.Observance;
+
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the National Day for Truth and Reconciliation - a federal
+ * statutory holiday on 30 September, honouring the survivors and victims of
+ * Canada's Indian residential school system and acknowledging the ongoing
+ * impacts on Indigenous communities.
+ *
+ * <p>This holiday was established by the federal government and first observed
+ * on <strong>30 September 2021</strong>. It is a rollable holiday: when 30
+ * September falls on a Saturday or Sunday, it is observed the following Monday
+ * under Canada's federal following-Monday substitution rule.</p>
+ *
+ * <p>This class is implemented as a {@link Observance} rather than a fixed
+ * {@code MonthDay} in order to enforce the year constraint via
+ * {@link #test(Integer)}, since {@code FixedHoliday} does not support year
+ * gating.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NationalDayForTruthAndReconciliation implements Observance {
+
+    @Override
+    public LocalDate apply(Integer year) {
+        if (!test(year)) return null;
+        return LocalDate.of(year, Month.SEPTEMBER, 30);
+    }
+
+    @Override
+    public boolean test(Integer year) {
+        return year != null && year >= 2021;
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,6 +1,7 @@
 org.holiday.calendar.impl.HolidayCalendarServiceAU
 org.holiday.calendar.impl.HolidayCalendarServiceAUD
 org.holiday.calendar.impl.HolidayCalendarServiceCA
+org.holiday.calendar.impl.HolidayCalendarServiceCAD
 org.holiday.calendar.impl.HolidayCalendarServiceCH
 org.holiday.calendar.impl.HolidayCalendarServiceDE
 org.holiday.calendar.impl.HolidayCalendarServiceEUR

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCADTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCADTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceCADTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "CAD";
+
+    public HolidayCalendarServiceCADTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        final Object[] civicHoliday   = {"Civic Holiday"};
+        final Object[] goodFriday     = {"Good Friday"};
+        final Object[] ndtr           = {"National Day For Truth and Reconciliation"};
+        final Object[] remembranceDay = {"Remembrance Day"};
+        final Object[] boxingDay      = {"Boxing Day"};
+        return Arrays.asList(civicHoliday, goodFriday, ndtr, remembranceDay, boxingDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // New Year's Day — following-Monday roll
+        final Object[] newYear22   = {2022, "New Year's Day", LocalDate.of(2022, Month.JANUARY,  3)}; // Sat → Mon
+        final Object[] newYear23   = {2023, "New Year's Day", LocalDate.of(2023, Month.JANUARY,  2)}; // Sun → Mon
+        final Object[] newYear25   = {2025, "New Year's Day", LocalDate.of(2025, Month.JANUARY,  1)}; // Wed → no roll
+
+        // Canada Day — following-Monday roll (note: 2023 Sat roll is absent from the CA calendar — this is correct)
+        final Object[] canadaDay18 = {2018, "Canada Day", LocalDate.of(2018, Month.JULY,  2)}; // Sun → Mon
+        final Object[] canadaDay23 = {2023, "Canada Day", LocalDate.of(2023, Month.JULY,  3)}; // Sat → Mon
+        final Object[] canadaDay24 = {2024, "Canada Day", LocalDate.of(2024, Month.JULY,  1)}; // Mon → no roll
+
+        // Remembrance Day — following-Monday roll for both Saturday and Sunday
+        final Object[] remembrance18 = {2018, "Remembrance Day", LocalDate.of(2018, Month.NOVEMBER, 12)}; // Sun → Mon
+        final Object[] remembrance23 = {2023, "Remembrance Day", LocalDate.of(2023, Month.NOVEMBER, 13)}; // Sat → Mon
+        final Object[] remembrance24 = {2024, "Remembrance Day", LocalDate.of(2024, Month.NOVEMBER, 11)}; // Mon → no roll
+
+        // Christmas / Boxing Day — 2021: Dec 25 = Sat, Dec 26 = Sun
+        final Object[] christmas21 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 27)}; // Sat → Mon
+        final Object[] boxingDay21 = {2021, "Boxing Day",    LocalDate.of(2021, Month.DECEMBER, 28)}; // Sun (displaced by Christmas) → Tue
+
+        // Christmas / Boxing Day — 2022: Dec 25 = Sun, Dec 26 = Mon (consumed by Christmas roll)
+        final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)}; // Sun → Mon
+        final Object[] boxingDay22 = {2022, "Boxing Day",    LocalDate.of(2022, Month.DECEMBER, 27)}; // Mon taken by Christmas → Tue
+
+        // Christmas / Boxing Day — 2023: Dec 25 = Mon, Dec 26 = Tue (no roll)
+        final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        final Object[] boxingDay23 = {2023, "Boxing Day",    LocalDate.of(2023, Month.DECEMBER, 26)};
+
+        // Christmas / Boxing Day — 2026: Dec 25 = Fri, Dec 26 = Sat
+        final Object[] christmas26 = {2026, "Christmas Day", LocalDate.of(2026, Month.DECEMBER, 25)}; // Fri → no roll
+        final Object[] boxingDay26 = {2026, "Boxing Day",    LocalDate.of(2026, Month.DECEMBER, 28)}; // Sat → Mon
+
+        // Good Friday (always a Friday — no roll ever applies)
+        final Object[] goodFriday22 = {2022, "Good Friday", LocalDate.of(2022, Month.APRIL, 15)};
+        final Object[] goodFriday24 = {2024, "Good Friday", LocalDate.of(2024, Month.MARCH, 29)};
+
+        // Family Day (3rd Monday in February — no roll ever applies)
+        final Object[] familyDay21  = {2021, "Family Day", LocalDate.of(2021, Month.FEBRUARY, 15)};
+        final Object[] familyDay22  = {2022, "Family Day", LocalDate.of(2022, Month.FEBRUARY, 21)};
+
+        // Victoria Day (last Monday on or before May 25 — no roll ever applies)
+        final Object[] victoriaDay21 = {2021, "Victoria Day", LocalDate.of(2021, Month.MAY, 24)};
+        final Object[] victoriaDay22 = {2022, "Victoria Day", LocalDate.of(2022, Month.MAY, 23)};
+        // Edge case: May 25, 2026 is a Monday — VictoriaDay must be the week before (May 18)
+        final Object[] victoriaDay26 = {2026, "Victoria Day", LocalDate.of(2026, Month.MAY, 18)};
+
+        // Civic Holiday (1st Monday in August — no roll ever applies)
+        final Object[] civicHoliday21 = {2021, "Civic Holiday", LocalDate.of(2021, Month.AUGUST, 2)};
+        final Object[] civicHoliday22 = {2022, "Civic Holiday", LocalDate.of(2022, Month.AUGUST, 1)};
+
+        // Labour Day (1st Monday in September — no roll ever applies)
+        final Object[] labourDay21  = {2021, "Labour Day", LocalDate.of(2021, Month.SEPTEMBER,  6)};
+        final Object[] labourDay25  = {2025, "Labour Day", LocalDate.of(2025, Month.SEPTEMBER,  1)}; // Sep 1 is itself Monday
+
+        // Thanksgiving Day (2nd Monday in October — no roll ever applies)
+        final Object[] thanksgiving21 = {2021, "Thanksgiving Day", LocalDate.of(2021, Month.OCTOBER, 11)};
+        final Object[] thanksgiving22 = {2022, "Thanksgiving Day", LocalDate.of(2022, Month.OCTOBER, 10)};
+
+        // National Day for Truth and Reconciliation — rollable
+        final Object[] ndtr21 = {2021, "National Day For Truth and Reconciliation",
+                                  LocalDate.of(2021, Month.SEPTEMBER, 30)}; // Thu → no roll (first observed year)
+        final Object[] ndtr23 = {2023, "National Day For Truth and Reconciliation",
+                                  LocalDate.of(2023, Month.OCTOBER,    2)}; // Sat → Mon (confirmed Bank of Canada schedule)
+
+        return Arrays.asList(
+                newYear22, newYear23, newYear25,
+                canadaDay18, canadaDay23, canadaDay24,
+                remembrance18, remembrance23, remembrance24,
+                christmas21, boxingDay21,
+                christmas22, boxingDay22,
+                christmas23, boxingDay23,
+                christmas26, boxingDay26,
+                goodFriday22, goodFriday24,
+                familyDay21, familyDay22,
+                victoriaDay21, victoriaDay22, victoriaDay26,
+                civicHoliday21, civicHoliday22,
+                labourDay21, labourDay25,
+                thanksgiving21, thanksgiving22,
+                ndtr21, ndtr23
+        ).listIterator();
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testHolidayCount() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        assertEquals(calendar.getHolidays().size(), 12,
+                "CAD calendar must define exactly 12 Bank of Canada Lynx closure days");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testEasterMondayAbsent() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        final boolean defined = calendar.getHolidays().stream()
+                .anyMatch(h -> "Easter Monday".equals(h.getName()));
+        assertFalse(defined,
+                "CAD calendar must not contain Easter Monday — it is not a Bank Act statutory holiday");
+    }
+
+    @Test
+    public void testNdtrAbsentBefore2021() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        for (final int year : new int[]{2019, 2020}) {
+            final boolean present = calendar.calculate(year).stream()
+                    .anyMatch(hd -> "National Day For Truth and Reconciliation"
+                            .equals(hd.getHoliday().getName()));
+            assertFalse(present,
+                    "NDTR must not appear in the CAD calendar for " + year + " (first observed 2021)");
+        }
+    }
+
+    @Test
+    public void testNdtrPresentFrom2021() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        for (final int year : new int[]{2021, 2022, 2023, 2024}) {
+            final boolean present = calendar.calculate(year).stream()
+                    .anyMatch(hd -> "National Day For Truth and Reconciliation"
+                            .equals(hd.getHoliday().getName()));
+            assertTrue(present,
+                    "NDTR must appear in the CAD calendar for year " + year);
+        }
+    }
+
+    @Test
+    public void testCalculatedHolidayCount() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        // Pre-2021: NDTR absent → 11 holidays
+        assertEquals(calendar.calculate(2019).size(), 11,
+                "CAD calendar should produce 11 holidays for 2019 (NDTR absent)");
+        assertEquals(calendar.calculate(2020).size(), 11,
+                "CAD calendar should produce 11 holidays for 2020 (NDTR absent)");
+        // 2021+: NDTR present → 12 holidays
+        assertEquals(calendar.calculate(2021).size(), 12,
+                "CAD calendar should produce 12 holidays for 2021");
+        assertEquals(calendar.calculate(2022).size(), 12,
+                "CAD calendar should produce 12 holidays for 2022");
+        assertEquals(calendar.calculate(2023).size(), 12,
+                "CAD calendar should produce 12 holidays for 2023");
+    }
+
+    @Test
+    public void testChronologicalOrder() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        for (final int year : new int[]{2018, 2021, 2022, 2023, 2024, 2025, 2026}) {
+            final List<HolidayDate> holidays = calendar.calculate(year);
+            assertFalse(holidays.isEmpty(), "Expected non-empty holiday list for " + year);
+            for (int i = 1; i < holidays.size(); i++) {
+                assertTrue(
+                        holidays.get(i).getDate().compareTo(holidays.get(i - 1).getDate()) >= 0,
+                        "Holidays out of chronological order for " + year
+                                + ": " + holidays.get(i - 1).getDate()
+                                + " > " + holidays.get(i).getDate());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
### #90 Added CAD (Bank of Canada Lynx) holiday calendar

**Description**

- Added `HolidayCalendarServiceCAD` — Bank of Canada Lynx RTGS settlement holiday calendar with 12 Bank Act statutory closure dates
- Distinct from the existing `CA` (Canada National Holidays) calendar: Easter Monday excluded, Family Day gated from 2013 (federal Bank Act adoption), NDTR included from 2021 and rollable
- All fixed holidays use a uniform following-Monday roll (Saturday → +2 days, Sunday → +1 day), consistent with the Bank of Canada's published holiday schedule and Canada's federal substitution convention
- Added `FamilyDayCAD` observance — federal Family Day gated `year >= 2013` (distinct from the provincial `FamilyDay` which starts 1990)
- Added `NationalDayForTruthAndReconciliation` observance — Sep 30, gated `year >= 2021`; implemented as `FloatingHoliday` to support the year constraint (not achievable with `FixedHoliday`)
- Added `BoxingDayCAD` observance — collision-aware floating observance that correctly displaces Boxing Day when Christmas Day has consumed 26 December as its own observed Monday substitute
- Registered in `module-info.java` and `META-INF/services` (alphabetical order, after `CA`)
- Updated README: Supported Calendars table and `listAvailableCodes()` example

**Related Issue**

- Closes #90

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed