### PR TITLE
#91 Added GBP (Bank of England CHAPS) holiday calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ Key design goals:
 | `US` | United States National Holidays |
 | `CA` | Canada National Holidays |
 | `UK` | United Kingdom National Holidays |
+| `GBP` | United Kingdom (CHAPS) Holidays |
 | `CH` | Switzerland National Holidays |
 | `DE` | Germany National Holidays |
 | `EUR` | Euro (TARGET2) Holidays |
@@ -59,7 +60,7 @@ Then add the modules you need:
   <version>0.0.1</version>
 </dependency>
 
-<!-- Western calendars: US, USD, CA, UK, CH, DE, EUR, FR, AU, AUD -->
+<!-- Western calendars: US, USD, CA, UK, GBP, CH, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>com.github.davejoyce.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
@@ -113,7 +114,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "DE", "EUR", "FR", "JP", "JPY", "SG", "CH", "UK", "US", "USD"]
+// ["AU", "AUD", "CA", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "CH", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -42,6 +42,7 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceDE,
         org.holiday.calendar.impl.HolidayCalendarServiceEUR,
         org.holiday.calendar.impl.HolidayCalendarServiceFR,
+        org.holiday.calendar.impl.HolidayCalendarServiceGBP,
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
         org.holiday.calendar.impl.HolidayCalendarServiceUS;
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceGBP.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceGBP.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.uk.EarlyMayBankHoliday;
+import org.holiday.calendar.observance.uk.SpringBankHoliday;
+import org.holiday.calendar.observance.uk.SummerBankHoliday;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Optional;
+
+/**
+ * Service for provision of United Kingdom (CHAPS) holiday calendar.
+ *
+ * <p>CHAPS (Clearing House Automated Payment System) is operated by the Bank of
+ * England and governs GBP high-value payment settlement. The system observes eight
+ * recurring annual bank holidays aligned with the England and Wales statutory bank
+ * holiday schedule.
+ *
+ * <p>Date-roll behaviour:
+ * <ul>
+ *   <li>Christmas Day and Boxing Day: when either falls on a weekend, both
+ *       substitute days are observed on the following Monday and Tuesday (+2 days).
+ *   <li>New Year's Day: when it falls on Saturday it is observed on the following
+ *       Monday (+2 days); when it falls on Sunday it is observed on Monday (+1 day).
+ * </ul>
+ *
+ * <p>NOTE: This calendar's {@code dateRoll} lambda is the authoritative roll
+ * mechanism for all three rollable fixed holidays. Setting {@code rollable(true)}
+ * alone is insufficient — each holiday's identity is checked in the lambda.
+ * Any future rollable holiday added to this calendar must also be handled there.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ * @see <a href="https://www.bankofengland.co.uk/payment-and-settlement/chaps/chaps-settlement-calendar">Bank of England CHAPS Settlement Calendar</a>
+ */
+public class HolidayCalendarServiceGBP extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "GBP";
+    private static final String NAME = "United Kingdom (CHAPS) Holidays";
+
+    public HolidayCalendarServiceGBP() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final EasterObservance easter = new WesternEaster();
+
+        final Holiday newYearsDay = Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JANUARY, 1)
+                .build();
+        final Holiday goodFriday = Holiday.builder()
+                .name("Good Friday")
+                .description("Commemoration of the crucifixion of Jesus Christ")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new GoodFriday(easter))
+                .build();
+        final Holiday easterMonday = Holiday.builder()
+                .name("Easter Monday")
+                .description("Day after Easter Sunday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EasterMonday(easter))
+                .build();
+        final Holiday earlyMayBankHoliday = Holiday.builder()
+                .name("Early May Bank Holiday")
+                .description("Early May bank holiday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EarlyMayBankHoliday())
+                .build();
+        final Holiday springBankHoliday = Holiday.builder()
+                .name("Spring Bank Holiday")
+                .description("Late May bank holiday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new SpringBankHoliday())
+                .build();
+        final Holiday summerBankHoliday = Holiday.builder()
+                .name("Summer Bank Holiday")
+                .description("Summer bank holiday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new SummerBankHoliday())
+                .build();
+        final Holiday christmasDay = Holiday.builder()
+                .name("Christmas Day")
+                .description("Commemoration of the birth of Jesus Christ")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 25)
+                .build();
+        final Holiday boxingDay = Holiday.builder()
+                .name("Boxing Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 26)
+                .build();
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(dateToRoll -> {
+                    final Optional<LocalDate> nydDate      = newYearsDay.dateForYear(dateToRoll.getYear());
+                    final Optional<LocalDate> christmasDate = christmasDay.dateForYear(dateToRoll.getYear());
+                    final Optional<LocalDate> boxingDayDate = boxingDay.dateForYear(dateToRoll.getYear());
+                    final boolean isNewYearsDay = nydDate.isPresent()       && dateToRoll.equals(nydDate.get());
+                    final boolean isChristmas   = christmasDate.isPresent() && dateToRoll.equals(christmasDate.get());
+                    final boolean isBoxingDay   = boxingDayDate.isPresent() && dateToRoll.equals(boxingDayDate.get());
+                    return switch (dateToRoll.getDayOfWeek()) {
+                        // Christmas/Boxing Day: +2 regardless of Saturday or Sunday (Mon or Tue substitute)
+                        // New Year's Day on Saturday: +2 to Monday
+                        case SATURDAY -> (isChristmas || isBoxingDay || isNewYearsDay)
+                                ? dateToRoll.plusDays(2L)
+                                : dateToRoll;
+                        // Christmas/Boxing Day on Sunday: +2 to Tuesday
+                        // New Year's Day on Sunday: +1 to Monday
+                        case SUNDAY -> (isChristmas || isBoxingDay)
+                                ? dateToRoll.plusDays(2L)
+                                : isNewYearsDay ? dateToRoll.plusDays(1L)
+                                : dateToRoll;
+                        default -> dateToRoll;
+                    };
+                })
+                .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(goodFriday)
+                .holiday(easterMonday)
+                .holiday(earlyMayBankHoliday)
+                .holiday(springBankHoliday)
+                .holiday(summerBankHoliday)
+                .holiday(christmasDay)
+                .holiday(boxingDay)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -5,5 +5,6 @@ org.holiday.calendar.impl.HolidayCalendarServiceCH
 org.holiday.calendar.impl.HolidayCalendarServiceDE
 org.holiday.calendar.impl.HolidayCalendarServiceEUR
 org.holiday.calendar.impl.HolidayCalendarServiceFR
+org.holiday.calendar.impl.HolidayCalendarServiceGBP
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceGBPTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceGBPTest.java
@@ -1,0 +1,172 @@
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+public class HolidayCalendarServiceGBPTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "GBP";
+
+    public HolidayCalendarServiceGBPTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        // Names chosen to distinguish GBP from other calendars:
+        // Early May BH and Spring BH are absent from EUR, US, CA, CH, DE, FR, AU.
+        // Summer BH confirms UK-family membership.
+        // Boxing Day is absent from EUR, US, CA.
+        final Object[] earlyMayBankHoliday = {"Early May Bank Holiday"};
+        final Object[] springBankHoliday   = {"Spring Bank Holiday"};
+        final Object[] summerBankHoliday   = {"Summer Bank Holiday"};
+        final Object[] boxingDay           = {"Boxing Day"};
+        return Arrays.asList(earlyMayBankHoliday, springBankHoliday, summerBankHoliday, boxingDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // --- New Year's Day rolling (GBP-specific fix; UK calendar does NOT roll NYD) ---
+        // 2021: Jan 1 = Friday  → no roll
+        final Object[] nyd2021 = {2021, "New Year's Day", LocalDate.of(2021, Month.JANUARY,  1)};
+        // 2022: Jan 1 = Saturday → +2 → Monday Jan 3
+        final Object[] nyd2022 = {2022, "New Year's Day", LocalDate.of(2022, Month.JANUARY,  3)};
+        // 2023: Jan 1 = Sunday  → +1 → Monday Jan 2
+        final Object[] nyd2023 = {2023, "New Year's Day", LocalDate.of(2023, Month.JANUARY,  2)};
+        // 2024: Jan 1 = Monday  → no roll
+        final Object[] nyd2024 = {2024, "New Year's Day", LocalDate.of(2024, Month.JANUARY,  1)};
+
+        // --- Christmas Day rolling ---
+        // 2020: Dec 25 = Friday   → no roll
+        final Object[] xmas2020 = {2020, "Christmas Day", LocalDate.of(2020, Month.DECEMBER, 25)};
+        // 2021: Dec 25 = Saturday → +2 → Monday Dec 27
+        final Object[] xmas2021 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 27)};
+        // 2022: Dec 25 = Sunday   → +2 → Tuesday Dec 27
+        final Object[] xmas2022 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 27)};
+        // 2023: Dec 25 = Monday   → no roll
+        final Object[] xmas2023 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+
+        // --- Boxing Day rolling ---
+        // 2020: Dec 26 = Saturday → +2 → Monday Dec 28
+        final Object[] boxing2020 = {2020, "Boxing Day", LocalDate.of(2020, Month.DECEMBER, 28)};
+        // 2021: Dec 26 = Sunday   → +2 → Tuesday Dec 28
+        final Object[] boxing2021 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 28)};
+        // 2022: Dec 26 = Monday   → not on a weekend; lambda not invoked → no roll
+        final Object[] boxing2022 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // 2023: Dec 26 = Tuesday  → no roll
+        final Object[] boxing2023 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        // 2026: Dec 26 = Saturday → +2 → Monday Dec 28 (second "Boxing Day only" scenario)
+        final Object[] boxing2026 = {2026, "Boxing Day", LocalDate.of(2026, Month.DECEMBER, 28)};
+
+        // --- Good Friday (floating, NOT rollable — always a Friday) ---
+        // 2021: Easter Sunday Apr 4  → Good Friday Apr 2
+        final Object[] goodFriday2021 = {2021, "Good Friday", LocalDate.of(2021, Month.APRIL,  2)};
+        // 2024: Easter Sunday Mar 31 → Good Friday Mar 29
+        final Object[] goodFriday2024 = {2024, "Good Friday", LocalDate.of(2024, Month.MARCH, 29)};
+
+        // --- Easter Monday (floating, NOT rollable — always a Monday) ---
+        // 2021: Easter Sunday Apr 4  → Easter Monday Apr 5
+        final Object[] easterMonday2021 = {2021, "Easter Monday", LocalDate.of(2021, Month.APRIL,  5)};
+        // 2024: Easter Sunday Mar 31 → Easter Monday Apr 1
+        final Object[] easterMonday2024 = {2024, "Easter Monday", LocalDate.of(2024, Month.APRIL,  1)};
+
+        // --- Early May Bank Holiday (1st Monday in May, NOT rollable) ---
+        // 2021: May 3  (May 1 = Saturday → 1st Monday = May 3)
+        final Object[] earlyMay2021 = {2021, "Early May Bank Holiday", LocalDate.of(2021, Month.MAY,  3)};
+        // 2023: May 1  (May 1 itself is a Monday — earliest possible date)
+        final Object[] earlyMay2023 = {2023, "Early May Bank Holiday", LocalDate.of(2023, Month.MAY,  1)};
+        // 2024: May 6  (May 1 = Wednesday → 1st Monday = May 6)
+        final Object[] earlyMay2024 = {2024, "Early May Bank Holiday", LocalDate.of(2024, Month.MAY,  6)};
+
+        // --- Spring Bank Holiday (last Monday in May, NOT rollable) ---
+        // 2021: May 31
+        final Object[] spring2021 = {2021, "Spring Bank Holiday", LocalDate.of(2021, Month.MAY,  31)};
+        // 2022: June 2 — Platinum Jubilee override encoded in SpringBankHoliday observance
+        final Object[] spring2022 = {2022, "Spring Bank Holiday", LocalDate.of(2022, Month.JUNE,  2)};
+        // 2023: May 29
+        final Object[] spring2023 = {2023, "Spring Bank Holiday", LocalDate.of(2023, Month.MAY,  29)};
+
+        // --- Summer Bank Holiday (last Monday in August, NOT rollable) ---
+        // 2022: Aug 29
+        final Object[] summer2022 = {2022, "Summer Bank Holiday", LocalDate.of(2022, Month.AUGUST, 29)};
+        // 2024: Aug 26
+        final Object[] summer2024 = {2024, "Summer Bank Holiday", LocalDate.of(2024, Month.AUGUST, 26)};
+        // 2026: Aug 31
+        final Object[] summer2026 = {2026, "Summer Bank Holiday", LocalDate.of(2026, Month.AUGUST, 31)};
+
+        return Arrays.asList(
+                nyd2021, nyd2022, nyd2023, nyd2024,
+                xmas2020, xmas2021, xmas2022, xmas2023,
+                boxing2020, boxing2021, boxing2022, boxing2023, boxing2026,
+                goodFriday2021, goodFriday2024,
+                easterMonday2021, easterMonday2024,
+                earlyMay2021, earlyMay2023, earlyMay2024,
+                spring2021, spring2022, spring2023,
+                summer2022, summer2024, summer2026
+        ).listIterator();
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testHolidayCount() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        assertEquals(calendar.getHolidays().size(), 8,
+                "GBP calendar must define exactly 8 recurring CHAPS closure days");
+    }
+
+    @Test
+    public void testNewYearsDayRoll_SaturdayCase() {
+        // 2022: Jan 1 = Saturday → observed Monday Jan 3
+        // This distinguishes GBP from UK, which does NOT correctly roll New Year's Day.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Optional<HolidayDate> found = calendar.calculate(2022).stream()
+                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(found.isPresent());
+        assertEquals(found.get().getDate(), LocalDate.of(2022, Month.JANUARY, 3));
+    }
+
+    @Test
+    public void testNewYearsDayRoll_SundayCase() {
+        // 2023: Jan 1 = Sunday → observed Monday Jan 2
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Optional<HolidayDate> found = calendar.calculate(2023).stream()
+                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(found.isPresent());
+        assertEquals(found.get().getDate(), LocalDate.of(2023, Month.JANUARY, 2));
+    }
+
+    @Test
+    public void testChristmasAndBoxingDayBothRoll_2021() {
+        // 2021: Dec 25 = Saturday (+2 → Mon Dec 27), Dec 26 = Sunday (+2 → Tue Dec 28)
+        final HolidayCalendar calendar = factory.create(CODE);
+        final List<HolidayDate> holidays = calendar.calculate(2021);
+
+        final Optional<HolidayDate> christmas = holidays.stream()
+                .filter(hd -> "Christmas Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        final Optional<HolidayDate> boxing = holidays.stream()
+                .filter(hd -> "Boxing Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+
+        assertTrue(christmas.isPresent());
+        assertTrue(boxing.isPresent());
+        assertEquals(christmas.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 27));
+        assertEquals(boxing.get().getDate(),    LocalDate.of(2021, Month.DECEMBER, 28));
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds `HolidayCalendarServiceGBP` to `holiday-calendar-western` with the 8 recurring annual CHAPS closure days for England & Wales
- Implements a corrected `dateRoll` lambda that properly rolls New Year's Day when it falls on a weekend (Saturday → +2 → Monday; Sunday → +1 → Monday), fixing a defect that exists in the `UK` calendar and is tracked separately in #97
- Reuses existing `uk.*` observances (`EarlyMayBankHoliday`, `SpringBankHoliday`, `SummerBankHoliday`) and `christian.*` observances (`WesternEaster`, `GoodFriday`, `EasterMonday`) — no new observance classes required
- Registers the new service in `META-INF/services` and `module-info.java`
- Adds `GBP` to the README supported calendars table and code examples

## Related issues

Closes #91
Identified during implementation: #96 (EarlyMayBankHoliday VE Day overrides), #97 (UK calendar NYD roll bug), #98 (GBP ad-hoc closures)

## Test plan

- [ ] `HolidayCalendarServiceGBPTest` passes — 35 tests covering all 8 holidays across years 2020–2026
- [ ] New Year's Day correctly rolls to following Monday in 2022 (Saturday) and 2023 (Sunday)
- [ ] All four Christmas/Boxing Day roll scenarios verified: both roll (2021), Christmas only (2022), Boxing Day only (2020, 2026), neither (2023)
- [ ] Spring Bank Holiday 2022 returns June 2 (Platinum Jubilee observance)
- [ ] `testHolidayCount` asserts exactly 8 holidays — guards against accidental addition of jubilee `SpecialAnniversary` entries from the `UK` calendar
- [ ] Full `holiday-calendar-western` test suite (366 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)