### PR TITLE
#96 Fixed EarlyMayBankHoliday VE Day anniversary overrides

### DIFF
--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/EarlyMayBankHoliday.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/EarlyMayBankHoliday.java
@@ -25,22 +25,33 @@ import java.time.LocalDate;
 import java.time.Month;
 import java.time.Year;
 import java.time.temporal.TemporalAdjusters;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Observance of Early May bank holiday - a proclaimed bank holiday in the
- * United Kingdom since 1978.
+ * United Kingdom since 1978. In years when the anniversary of VE Day is
+ * commemorated, this holiday's observed date is moved to May 8.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class EarlyMayBankHoliday implements Observance {
 
+    private final Map<Integer, LocalDate> veDayYearDates;
+
+    public EarlyMayBankHoliday() {
+        veDayYearDates = new HashMap<>();
+        veDayYearDates.put(1995, LocalDate.of(1995, Month.MAY, 8)); // VE Day 50th anniversary
+        veDayYearDates.put(2020, LocalDate.of(2020, Month.MAY, 8)); // VE Day 75th anniversary
+    }
+
     @Override
     public LocalDate apply(Integer year) {
         if (!test(year)) return null;
-        return Year.of(year)
-                   .atMonth(Month.MAY)
-                   .atDay(1)
-                   .with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY));
+        return veDayYearDates.getOrDefault(year, Year.of(year)
+                                                     .atMonth(Month.MAY)
+                                                     .atDay(1)
+                                                     .with(TemporalAdjusters.firstInMonth(DayOfWeek.MONDAY)));
     }
 
     @Override

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceGBPTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceGBPTest.java
@@ -85,6 +85,10 @@ public class HolidayCalendarServiceGBPTest extends AbstractHolidayCalendarServic
         final Object[] easterMonday2024 = {2024, "Easter Monday", LocalDate.of(2024, Month.APRIL,  1)};
 
         // --- Early May Bank Holiday (1st Monday in May, NOT rollable) ---
+        // 1995: VE Day 50th anniversary override → May 8
+        final Object[] earlyMay1995 = {1995, "Early May Bank Holiday", LocalDate.of(1995, Month.MAY,  8)};
+        // 2020: VE Day 75th anniversary override → May 8
+        final Object[] earlyMay2020 = {2020, "Early May Bank Holiday", LocalDate.of(2020, Month.MAY,  8)};
         // 2021: May 3  (May 1 = Saturday → 1st Monday = May 3)
         final Object[] earlyMay2021 = {2021, "Early May Bank Holiday", LocalDate.of(2021, Month.MAY,  3)};
         // 2023: May 1  (May 1 itself is a Monday — earliest possible date)
@@ -114,7 +118,7 @@ public class HolidayCalendarServiceGBPTest extends AbstractHolidayCalendarServic
                 boxing2020, boxing2021, boxing2022, boxing2023, boxing2026,
                 goodFriday2021, goodFriday2024,
                 easterMonday2021, easterMonday2024,
-                earlyMay2021, earlyMay2023, earlyMay2024,
+                earlyMay1995, earlyMay2020, earlyMay2021, earlyMay2023, earlyMay2024,
                 spring2021, spring2022, spring2023,
                 summer2022, summer2024, summer2026
         ).listIterator();

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/uk/EarlyMayBankHolidayTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/uk/EarlyMayBankHolidayTest.java
@@ -37,6 +37,8 @@ public class EarlyMayBankHolidayTest extends AbstractObservanceTest {
         data.add(new Object[]{ 1977, null });
         data.add(new Object[]{ 1978, LocalDate.of(1978, Month.MAY, 1) });
         data.add(new Object[]{ 1990, LocalDate.of(1990, Month.MAY, 7) });
+        data.add(new Object[]{ 1995, LocalDate.of(1995, Month.MAY, 8) }); // VE Day 50th anniversary
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.MAY, 8) }); // VE Day 75th anniversary
         data.add(new Object[]{ 2021, LocalDate.of(2021, Month.MAY, 3) });
         data.add(new Object[]{ 2022, LocalDate.of(2022, Month.MAY, 2) });
 


### PR DESCRIPTION
## Summary

- `EarlyMayBankHoliday` now returns **May 8** for 1995 (VE Day 50th anniversary) and 2020 (VE Day 75th anniversary) instead of the formula's 1st Monday in May
- Adds a `veDayYearDates` map (same pattern as `SpringBankHoliday.jubileeYearDates`) with entries for both affected years; the standard formula applies for all other years
- Fix automatically corrects both the `UK` and `GBP` calendars since both reuse `EarlyMayBankHoliday`

## Related issues

Closes #96

## Test plan

- [ ] `EarlyMayBankHolidayTest` — two new data rows added: `1995 → 1995-05-08` and `2020 → 2020-05-08`
- [ ] `HolidayCalendarServiceGBPTest` — two new `expectedHolidayOccurrences` entries covering both VE Day years via the GBP calendar
- [ ] All non-override years continue to return the 1st Monday in May (existing data rows unchanged)
- [ ] Full `holiday-calendar-western` test suite (414 tests) passes with no regressions

🤖 Generated with [Claude Code](https://claude.ai/claude-code)