### PR TITLE
#97 Fix UK calendar New Year's Day date roll

### DIFF
--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceGBP.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceGBP.java
@@ -28,10 +28,9 @@ import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.uk.EarlyMayBankHoliday;
 import org.holiday.calendar.observance.uk.SpringBankHoliday;
 import org.holiday.calendar.observance.uk.SummerBankHoliday;
+import org.holiday.calendar.observance.uk.UKDateRolls;
 
-import java.time.LocalDate;
 import java.time.Month;
-import java.util.Optional;
 
 /**
  * Service for provision of United Kingdom (CHAPS) holiday calendar.
@@ -129,28 +128,7 @@ public class HolidayCalendarServiceGBP extends AbstractHolidayCalendarService {
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
-                .dateRoll(dateToRoll -> {
-                    final Optional<LocalDate> nydDate      = newYearsDay.dateForYear(dateToRoll.getYear());
-                    final Optional<LocalDate> christmasDate = christmasDay.dateForYear(dateToRoll.getYear());
-                    final Optional<LocalDate> boxingDayDate = boxingDay.dateForYear(dateToRoll.getYear());
-                    final boolean isNewYearsDay = nydDate.isPresent()       && dateToRoll.equals(nydDate.get());
-                    final boolean isChristmas   = christmasDate.isPresent() && dateToRoll.equals(christmasDate.get());
-                    final boolean isBoxingDay   = boxingDayDate.isPresent() && dateToRoll.equals(boxingDayDate.get());
-                    return switch (dateToRoll.getDayOfWeek()) {
-                        // Christmas/Boxing Day: +2 regardless of Saturday or Sunday (Mon or Tue substitute)
-                        // New Year's Day on Saturday: +2 to Monday
-                        case SATURDAY -> (isChristmas || isBoxingDay || isNewYearsDay)
-                                ? dateToRoll.plusDays(2L)
-                                : dateToRoll;
-                        // Christmas/Boxing Day on Sunday: +2 to Tuesday
-                        // New Year's Day on Sunday: +1 to Monday
-                        case SUNDAY -> (isChristmas || isBoxingDay)
-                                ? dateToRoll.plusDays(2L)
-                                : isNewYearsDay ? dateToRoll.plusDays(1L)
-                                : dateToRoll;
-                        default -> dateToRoll;
-                    };
-                })
+                .dateRoll(UKDateRolls.fixedHolidayRoll(newYearsDay, christmasDay, boxingDay))
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holiday(newYearsDay)
                 .holiday(goodFriday)

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUK.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUK.java
@@ -28,10 +28,10 @@ import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.uk.EarlyMayBankHoliday;
 import org.holiday.calendar.observance.uk.SpringBankHoliday;
 import org.holiday.calendar.observance.uk.SummerBankHoliday;
+import org.holiday.calendar.observance.uk.UKDateRolls;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.util.Optional;
 
 /**
  * Service for provision of UK national holiday calendar.
@@ -138,16 +138,7 @@ public class HolidayCalendarServiceUK extends AbstractHolidayCalendarService {
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
-                .dateRoll(dateToRoll -> {
-                    final Optional<LocalDate> christmasDate = christmasDay.dateForYear(dateToRoll.getYear());
-                    final Optional<LocalDate> boxingDayDate = boxingDay.dateForYear(dateToRoll.getYear());
-                    final boolean isChristmas = christmasDate.isPresent() && dateToRoll.equals(christmasDate.get());
-                    final boolean isBoxingDay = boxingDayDate.isPresent() && dateToRoll.equals(boxingDayDate.get());
-                    return switch (dateToRoll.getDayOfWeek()) {
-                        case SATURDAY, SUNDAY -> (isChristmas || isBoxingDay) ? dateToRoll.plusDays(2L) : dateToRoll;
-                        default -> dateToRoll;
-                    };
-                })
+                .dateRoll(UKDateRolls.fixedHolidayRoll(newYearsDay, christmasDay, boxingDay))
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holiday(newYearsDay)
                 .holiday(goodFriday)

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/UKDateRolls.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/UKDateRolls.java
@@ -60,9 +60,11 @@ public final class UKDateRolls {
             return switch (dateToRoll.getDayOfWeek()) {
                 case SATURDAY -> (isChristmas || isBoxingDay || isNewYearsDay)
                         ? dateToRoll.plusDays(2L) : dateToRoll;
-                case SUNDAY -> (isChristmas || isBoxingDay)
-                        ? dateToRoll.plusDays(2L)
-                        : isNewYearsDay ? dateToRoll.plusDays(1L) : dateToRoll;
+                case SUNDAY -> {
+                    if (isChristmas || isBoxingDay) yield dateToRoll.plusDays(2L);
+                    if (isNewYearsDay)              yield dateToRoll.plusDays(1L);
+                    yield dateToRoll;
+                }
                 default -> dateToRoll;
             };
         };

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/UKDateRolls.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/UKDateRolls.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.uk;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.function.DateRoll;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * Factory providing {@link DateRoll} strategies for United Kingdom holiday calendars.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public final class UKDateRolls {
+
+    private UKDateRolls() {}
+
+    /**
+     * Returns the standard UK date roll strategy for New Year's Day, Christmas Day,
+     * and Boxing Day.
+     *
+     * <ul>
+     *   <li>Christmas Day / Boxing Day on Saturday or Sunday: both substitute days
+     *       are observed on the following Monday and Tuesday (+2 days).</li>
+     *   <li>New Year's Day on Saturday: observed on the following Monday (+2 days).</li>
+     *   <li>New Year's Day on Sunday: observed on the following Monday (+1 day).</li>
+     * </ul>
+     *
+     * @param newYearsDay  the New Year's Day holiday
+     * @param christmasDay the Christmas Day holiday
+     * @param boxingDay    the Boxing Day holiday
+     * @return date roll strategy for these holidays
+     */
+    public static DateRoll fixedHolidayRoll(Holiday newYearsDay, Holiday christmasDay, Holiday boxingDay) {
+        return dateToRoll -> {
+            final Optional<LocalDate> nydDate       = newYearsDay.dateForYear(dateToRoll.getYear());
+            final Optional<LocalDate> christmasDate = christmasDay.dateForYear(dateToRoll.getYear());
+            final Optional<LocalDate> boxingDayDate = boxingDay.dateForYear(dateToRoll.getYear());
+            final boolean isNewYearsDay = nydDate.isPresent()       && dateToRoll.equals(nydDate.get());
+            final boolean isChristmas   = christmasDate.isPresent() && dateToRoll.equals(christmasDate.get());
+            final boolean isBoxingDay   = boxingDayDate.isPresent() && dateToRoll.equals(boxingDayDate.get());
+            return switch (dateToRoll.getDayOfWeek()) {
+                case SATURDAY -> (isChristmas || isBoxingDay || isNewYearsDay)
+                        ? dateToRoll.plusDays(2L) : dateToRoll;
+                case SUNDAY -> (isChristmas || isBoxingDay)
+                        ? dateToRoll.plusDays(2L)
+                        : isNewYearsDay ? dateToRoll.plusDays(1L) : dateToRoll;
+                default -> dateToRoll;
+            };
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUKTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUKTest.java
@@ -38,6 +38,34 @@ public class HolidayCalendarServiceUKTest extends AbstractHolidayCalendarService
     }
 
     @Test
+    public void testDateRoll_NewYearsDaySaturday() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        List<HolidayDate> ukHolidays2022 = calendar.calculate(2022);
+        Optional<HolidayDate> foundNewYearsDay = ukHolidays2022.stream()
+                                                                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                                                                .findFirst();
+        assertTrue(foundNewYearsDay.isPresent());
+        assertEquals(foundNewYearsDay.get().getDate(), LocalDate.of(2022, Month.JANUARY, 3));
+    }
+
+    @Test
+    public void testDateRoll_NewYearsDaySunday() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        List<HolidayDate> ukHolidays2023 = calendar.calculate(2023);
+        Optional<HolidayDate> foundNewYearsDay = ukHolidays2023.stream()
+                                                                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                                                                .findFirst();
+        assertTrue(foundNewYearsDay.isPresent());
+        assertEquals(foundNewYearsDay.get().getDate(), LocalDate.of(2023, Month.JANUARY, 2));
+    }
+
+    @Test
     public void testDateRoll_DefaultCase() {
         HolidayCalendarFactory factory = new HolidayCalendarFactory();
         HolidayCalendar calendar = factory.create(CODE);
@@ -62,6 +90,8 @@ public class HolidayCalendarServiceUKTest extends AbstractHolidayCalendarService
     @DataProvider
     @Override
     Iterator<Object[]> expectedHolidayOccurrences() {
+        final Object[] newYearsDay22 = {2022, "New Year's Day", LocalDate.of(2022, Month.JANUARY, 3)};
+        final Object[] newYearsDay23 = {2023, "New Year's Day", LocalDate.of(2023, Month.JANUARY, 2)};
         final Object[] christmas18 = {2018, "Christmas Day", LocalDate.of(2018, Month.DECEMBER, 25)};
         final Object[] christmas19 = {2019, "Christmas Day", LocalDate.of(2019, Month.DECEMBER, 25)};
         final Object[] christmas20 = {2020, "Christmas Day", LocalDate.of(2020, Month.DECEMBER, 25)};
@@ -74,7 +104,8 @@ public class HolidayCalendarServiceUKTest extends AbstractHolidayCalendarService
         final Object[] boxingDay21 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 28)};
         final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
-        return Arrays.asList(christmas18, christmas19, christmas20, christmas21, christmas22, christmas23,
+        return Arrays.asList(newYearsDay22, newYearsDay23,
+                             christmas18, christmas19, christmas20, christmas21, christmas22, christmas23,
                              boxingDay18, boxingDay19, boxingDay20, boxingDay21, boxingDay22, boxingDay23).listIterator();
     }
 


### PR DESCRIPTION
## Summary

- Fixes `HolidayCalendarServiceUK` date roll lambda which was not handling New Year's Day when it falls on a weekend — despite the holiday being marked `rollable(true)`, the `SATURDAY, SUNDAY` case only checked for Christmas Day and Boxing Day, leaving New Year's Day unrolled
- Extends the lambda to match the correct GBP behaviour: Saturday → +2 (Monday), Sunday → +1 (Monday)
- Extracts the now-identical roll logic from both `HolidayCalendarServiceUK` and `HolidayCalendarServiceGBP` into a new `UKDateRolls.fixedHolidayRoll()` factory method in `org.holiday.calendar.observance.uk`, eliminating the duplication

## Related issues

Closes #97

## Test plan

- [ ] `testDateRoll_NewYearsDaySaturday` — 2022-01-01 (Saturday) rolls to 2022-01-03 (Monday)
- [ ] `testDateRoll_NewYearsDaySunday` — 2023-01-01 (Sunday) rolls to 2023-01-02 (Monday)
- [ ] `expectedHolidayOccurrences` data provider covers New Year's Day for 2022 and 2023
- [ ] All existing Christmas Day and Boxing Day roll tests continue to pass for both `UK` and `GBP` calendars
- [ ] Full `holiday-calendar-western` test suite passes with no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)