### PR TITLE
#92 Add CHF holiday calendar (Switzerland SIC/SNB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Key design goals:
 | `UK` | United Kingdom National Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `CH` | Switzerland National Holidays |
+| `CHF` | Switzerland (SIC/SNB) Holidays |
 | `DE` | Germany National Holidays |
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France National Holidays |
@@ -61,7 +62,7 @@ Then add the modules you need:
   <version>0.0.1</version>
 </dependency>
 
-<!-- Western calendars: US, USD, CA, UK, GBP, CH, DE, EUR, FR, AU, AUD -->
+<!-- Western calendars: US, USD, CA, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>com.github.davejoyce.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
@@ -115,7 +116,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "CAD", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "CH", "UK", "US", "USD"]
+// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -40,6 +40,7 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceCA,
         org.holiday.calendar.impl.HolidayCalendarServiceCAD,
         org.holiday.calendar.impl.HolidayCalendarServiceCH,
+        org.holiday.calendar.impl.HolidayCalendarServiceCHF,
         org.holiday.calendar.impl.HolidayCalendarServiceDE,
         org.holiday.calendar.impl.HolidayCalendarServiceEUR,
         org.holiday.calendar.impl.HolidayCalendarServiceFR,

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCHF.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCHF.java
@@ -124,7 +124,7 @@ public class HolidayCalendarServiceCHF extends AbstractHolidayCalendarService {
                                             .monthDay(Month.DECEMBER, 25)
                                             .build();
         final Holiday boxingDay = Holiday.builder()
-                                         .name("Boxing Day")
+                                         .name("St. Stephen's Day")
                                          .description("Day after Christmas")
                                          .type(Holiday.Type.FIXED)
                                          .rollable(false)

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCHF.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCHF.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.christian.AscensionDay;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.christian.WhitMonday;
+
+import java.time.Month;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of Switzerland (SIC/Swiss National Bank) holiday calendar.
+ *
+ * <p>The SIC (Swiss Interbank Clearing) system, operated by SIX Interbank Clearing AG
+ * on behalf of the Swiss National Bank, follows a no-adjustment convention: holidays
+ * are observed on their published calendar dates regardless of day of week. If a
+ * closure date falls on a weekend, no compensatory weekday closure is designated.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ * @see <a href="https://www.six-group.com/en/products-services/banking-services/interbank-clearing/settlement-services/sic.html">SIX SIC Settlement Services</a>
+ */
+public class HolidayCalendarServiceCHF extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "CHF";
+    private static final String NAME = "Switzerland (SIC/SNB) Holidays";
+
+    public HolidayCalendarServiceCHF() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final EasterObservance easter = new WesternEaster();
+
+        final Holiday newYearsDay = Holiday.builder()
+                                           .name("New Year's Day")
+                                           .description("First day of new year in the Common Era (CE)")
+                                           .type(Holiday.Type.FIXED)
+                                           .rollable(false)
+                                           .monthDay(Month.JANUARY, 1)
+                                           .build();
+        final Holiday berchtoldstag = Holiday.builder()
+                                             .name("Berchtoldstag")
+                                             .description("Day after New Year's Day; SIC settlement closure day "
+                                                     + "observed as a cantonal holiday across most Swiss cantons")
+                                             .type(Holiday.Type.FIXED)
+                                             .rollable(false)
+                                             .monthDay(Month.JANUARY, 2)
+                                             .build();
+        final Holiday goodFriday = Holiday.builder()
+                                          .name("Good Friday")
+                                          .description("Friday before Easter Sunday")
+                                          .type(Holiday.Type.FLOATING)
+                                          .rollable(false)
+                                          .observance(new GoodFriday(easter))
+                                          .build();
+        final Holiday easterMonday = Holiday.builder()
+                                            .name("Easter Monday")
+                                            .description("Monday after Easter Sunday")
+                                            .type(Holiday.Type.FLOATING)
+                                            .rollable(false)
+                                            .observance(new EasterMonday(easter))
+                                            .build();
+        final Holiday labourDay = Holiday.builder()
+                                         .name("Labour Day")
+                                         .description("International Workers' Day")
+                                         .type(Holiday.Type.FIXED)
+                                         .rollable(false)
+                                         .monthDay(Month.MAY, 1)
+                                         .build();
+        // AscensionDay offset 39: Easter Sunday + 39 days = Thursday (the "40th day"
+        // counting Easter Sunday as day 1). Do not change to 40.
+        final Holiday ascensionDay = Holiday.builder()
+                                            .name("Ascension Day")
+                                            .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
+                                            .type(Holiday.Type.FLOATING)
+                                            .rollable(false)
+                                            .observance(new AscensionDay(easter))
+                                            .build();
+        final Holiday whitMonday = Holiday.builder()
+                                          .name("Whit Monday")
+                                          .description("Monday after Whit Sunday (Pentecost)")
+                                          .type(Holiday.Type.FLOATING)
+                                          .rollable(false)
+                                          .observance(new WhitMonday(easter))
+                                          .build();
+        final Holiday swissNationalDay = Holiday.builder()
+                                                .name("Swiss National Day")
+                                                .description("Date of the Federal Charter of 1291")
+                                                .type(Holiday.Type.FIXED)
+                                                .rollable(false)
+                                                .monthDay(Month.AUGUST, 1)
+                                                .build();
+        final Holiday christmasDay = Holiday.builder()
+                                            .name("Christmas Day")
+                                            .description("Celebration of traditional Christmas holiday")
+                                            .type(Holiday.Type.FIXED)
+                                            .rollable(false)
+                                            .monthDay(Month.DECEMBER, 25)
+                                            .build();
+        final Holiday boxingDay = Holiday.builder()
+                                         .name("Boxing Day")
+                                         .description("Day after Christmas")
+                                         .type(Holiday.Type.FIXED)
+                                         .rollable(false)
+                                         .monthDay(Month.DECEMBER, 26)
+                                         .build();
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(berchtoldstag)
+                .holiday(goodFriday)
+                .holiday(easterMonday)
+                .holiday(labourDay)
+                .holiday(ascensionDay)
+                .holiday(whitMonday)
+                .holiday(swissNationalDay)
+                .holiday(christmasDay)
+                .holiday(boxingDay)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -3,6 +3,7 @@ org.holiday.calendar.impl.HolidayCalendarServiceAUD
 org.holiday.calendar.impl.HolidayCalendarServiceCA
 org.holiday.calendar.impl.HolidayCalendarServiceCAD
 org.holiday.calendar.impl.HolidayCalendarServiceCH
+org.holiday.calendar.impl.HolidayCalendarServiceCHF
 org.holiday.calendar.impl.HolidayCalendarServiceDE
 org.holiday.calendar.impl.HolidayCalendarServiceEUR
 org.holiday.calendar.impl.HolidayCalendarServiceFR

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHFTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHFTest.java
@@ -45,7 +45,7 @@ public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServic
         // Berchtoldstag is the primary CHF differentiator — absent from the CH calendar.
         final Object[] berchtoldstag    = new Object[]{"Berchtoldstag"};
         final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
-        final Object[] boxingDay        = new Object[]{"Boxing Day"};
+        final Object[] boxingDay        = new Object[]{"St. Stephen's Day"};
         return Arrays.asList(berchtoldstag, swissNationalDay, boxingDay).listIterator();
     }
 
@@ -126,15 +126,15 @@ public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServic
         // 2023: Monday    — weekday
         final Object[] christmas2023 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
 
-        // ---- Boxing Day (Dec 26) — no roll ----
+        // ---- St. Stephen's Day (Dec 26) — no roll ----
         // 2021: Sunday    — no roll
-        final Object[] boxingDay2021 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 26)};
+        final Object[] boxingDay2021 = {2021, "St. Stephen's Day", LocalDate.of(2021, Month.DECEMBER, 26)};
         // 2022: Monday    — weekday
-        final Object[] boxingDay2022 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        final Object[] boxingDay2022 = {2022, "St. Stephen's Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // 2023: Tuesday   — weekday
-        final Object[] boxingDay2023 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        final Object[] boxingDay2023 = {2023, "St. Stephen's Day", LocalDate.of(2023, Month.DECEMBER, 26)};
         // 2026: Saturday  — no roll
-        final Object[] boxingDay2026 = {2026, "Boxing Day", LocalDate.of(2026, Month.DECEMBER, 26)};
+        final Object[] boxingDay2026 = {2026, "St. Stephen's Day", LocalDate.of(2026, Month.DECEMBER, 26)};
 
         return Arrays.asList(
                 nyd2021, nyd2022, nyd2023,

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHFTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHFTest.java
@@ -45,8 +45,8 @@ public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServic
         // Berchtoldstag is the primary CHF differentiator — absent from the CH calendar.
         final Object[] berchtoldstag    = new Object[]{"Berchtoldstag"};
         final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
-        final Object[] boxingDay        = new Object[]{"St. Stephen's Day"};
-        return Arrays.asList(berchtoldstag, swissNationalDay, boxingDay).listIterator();
+        final Object[] stStephensDay        = new Object[]{"St. Stephen's Day"};
+        return Arrays.asList(berchtoldstag, swissNationalDay, stStephensDay).listIterator();
     }
 
     @DataProvider
@@ -128,13 +128,13 @@ public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServic
 
         // ---- St. Stephen's Day (Dec 26) — no roll ----
         // 2021: Sunday    — no roll
-        final Object[] boxingDay2021 = {2021, "St. Stephen's Day", LocalDate.of(2021, Month.DECEMBER, 26)};
+        final Object[] stStephensDay2021 = {2021, "St. Stephen's Day", LocalDate.of(2021, Month.DECEMBER, 26)};
         // 2022: Monday    — weekday
-        final Object[] boxingDay2022 = {2022, "St. Stephen's Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        final Object[] stStephensDay2022 = {2022, "St. Stephen's Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // 2023: Tuesday   — weekday
-        final Object[] boxingDay2023 = {2023, "St. Stephen's Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        final Object[] stStephensDay2023 = {2023, "St. Stephen's Day", LocalDate.of(2023, Month.DECEMBER, 26)};
         // 2026: Saturday  — no roll
-        final Object[] boxingDay2026 = {2026, "St. Stephen's Day", LocalDate.of(2026, Month.DECEMBER, 26)};
+        final Object[] stStephensDay2026 = {2026, "St. Stephen's Day", LocalDate.of(2026, Month.DECEMBER, 26)};
 
         return Arrays.asList(
                 nyd2021, nyd2022, nyd2023,
@@ -146,7 +146,7 @@ public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServic
                 whitMonday2021, whitMonday2022, whitMonday2023,
                 nationalDay2021, nationalDay2022, nationalDay2026,
                 christmas2021, christmas2022, christmas2023,
-                boxingDay2021, boxingDay2022, boxingDay2023, boxingDay2026
+                stStephensDay2021, stStephensDay2022, stStephensDay2023, stStephensDay2026
         ).listIterator();
     }
 
@@ -154,7 +154,7 @@ public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServic
     public void testHolidayCount() {
         final HolidayCalendar calendar = factory.create(CODE);
         // New Year's Day, Berchtoldstag, Good Friday, Easter Monday, Labour Day,
-        // Ascension Day, Whit Monday, Swiss National Day, Christmas Day, Boxing Day.
+        // Ascension Day, Whit Monday, Swiss National Day, Christmas Day, St. Stephen's Day.
         assertEquals(calendar.getHolidays().size(), 10,
                 "CHF calendar must define exactly 10 SIC closure days");
     }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHFTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHFTest.java
@@ -1,0 +1,203 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceCHFTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "CHF";
+
+    public HolidayCalendarServiceCHFTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        // Berchtoldstag is the primary CHF differentiator — absent from the CH calendar.
+        final Object[] berchtoldstag    = new Object[]{"Berchtoldstag"};
+        final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
+        final Object[] boxingDay        = new Object[]{"Boxing Day"};
+        return Arrays.asList(berchtoldstag, swissNationalDay, boxingDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // SIC no-adjustment convention: all holidays observe on their natural calendar dates.
+
+        // ---- New Year's Day (Jan 1) — no roll ----
+        // 2021: Friday    — weekday, no adjustment needed
+        final Object[] nyd2021 = {2021, "New Year's Day", LocalDate.of(2021, Month.JANUARY, 1)};
+        // 2022: Saturday  — no roll (SIC no-adjustment)
+        final Object[] nyd2022 = {2022, "New Year's Day", LocalDate.of(2022, Month.JANUARY, 1)};
+        // 2023: Sunday    — no roll
+        final Object[] nyd2023 = {2023, "New Year's Day", LocalDate.of(2023, Month.JANUARY, 1)};
+
+        // ---- Berchtoldstag (Jan 2) — no roll — NOT in CH calendar ----
+        // 2021: Saturday  — no roll
+        final Object[] berchtold2021 = {2021, "Berchtoldstag", LocalDate.of(2021, Month.JANUARY, 2)};
+        // 2022: Sunday    — no roll
+        final Object[] berchtold2022 = {2022, "Berchtoldstag", LocalDate.of(2022, Month.JANUARY, 2)};
+        // 2023: Monday    — weekday
+        final Object[] berchtold2023 = {2023, "Berchtoldstag", LocalDate.of(2023, Month.JANUARY, 2)};
+
+        // ---- Good Friday (floating, rollable=false — always a Friday) ----
+        // 2021: Easter Apr 4  → Good Friday Apr 2
+        final Object[] goodFriday2021 = {2021, "Good Friday", LocalDate.of(2021, Month.APRIL,  2)};
+        // 2022: Easter Apr 17 → Good Friday Apr 15
+        final Object[] goodFriday2022 = {2022, "Good Friday", LocalDate.of(2022, Month.APRIL, 15)};
+        // 2024: Easter Mar 31 → Good Friday Mar 29
+        final Object[] goodFriday2024 = {2024, "Good Friday", LocalDate.of(2024, Month.MARCH, 29)};
+
+        // ---- Easter Monday (floating, rollable=false — always a Monday) ----
+        // 2021: Easter Apr 4  → Easter Monday Apr 5
+        final Object[] easterMonday2021 = {2021, "Easter Monday", LocalDate.of(2021, Month.APRIL,  5)};
+        // 2022: Easter Apr 17 → Easter Monday Apr 18
+        final Object[] easterMonday2022 = {2022, "Easter Monday", LocalDate.of(2022, Month.APRIL, 18)};
+        // 2024: Easter Mar 31 → Easter Monday Apr 1
+        final Object[] easterMonday2024 = {2024, "Easter Monday", LocalDate.of(2024, Month.APRIL,  1)};
+
+        // ---- Labour Day (May 1) — no roll ----
+        // 2021: Saturday  — no roll
+        final Object[] labourDay2021 = {2021, "Labour Day", LocalDate.of(2021, Month.MAY, 1)};
+        // 2022: Sunday    — no roll
+        final Object[] labourDay2022 = {2022, "Labour Day", LocalDate.of(2022, Month.MAY, 1)};
+        // 2023: Monday    — weekday
+        final Object[] labourDay2023 = {2023, "Labour Day", LocalDate.of(2023, Month.MAY, 1)};
+
+        // ---- Ascension Day (floating, rollable=false — always a Thursday, Easter+39) ----
+        // 2021: Easter Apr 4  + 39 = May 13
+        final Object[] ascension2021 = {2021, "Ascension Day", LocalDate.of(2021, Month.MAY, 13)};
+        // 2022: Easter Apr 17 + 39 = May 26
+        final Object[] ascension2022 = {2022, "Ascension Day", LocalDate.of(2022, Month.MAY, 26)};
+        // 2023: Easter Apr 9  + 39 = May 18
+        final Object[] ascension2023 = {2023, "Ascension Day", LocalDate.of(2023, Month.MAY, 18)};
+
+        // ---- Whit Monday (floating, rollable=false — always a Monday, Easter+50) ----
+        // 2021: Easter Apr 4  + 50 = May 24
+        final Object[] whitMonday2021 = {2021, "Whit Monday", LocalDate.of(2021, Month.MAY, 24)};
+        // 2022: Easter Apr 17 + 50 = Jun 6
+        final Object[] whitMonday2022 = {2022, "Whit Monday", LocalDate.of(2022, Month.JUNE,  6)};
+        // 2023: Easter Apr 9  + 50 = May 29
+        final Object[] whitMonday2023 = {2023, "Whit Monday", LocalDate.of(2023, Month.MAY, 29)};
+
+        // ---- Swiss National Day (Aug 1) — no roll ----
+        // 2021: Sunday    — no roll (CH rolls this to Aug 2; CHF does not)
+        final Object[] nationalDay2021 = {2021, "Swiss National Day", LocalDate.of(2021, Month.AUGUST, 1)};
+        // 2022: Monday    — weekday
+        final Object[] nationalDay2022 = {2022, "Swiss National Day", LocalDate.of(2022, Month.AUGUST, 1)};
+        // 2026: Saturday  — no roll
+        final Object[] nationalDay2026 = {2026, "Swiss National Day", LocalDate.of(2026, Month.AUGUST, 1)};
+
+        // ---- Christmas Day (Dec 25) — no roll ----
+        // 2021: Saturday  — no roll (CH rolls this to Dec 24; CHF does not)
+        final Object[] christmas2021 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 25)};
+        // 2022: Sunday    — no roll (CH rolls this to Dec 26; CHF does not)
+        final Object[] christmas2022 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 25)};
+        // 2023: Monday    — weekday
+        final Object[] christmas2023 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+
+        // ---- Boxing Day (Dec 26) — no roll ----
+        // 2021: Sunday    — no roll
+        final Object[] boxingDay2021 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 26)};
+        // 2022: Monday    — weekday
+        final Object[] boxingDay2022 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // 2023: Tuesday   — weekday
+        final Object[] boxingDay2023 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        // 2026: Saturday  — no roll
+        final Object[] boxingDay2026 = {2026, "Boxing Day", LocalDate.of(2026, Month.DECEMBER, 26)};
+
+        return Arrays.asList(
+                nyd2021, nyd2022, nyd2023,
+                berchtold2021, berchtold2022, berchtold2023,
+                goodFriday2021, goodFriday2022, goodFriday2024,
+                easterMonday2021, easterMonday2022, easterMonday2024,
+                labourDay2021, labourDay2022, labourDay2023,
+                ascension2021, ascension2022, ascension2023,
+                whitMonday2021, whitMonday2022, whitMonday2023,
+                nationalDay2021, nationalDay2022, nationalDay2026,
+                christmas2021, christmas2022, christmas2023,
+                boxingDay2021, boxingDay2022, boxingDay2023, boxingDay2026
+        ).listIterator();
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testHolidayCount() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        // New Year's Day, Berchtoldstag, Good Friday, Easter Monday, Labour Day,
+        // Ascension Day, Whit Monday, Swiss National Day, Christmas Day, Boxing Day.
+        assertEquals(calendar.getHolidays().size(), 10,
+                "CHF calendar must define exactly 10 SIC closure days");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testBerchtoldTagAbsentFromCH() {
+        // Berchtoldstag is the sole holiday present in CHF but absent from CH.
+        // Asserting its absence from CH validates that the CHF presence assertion is meaningful.
+        final HolidayCalendar chCalendar = factory.create("CH");
+        final boolean defined = chCalendar.getHolidays()
+                .stream()
+                .anyMatch(h -> "Berchtoldstag".equals(h.getName()));
+        assertFalse(defined, "CH calendar must NOT contain Berchtoldstag — it is a CHF-only holiday");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testNoAdjustmentForWeekendHoliday() {
+        // Swiss National Day 2021 (Aug 1 = Sunday) must observe on Aug 1 — not rolled to Aug 2.
+        // This is the sharpest proof that CHF uses noRoll() rather than any rolling strategy.
+        // By contrast, the CH calendar (previousFridayOrFollowingMonday) would give Aug 2.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final List<HolidayDate> results = calendar.calculate(2021);
+        final LocalDate observed = results.stream()
+                .filter(hd -> "Swiss National Day".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .map(HolidayDate::getDate)
+                .orElseThrow();
+        assertEquals(observed, LocalDate.of(2021, Month.AUGUST, 1),
+                "CHF must observe Swiss National Day on Aug 1 even when it falls on a Sunday");
+    }
+
+    @Test(dependsOnMethods = "testHolidayCalendarFactoryCreate")
+    public void testChronologicalOrder() {
+        final HolidayCalendar calendar = factory.create(CODE);
+        for (final int year : new int[]{2021, 2022, 2023, 2024, 2025, 2026, 2027}) {
+            final List<HolidayDate> holidays = calendar.calculate(year);
+            assertFalse(holidays.isEmpty(), "Expected non-empty holiday list for " + year);
+            for (int i = 1; i < holidays.size(); i++) {
+                assertFalse(holidays.get(i).getDate().isBefore(holidays.get(i - 1).getDate()), "Holidays out of chronological order for " + year
+                        + ": " + holidays.get(i - 1).getDate()
+                        + " > " + holidays.get(i).getDate());
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary

- Adds `HolidayCalendarServiceCHF` — the SIC (Swiss Interbank Clearing) settlement calendar operated by SIX Interbank Clearing AG on behalf of the Swiss National Bank
- 10 holidays: New Year's Day, Berchtoldstag (2 Jan), Good Friday, Easter Monday, Labour Day, Ascension Day, Whit Monday, Swiss National Day, Christmas Day, Boxing Day
- Uses `DateRolls.noRoll()` — SIC follows a no-adjustment convention; holidays are observed on their published calendar dates regardless of day of week
- Registers `CHF` alongside the existing `CH` (SIX Swiss Exchange) calendar — the two are distinct; `CHF` adds Berchtoldstag and uses a different roll convention

## Key design decisions

**No-adjustment convention:** Despite the GitHub issue text mentioning "following-Monday roll rules", the authoritative SIC/SNB documentation confirms no date adjustment. All holidays are `rollable(false)`. See comment on issue #92 for details.

**Berchtoldstag (2 January):** Present in `CHF` only. It is a cantonal holiday (not a federal holiday) but an official SIC system closure day. This is the sole holiday difference between `CHF` and `CH`.

**`CH` unchanged:** The existing `CH` (SIX Swiss Exchange) calendar is untouched.

## Test plan

- [x] 39 tests in `HolidayCalendarServiceCHFTest` — all pass
- [x] Data-driven `expectedHolidayOccurrences` covers all 10 holidays across multiple years, including weekend occurrences that confirm no adjustment is applied
- [x] `testHolidayCount()` — asserts exactly 10 holidays
- [x] `testBerchtoldTagAbsentFromCH()` — cross-calendar assertion proving Berchtoldstag is CHF-only
- [x] `testNoAdjustmentForWeekendHoliday()` — asserts Swiss National Day 2021 (Sunday) observes on Aug 1, not Aug 2
- [x] `testChronologicalOrder()` — asserts sorted output for 2021–2027
- [x] Full western module test suite: 461/461 pass, no regressions

Closes #92

🤖 Generated with [Claude Code](https://claude.com/claude-code)