### PR TITLE
#111 Extend VesakDay (SG) lookup table through 2055

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/lunar/VesakDay.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/lunar/VesakDay.java
@@ -30,25 +30,57 @@ import java.util.Map;
  * calendar, observed as a public holiday on the date officially gazetted by
  * the Singapore government.
  *
- * <p>Dates are sourced from official Singapore public holiday announcements.</p>
+ * <p>Dates for 2019–2030 are sourced from official Singapore Ministry of Manpower (MOM)
+ * public holiday gazette notifications. Dates for 2031–2055 are pre-computed from the
+ * Hong Kong Observatory Gregorian-Lunar Calendar Conversion Tables (day 15 of Chinese
+ * lunisolar month 4 in SGT), pending official MOM gazette confirmation. All entries
+ * should be verified against MOM announcements as Singapore approaches each year.</p>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class VesakDay extends AbstractObservance {
 
     private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
+        // 2019–2030: Singapore MOM official gazette
         Map.entry(2019, LocalDate.of(2019, 5, 19)),
-        Map.entry(2020, LocalDate.of(2020, 5, 7)),
+        Map.entry(2020, LocalDate.of(2020, 5,  7)),
         Map.entry(2021, LocalDate.of(2021, 5, 26)),
         Map.entry(2022, LocalDate.of(2022, 5, 15)),
-        Map.entry(2023, LocalDate.of(2023, 6, 2)),
+        Map.entry(2023, LocalDate.of(2023, 6,  2)),
         Map.entry(2024, LocalDate.of(2024, 5, 22)),
         Map.entry(2025, LocalDate.of(2025, 5, 12)),
         Map.entry(2026, LocalDate.of(2026, 5, 31)),
         Map.entry(2027, LocalDate.of(2027, 5, 20)),
-        Map.entry(2028, LocalDate.of(2028, 5, 8)),
+        Map.entry(2028, LocalDate.of(2028, 5,  8)),
         Map.entry(2029, LocalDate.of(2029, 5, 27)),
-        Map.entry(2030, LocalDate.of(2030, 5, 16))
+        Map.entry(2030, LocalDate.of(2030, 5, 16)),
+        // 2031–2055: HKO Gregorian-Lunar Conversion Tables (M4 day 15 in SGT);
+        // verify against MOM gazette as each year is officially published.
+        Map.entry(2031, LocalDate.of(2031, 6,  4)),
+        Map.entry(2032, LocalDate.of(2032, 5, 23)),
+        Map.entry(2033, LocalDate.of(2033, 5, 13)),
+        Map.entry(2034, LocalDate.of(2034, 6,  1)),
+        Map.entry(2035, LocalDate.of(2035, 5, 22)),
+        Map.entry(2036, LocalDate.of(2036, 5, 10)),
+        Map.entry(2037, LocalDate.of(2037, 5, 29)),
+        Map.entry(2038, LocalDate.of(2038, 5, 18)),
+        Map.entry(2039, LocalDate.of(2039, 5,  7)),
+        Map.entry(2040, LocalDate.of(2040, 5, 25)),
+        Map.entry(2041, LocalDate.of(2041, 5, 14)),
+        Map.entry(2042, LocalDate.of(2042, 6,  2)),
+        Map.entry(2043, LocalDate.of(2043, 5, 23)),
+        Map.entry(2044, LocalDate.of(2044, 5, 12)),
+        Map.entry(2045, LocalDate.of(2045, 5, 31)),
+        Map.entry(2046, LocalDate.of(2046, 5, 20)),
+        Map.entry(2047, LocalDate.of(2047, 5,  9)),
+        Map.entry(2048, LocalDate.of(2048, 5, 27)), // computed via Xiaoman method; HKO 2048e PDF is image-rendered
+        Map.entry(2049, LocalDate.of(2049, 5, 16)),
+        Map.entry(2050, LocalDate.of(2050, 6,  4)),
+        Map.entry(2051, LocalDate.of(2051, 5, 24)),
+        Map.entry(2052, LocalDate.of(2052, 5, 13)),
+        Map.entry(2053, LocalDate.of(2053, 6,  1)),
+        Map.entry(2054, LocalDate.of(2054, 5, 22)),
+        Map.entry(2055, LocalDate.of(2055, 5, 11))
     );
 
     @Override

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
@@ -218,4 +218,27 @@ public class HolidayCalendarServiceSGTest {
         assertTrue(found, "Calendar should contain holiday: " + holidayName);
     }
 
+    @Test
+    public void testVesakDay2055PresentAndCorrect() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2055);
+        Optional<HolidayDate> vesak = holidays.stream()
+                .filter(hd -> "Vesak Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(vesak.isPresent(), "Vesak Day must be present for 2055");
+        assertEquals(vesak.get().getDate(), LocalDate.of(2055, Month.MAY, 11),
+                "Vesak Day 2055 should be May 11");
+    }
+
+    @Test
+    public void testVesakDay2056AbsentSilently() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays2056 = calendar.calculate(2056);
+        Optional<HolidayDate> vesak = holidays2056.stream()
+                .filter(hd -> "Vesak Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertFalse(vesak.isPresent(),
+                "Vesak Day must be silently absent for 2056 — beyond the table ceiling");
+    }
+
 }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/lunar/VesakDayTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/lunar/VesakDayTest.java
@@ -1,0 +1,216 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.lunar;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class VesakDayTest {
+
+    private final VesakDay observance = new VesakDay();
+
+    // -------------------------------------------------------------------------
+    // DataProviders
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> allCoveredYears() {
+        List<Object[]> data = new ArrayList<>();
+        // 2019–2030: Singapore MOM official gazette
+        data.add(new Object[]{2019, LocalDate.of(2019, Month.MAY,    19)});
+        data.add(new Object[]{2020, LocalDate.of(2020, Month.MAY,     7)});
+        data.add(new Object[]{2021, LocalDate.of(2021, Month.MAY,    26)});
+        data.add(new Object[]{2022, LocalDate.of(2022, Month.MAY,    15)});
+        data.add(new Object[]{2023, LocalDate.of(2023, Month.JUNE,    2)});
+        data.add(new Object[]{2024, LocalDate.of(2024, Month.MAY,    22)});
+        data.add(new Object[]{2025, LocalDate.of(2025, Month.MAY,    12)});
+        data.add(new Object[]{2026, LocalDate.of(2026, Month.MAY,    31)});
+        data.add(new Object[]{2027, LocalDate.of(2027, Month.MAY,    20)});
+        data.add(new Object[]{2028, LocalDate.of(2028, Month.MAY,     8)});
+        data.add(new Object[]{2029, LocalDate.of(2029, Month.MAY,    27)});
+        data.add(new Object[]{2030, LocalDate.of(2030, Month.MAY,    16)});
+        // 2031–2055: HKO Gregorian-Lunar Conversion Tables
+        data.add(new Object[]{2031, LocalDate.of(2031, Month.JUNE,    4)});
+        data.add(new Object[]{2032, LocalDate.of(2032, Month.MAY,    23)});
+        data.add(new Object[]{2033, LocalDate.of(2033, Month.MAY,    13)});
+        data.add(new Object[]{2034, LocalDate.of(2034, Month.JUNE,    1)});
+        data.add(new Object[]{2035, LocalDate.of(2035, Month.MAY,    22)});
+        data.add(new Object[]{2036, LocalDate.of(2036, Month.MAY,    10)});
+        data.add(new Object[]{2037, LocalDate.of(2037, Month.MAY,    29)});
+        data.add(new Object[]{2038, LocalDate.of(2038, Month.MAY,    18)});
+        data.add(new Object[]{2039, LocalDate.of(2039, Month.MAY,     7)});
+        data.add(new Object[]{2040, LocalDate.of(2040, Month.MAY,    25)});
+        data.add(new Object[]{2041, LocalDate.of(2041, Month.MAY,    14)});
+        data.add(new Object[]{2042, LocalDate.of(2042, Month.JUNE,    2)});
+        data.add(new Object[]{2043, LocalDate.of(2043, Month.MAY,    23)});
+        data.add(new Object[]{2044, LocalDate.of(2044, Month.MAY,    12)});
+        data.add(new Object[]{2045, LocalDate.of(2045, Month.MAY,    31)});
+        data.add(new Object[]{2046, LocalDate.of(2046, Month.MAY,    20)});
+        data.add(new Object[]{2047, LocalDate.of(2047, Month.MAY,     9)});
+        data.add(new Object[]{2048, LocalDate.of(2048, Month.MAY,    27)});
+        data.add(new Object[]{2049, LocalDate.of(2049, Month.MAY,    16)});
+        data.add(new Object[]{2050, LocalDate.of(2050, Month.JUNE,    4)});
+        data.add(new Object[]{2051, LocalDate.of(2051, Month.MAY,    24)});
+        data.add(new Object[]{2052, LocalDate.of(2052, Month.MAY,    13)});
+        data.add(new Object[]{2053, LocalDate.of(2053, Month.JUNE,    1)});
+        data.add(new Object[]{2054, LocalDate.of(2054, Month.MAY,    22)});
+        data.add(new Object[]{2055, LocalDate.of(2055, Month.MAY,    11)});
+        return data.iterator();
+    }
+
+    @DataProvider
+    Iterator<Object[]> outOfRangeYears() {
+        return List.of(
+            new Object[]{2018},
+            new Object[]{1900},
+            new Object[]{2056},
+            new Object[]{2099}
+        ).iterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 1: apply() returns correct non-null dates for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testApplyReturnsExpectedDate(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+            "VesakDay.apply(" + year + ") should return " + expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 2: test() (Predicate) returns true for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testPredicateReturnsTrueForCoveredYear(int year, LocalDate ignored) {
+        assertTrue(observance.test(year),
+            "VesakDay.test(" + year + ") should return true");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 3: apply() returns null for out-of-range years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "outOfRangeYears")
+    public void testApplyReturnsNullOutOfRange(int year) {
+        assertNull(observance.apply(year),
+            "VesakDay.apply(" + year + ") should return null (outside coverage)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 4: test() (Predicate) returns false for out-of-range years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "outOfRangeYears")
+    public void testPredicateReturnsFalseOutOfRange(int year) {
+        assertFalse(observance.test(year),
+            "VesakDay.test(" + year + ") should return false (outside coverage)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 5: null-safety from AbstractObservance contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+            "VesakDay.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+            "VesakDay.test(null) must return false per AbstractObservance contract");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 6: Boundary and seam spot checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testOriginalCeilingYear2030() {
+        assertEquals(observance.apply(2030), LocalDate.of(2030, Month.MAY, 16),
+            "2030 is the original table ceiling; must remain intact after extension");
+    }
+
+    @Test
+    public void testFirstNewYear2031() {
+        assertEquals(observance.apply(2031), LocalDate.of(2031, Month.JUNE, 4),
+            "2031 is the first newly-added year");
+    }
+
+    @Test
+    public void testMidpointYear2042() {
+        assertEquals(observance.apply(2042), LocalDate.of(2042, Month.JUNE, 2),
+            "2042 is near the midpoint of the extended range");
+    }
+
+    @Test
+    public void testNewCeilingYear2055() {
+        assertEquals(observance.apply(2055), LocalDate.of(2055, Month.MAY, 11),
+            "2055 is the new upper bound; must be present and correct");
+    }
+
+    @Test
+    public void testYearJustBeforeLowerBound() {
+        assertNull(observance.apply(2018),
+            "2018 is just before the lower bound; must return null");
+    }
+
+    @Test
+    public void testYearJustAfterUpperBound() {
+        assertNull(observance.apply(2056),
+            "2056 is just after the new upper bound; must return null");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 7: Month-range sanity — all Vesak dates must fall in May or June
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testDateFallsInMayOrJune(int year, LocalDate expected) {
+        Month month = expected.getMonth();
+        assertTrue(month == Month.MAY || month == Month.JUNE,
+            "VesakDay " + year + " (" + expected + ") must fall in May or June");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 8: Structural guard — table covers exactly 37 years
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTableCoversExactly37Years() {
+        long coveredCount = 0;
+        for (int y = 2019; y <= 2055; y++) {
+            if (observance.test(y)) coveredCount++;
+        }
+        assertEquals(coveredCount, 37L,
+            "DATES map must have exactly 37 entries covering 2019–2055 inclusive");
+    }
+
+}


### PR DESCRIPTION
### #111 Extend VesakDay (SG) lookup table through 2055

**Description**

- Extended `VesakDay.DATES` with 25 new entries covering 2031–2055 (up from 2019–2030)
- Dates for 2031–2055 sourced from Hong Kong Observatory Gregorian-Lunar Calendar Conversion Tables (day 15 of Chinese lunisolar month 4 in SGT); the 2048 entry is computed via the Xiǎomǎn solar-term method as the HKO 2048 PDF is image-rendered
- Updated Javadoc to distinguish MOM-gazetted entries (2019–2030) from HKO-provisional entries (2031–2055)
- `DATA_VALID_THROUGH_YEAR` in `HolidayCalendarServiceSG` intentionally unchanged at 2030 — per the existing coordination constraint, that constant updates only when all four gazetted observances (VesakDay, HariRayaHaji, HariRayaPuasa, Deepavali) are extended together
- Added `VesakDayTest` covering all 37 years via `@DataProvider`, out-of-range/null contracts, month-range sanity, and a structural guard asserting exactly 37 entries
- Added integration tests `testVesakDay2055PresentAndCorrect` and `testVesakDay2056AbsentSilently` to `HolidayCalendarServiceSGTest`

**Related Issue**

- [#111 — Extend Vesak Day (SG) lookup table through 2055](https://github.com/holiday-calendar/holiday-calendar-java/issues/111)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed