### PR TITLE
#94 Bump version to 1.0.0-SNAPSHOT

### DIFF
--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>1.0.0-SNAPSHOT</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>1.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>


### PR DESCRIPTION
### #94 Bump version to 1.0.0-SNAPSHOT

**Description**

- Bumped Maven project version from `0.0.2-SNAPSHOT` to `1.0.0-SNAPSHOT` across all modules (root POM and four child POMs)

**Related Issue**

- [#94 Chore: bump version to 1.0.0-SNAPSHOT](https://github.com/holiday-calendar/holiday-calendar-java/issues/94)

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Other (please describe): Version bump

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed