### PR TITLE
#110 Expose dataValidThrough() on HolidayCalendarService

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
@@ -32,6 +32,7 @@ import org.holiday.calendar.observance.lunar.ChineseNewYearSecondDay;
 import org.holiday.calendar.observance.lunar.VesakDay;
 
 import java.time.Month;
+import java.util.OptionalInt;
 
 /**
  * Service for provision of Singapore Exchange (SGX) holiday calendar.
@@ -43,8 +44,18 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
     private static final String CODE = "SG";
     private static final String NAME = "Singapore (SGX) Holidays";
 
+    // Boundary year through which all four gazetted lookup-table observances
+    // (VesakDay, HariRayaHaji, HariRayaPuasa, Deepavali) are populated.
+    // Update this constant and all four DATES maps together when new years are added.
+    private static final int DATA_VALID_THROUGH_YEAR = 2030;
+
     public HolidayCalendarServiceSG() {
         super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(DATA_VALID_THROUGH_YEAR);
     }
 
     @Override

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
@@ -31,6 +31,7 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.testng.Assert.*;
 
@@ -154,6 +155,50 @@ public class HolidayCalendarServiceSGTest {
         assertTrue(nationalDay2023.isPresent());
         assertEquals(nationalDay2023.get().getDate(), LocalDate.of(2023, Month.AUGUST, 9),
                 "National Day 2023 (Aug 9, Wednesday) should not roll");
+    }
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isPresent(),
+            "SG calendar has lookup-table holidays; must return a bounded year from dataValidThrough()");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().getAsInt(), 2030,
+            "SG lookup tables (VesakDay, HariRayaHaji, HariRayaPuasa, Deepavali) all end at 2030");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("SG");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().getAsInt(),
+            "factory.dataValidThrough(\"SG\") must delegate to the service and return the same year");
+    }
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().getAsInt();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+            "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
+        assertEquals(holidays.size(), 11,
+            "Expected all 11 SG holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsLookupTableHolidays() {
+        int boundaryYear = service.dataValidThrough().getAsInt();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidaysAtBoundary = calendar.calculate(boundaryYear);
+        // Must not throw — silent omission is the documented calculate() contract
+        List<HolidayDate> holidaysBeyond = calendar.calculate(boundaryYear + 1);
+        assertTrue(holidaysBeyond.size() < holidaysAtBoundary.size(),
+            "Year beyond dataValidThrough should produce fewer holidays (lookup tables exhausted); " +
+            "at boundary: " + holidaysAtBoundary.size() + ", beyond: " + holidaysBeyond.size());
     }
 
     @DataProvider

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
@@ -82,10 +82,7 @@ public class HolidayCalendarServiceSGTest {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(2024);
         for (int i = 1; i < holidays.size(); i++) {
-            assertTrue(
-                holidays.get(i).getDate().compareTo(holidays.get(i - 1).getDate()) >= 0,
-                "Holidays should be in chronological order"
-            );
+            assertFalse(holidays.get(i).getDate().isBefore(holidays.get(i - 1).getDate()), "Holidays should be in chronological order");
         }
     }
 

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendarFactory.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendarFactory.java
@@ -22,6 +22,7 @@ package org.holiday.calendar;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.StreamSupport;
+import java.util.OptionalInt;
 
 /**
  * Factory for creation of {@link HolidayCalendar} objects.
@@ -74,6 +75,27 @@ public class HolidayCalendarFactory {
                 .filter(Objects::nonNull)
                 .sorted()
                 .toList();
+    }
+
+    /**
+     * Returns the latest year for which the calendar identified by {@code code}
+     * provides authoritative data, by delegating to
+     * {@link HolidayCalendarService#dataValidThrough()} on the service that
+     * provides that code.
+     *
+     * <p>An empty result means the calendar is fully algorithmic with no known
+     * upper bound. A non-empty result means at least one holiday in the calendar
+     * is backed by a lookup table that ends at the returned year; calculations
+     * for later years will silently omit those holidays.
+     *
+     * @param code short code identifier of the desired holiday calendar
+     * @return the last authoritative year, or {@link OptionalInt#empty()} if
+     *         the calendar is fully algorithmic with no known upper bound
+     * @throws HolidayCalendarNotFoundException if {@code code} does not match
+     *         any registered service
+     */
+    public OptionalInt dataValidThrough(String code) {
+        return getService(code).dataValidThrough();
     }
 
 }

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendarService.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendarService.java
@@ -18,6 +18,8 @@
 
 package org.holiday.calendar;
 
+import java.util.OptionalInt;
+
 /**
  * Required behavior of a service which provides the {@link HolidayCalendar}
  * object assigned to a unique <em>code</em> identifier.
@@ -61,6 +63,38 @@ public interface HolidayCalendarService {
      */
     default String getRegion() {
         return null;
+    }
+
+    /**
+     * Returns the latest year for which this service provides authoritative
+     * holiday data for <em>all</em> lookup-table-backed holidays in this calendar.
+     *
+     * <p>An empty result indicates that every holiday in this calendar is
+     * computed algorithmically and therefore has no known upper bound &mdash; all
+     * years are equally authoritative (e.g. Easter-based or nth-weekday rules).
+     *
+     * <p>A non-empty result indicates that one or more holidays are backed by a
+     * finite, officially-gazetted lookup table. The returned value is the last
+     * year for which all such tables have been populated. For years beyond this
+     * value, {@link HolidayCalendar#calculate(int)} will silently omit those
+     * holidays without throwing an exception. This method is an advisory signal
+     * only &mdash; it does not alter {@code calculate()} behaviour. Callers that
+     * require complete data should verify that the requested year does not
+     * exceed this bound before invoking {@code calculate()}.
+     *
+     * <p>Implementations backed by lookup tables <strong>must</strong> override
+     * this method and return {@code OptionalInt.of(lastTableYear)}, where
+     * {@code lastTableYear} is the minimum of the last year covered by each
+     * individual lookup table in the calendar. Subclasses of
+     * {@link AbstractHolidayCalendarService} that use lookup tables should
+     * override this method accordingly.
+     *
+     * @return the last year for which data is fully authoritative, or
+     *         {@link OptionalInt#empty()} if the calendar is fully algorithmic
+     *         with no known upper bound
+     */
+    default OptionalInt dataValidThrough() {
+        return OptionalInt.empty();
     }
 
 }

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/HolidayCalendarFactoryTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/HolidayCalendarFactoryTest.java
@@ -3,6 +3,7 @@ package org.holiday.calendar;
 import org.testng.annotations.Test;
 
 import java.util.List;
+import java.util.OptionalInt;
 
 import static org.testng.Assert.*;
 
@@ -33,6 +34,21 @@ public class HolidayCalendarFactoryTest {
         List<String> codes = factory.listAvailableCodes();
         assertNotNull(codes);
         assertTrue(codes.contains(CODE));
+    }
+
+    @Test
+    public void testDataValidThroughAlgorithmicCalendarReturnsEmpty() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        OptionalInt result = factory.dataValidThrough(CODE);
+        assertFalse(result.isPresent(),
+            "Fully algorithmic calendar should return OptionalInt.empty() from dataValidThrough()");
+    }
+
+    @Test(expectedExceptions = HolidayCalendarNotFoundException.class)
+    public void testDataValidThroughInvalidCodeThrowsException() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        factory.dataValidThrough(INVALID_CODE);
+        fail("Expected HolidayCalendarNotFoundException to be thrown for code " + INVALID_CODE);
     }
 
 }


### PR DESCRIPTION
### Title of the PR

Expose `dataValidThrough()` on `HolidayCalendarService`

**Description**

- Added `default OptionalInt dataValidThrough()` to `HolidayCalendarService`, returning `OptionalInt.empty()` for fully-algorithmic calendars (no known upper bound)
- Added `public OptionalInt dataValidThrough(String code)` convenience accessor to `HolidayCalendarFactory`, delegating to the underlying service with the same `HolidayCalendarNotFoundException` semantics as `create()`
- Overrode `dataValidThrough()` in `HolidayCalendarServiceSG` to return `OptionalInt.of(2030)` — the minimum boundary across all four gazetted lookup-table observances (VesakDay, HariRayaHaji, HariRayaPuasa, Deepavali); added `DATA_VALID_THROUGH_YEAR` constant with a maintenance comment naming all four tables
- Added 7 new tests across `HolidayCalendarFactoryTest` (core) and `HolidayCalendarServiceSGTest` (apac), including a boundary test that confirms `calculate(boundaryYear + 1)` silently drops lookup-table holidays without throwing

**Related Issue**

- [#110 — Expose dataValidThrough() on HolidayCalendarService](https://github.com/holiday-calendar/holiday-calendar-java/issues/110)

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed