### PR TITLE
#112 Extended Hari Raya Puasa lookup table through 2055

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaPuasa.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaPuasa.java
@@ -29,25 +29,63 @@ import java.util.Map;
  * and follows the local lunar sighting, which may differ from tabular
  * Islamic calendar calculations.
  *
- * <p>Dates are sourced from official Singapore public holiday announcements.</p>
+ * <p>Dates for 2019–2030 are sourced from official Singapore Ministry of Manpower (MOM)
+ * public holiday gazette notifications and MUIS (Majlis Ugama Islam Singapura) announcements.
+ * Dates for 2031–2055 are projected from the Umm al-Qura tabular Islamic calendar
+ * (1 Shawwal AH, adjusted to SGT via Singapore's Imkan ar-Rukyah +1-day offset); verify
+ * against MUIS/MOM gazette announcements at https://data.gov.sg/collections/691/view as
+ * each year is officially published.</p>
+ *
+ * <p>Note: Gregorian year 2033 contains two Eid al-Fitr occurrences (~January 4 and
+ * ~December 24). This map records only the first (January) occurrence; the December
+ * occurrence cannot be represented under the single-date-per-year-key design.</p>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HariRayaPuasa extends AbstractObservance {
 
     private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
-        Map.entry(2019, LocalDate.of(2019, 6, 5)),
-        Map.entry(2020, LocalDate.of(2020, 5, 24)),
-        Map.entry(2021, LocalDate.of(2021, 5, 13)),
-        Map.entry(2022, LocalDate.of(2022, 5, 3)),
-        Map.entry(2023, LocalDate.of(2023, 4, 21)),
-        Map.entry(2024, LocalDate.of(2024, 4, 10)),
-        Map.entry(2025, LocalDate.of(2025, 3, 31)),
-        Map.entry(2026, LocalDate.of(2026, 3, 20)),
-        Map.entry(2027, LocalDate.of(2027, 3, 10)),
-        Map.entry(2028, LocalDate.of(2028, 2, 27)),
-        Map.entry(2029, LocalDate.of(2029, 2, 16)),
-        Map.entry(2030, LocalDate.of(2030, 2, 5))
+        // 2019–2030: Singapore MOM/MUIS official gazette
+        Map.entry(2019, LocalDate.of(2019,  6,  5)),
+        Map.entry(2020, LocalDate.of(2020,  5, 24)),
+        Map.entry(2021, LocalDate.of(2021,  5, 13)),
+        Map.entry(2022, LocalDate.of(2022,  5,  3)),
+        Map.entry(2023, LocalDate.of(2023,  4, 21)),
+        Map.entry(2024, LocalDate.of(2024,  4, 10)),
+        Map.entry(2025, LocalDate.of(2025,  3, 31)),
+        Map.entry(2026, LocalDate.of(2026,  3, 20)),
+        Map.entry(2027, LocalDate.of(2027,  3, 10)),
+        Map.entry(2028, LocalDate.of(2028,  2, 27)),
+        Map.entry(2029, LocalDate.of(2029,  2, 16)),
+        Map.entry(2030, LocalDate.of(2030,  2,  5)),
+        // 2031–2055: Umm al-Qura tabular Islamic calendar (1 Shawwal AH, adjusted to SGT
+        // via Singapore's Imkan ar-Rukyah +1-day offset); verify against MUIS/MOM gazette
+        // as each year is officially published. 2033 records only the January occurrence.
+        Map.entry(2031, LocalDate.of(2031,  1, 25)),
+        Map.entry(2032, LocalDate.of(2032,  1, 15)),
+        Map.entry(2033, LocalDate.of(2033,  1,  4)),
+        Map.entry(2034, LocalDate.of(2034, 12, 13)),
+        Map.entry(2035, LocalDate.of(2035, 12,  2)),
+        Map.entry(2036, LocalDate.of(2036, 11, 20)),
+        Map.entry(2037, LocalDate.of(2037, 11, 10)),
+        Map.entry(2038, LocalDate.of(2038, 10, 30)),
+        Map.entry(2039, LocalDate.of(2039, 10, 20)),
+        Map.entry(2040, LocalDate.of(2040, 10,  9)),
+        Map.entry(2041, LocalDate.of(2041,  9, 28)),
+        Map.entry(2042, LocalDate.of(2042,  9, 17)),
+        Map.entry(2043, LocalDate.of(2043,  9,  6)),
+        Map.entry(2044, LocalDate.of(2044,  8, 25)),
+        Map.entry(2045, LocalDate.of(2045,  8, 15)),
+        Map.entry(2046, LocalDate.of(2046,  8,  5)),
+        Map.entry(2047, LocalDate.of(2047,  7, 25)),
+        Map.entry(2048, LocalDate.of(2048,  7, 14)),
+        Map.entry(2049, LocalDate.of(2049,  7,  3)),
+        Map.entry(2050, LocalDate.of(2050,  6, 22)),
+        Map.entry(2051, LocalDate.of(2051,  6, 11)),
+        Map.entry(2052, LocalDate.of(2052,  5, 31)),
+        Map.entry(2053, LocalDate.of(2053,  5, 20)),
+        Map.entry(2054, LocalDate.of(2054,  5, 10)),
+        Map.entry(2055, LocalDate.of(2055,  4, 29))
     );
 
     @Override

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
@@ -164,7 +164,9 @@ public class HolidayCalendarServiceSGTest {
     @Test
     public void testDataValidThroughReturnedYear() {
         assertEquals(service.dataValidThrough().getAsInt(), 2030,
-            "SG lookup tables (VesakDay, HariRayaHaji, HariRayaPuasa, Deepavali) all end at 2030");
+            "dataValidThrough() returns the minimum ceiling across all four lookup-table observances; " +
+            "VesakDay (#111) and HariRayaPuasa (#112) extend to 2055, but HariRayaHaji and Deepavali " +
+            "still end at 2030, so the minimum remains 2030");
     }
 
     @Test
@@ -239,6 +241,28 @@ public class HolidayCalendarServiceSGTest {
                 .findFirst();
         assertFalse(vesak.isPresent(),
                 "Vesak Day must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testHariRayaPuasa2055PresentAndCorrect() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2055);
+        Optional<HolidayDate> hrp = holidays.stream()
+                .filter(hd -> "Hari Raya Puasa".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(hrp.isPresent(), "Hari Raya Puasa must be present for 2055");
+        assertEquals(hrp.get().getDate(), LocalDate.of(2055, Month.APRIL, 29),
+                "Hari Raya Puasa 2055 should be April 29");
+    }
+
+    @Test
+    public void testHariRayaPuasa2056AbsentSilently() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Optional<HolidayDate> hrp = calendar.calculate(2056).stream()
+                .filter(hd -> "Hari Raya Puasa".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertFalse(hrp.isPresent(),
+                "Hari Raya Puasa must be silently absent for 2056 — beyond the table ceiling");
     }
 
 }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/islamic/HariRayaPuasaTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/islamic/HariRayaPuasaTest.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic;
+
+import org.holiday.calendar.observance.lunar.VesakDay;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class HariRayaPuasaTest {
+
+    private final HariRayaPuasa observance = new HariRayaPuasa();
+
+    // -------------------------------------------------------------------------
+    // DataProviders
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> allCoveredYears() {
+        List<Object[]> data = new ArrayList<>();
+        // 2019–2030: Singapore MOM/MUIS official gazette
+        data.add(new Object[]{2019, LocalDate.of(2019, Month.JUNE,      5)});
+        data.add(new Object[]{2020, LocalDate.of(2020, Month.MAY,      24)});
+        data.add(new Object[]{2021, LocalDate.of(2021, Month.MAY,      13)});
+        data.add(new Object[]{2022, LocalDate.of(2022, Month.MAY,       3)});
+        data.add(new Object[]{2023, LocalDate.of(2023, Month.APRIL,    21)});
+        data.add(new Object[]{2024, LocalDate.of(2024, Month.APRIL,    10)});
+        data.add(new Object[]{2025, LocalDate.of(2025, Month.MARCH,    31)});
+        data.add(new Object[]{2026, LocalDate.of(2026, Month.MARCH,    20)});
+        data.add(new Object[]{2027, LocalDate.of(2027, Month.MARCH,    10)});
+        data.add(new Object[]{2028, LocalDate.of(2028, Month.FEBRUARY, 27)});
+        data.add(new Object[]{2029, LocalDate.of(2029, Month.FEBRUARY, 16)});
+        data.add(new Object[]{2030, LocalDate.of(2030, Month.FEBRUARY,  5)});
+        // 2031–2055: Umm al-Qura tabular Islamic calendar (1 Shawwal AH, SGT +1-day offset)
+        data.add(new Object[]{2031, LocalDate.of(2031, Month.JANUARY,  25)});
+        data.add(new Object[]{2032, LocalDate.of(2032, Month.JANUARY,  15)});
+        data.add(new Object[]{2033, LocalDate.of(2033, Month.JANUARY,   4)});
+        data.add(new Object[]{2034, LocalDate.of(2034, Month.DECEMBER, 13)});
+        data.add(new Object[]{2035, LocalDate.of(2035, Month.DECEMBER,  2)});
+        data.add(new Object[]{2036, LocalDate.of(2036, Month.NOVEMBER, 20)});
+        data.add(new Object[]{2037, LocalDate.of(2037, Month.NOVEMBER, 10)});
+        data.add(new Object[]{2038, LocalDate.of(2038, Month.OCTOBER,  30)});
+        data.add(new Object[]{2039, LocalDate.of(2039, Month.OCTOBER,  20)});
+        data.add(new Object[]{2040, LocalDate.of(2040, Month.OCTOBER,   9)});
+        data.add(new Object[]{2041, LocalDate.of(2041, Month.SEPTEMBER,28)});
+        data.add(new Object[]{2042, LocalDate.of(2042, Month.SEPTEMBER,17)});
+        data.add(new Object[]{2043, LocalDate.of(2043, Month.SEPTEMBER, 6)});
+        data.add(new Object[]{2044, LocalDate.of(2044, Month.AUGUST,   25)});
+        data.add(new Object[]{2045, LocalDate.of(2045, Month.AUGUST,   15)});
+        data.add(new Object[]{2046, LocalDate.of(2046, Month.AUGUST,    5)});
+        data.add(new Object[]{2047, LocalDate.of(2047, Month.JULY,     25)});
+        data.add(new Object[]{2048, LocalDate.of(2048, Month.JULY,     14)});
+        data.add(new Object[]{2049, LocalDate.of(2049, Month.JULY,      3)});
+        data.add(new Object[]{2050, LocalDate.of(2050, Month.JUNE,     22)});
+        data.add(new Object[]{2051, LocalDate.of(2051, Month.JUNE,     11)});
+        data.add(new Object[]{2052, LocalDate.of(2052, Month.MAY,      31)});
+        data.add(new Object[]{2053, LocalDate.of(2053, Month.MAY,      20)});
+        data.add(new Object[]{2054, LocalDate.of(2054, Month.MAY,      10)});
+        data.add(new Object[]{2055, LocalDate.of(2055, Month.APRIL,    29)});
+        return data.iterator();
+    }
+
+    @DataProvider
+    Iterator<Object[]> outOfRangeYears() {
+        return List.of(
+            new Object[]{2018},
+            new Object[]{1900},
+            new Object[]{2056},
+            new Object[]{2099}
+        ).iterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 1: apply() returns correct non-null dates for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testApplyReturnsExpectedDate(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+            "HariRayaPuasa.apply(" + year + ") should return " + expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 2: test() (Predicate) returns true for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testPredicateReturnsTrueForCoveredYear(int year, LocalDate ignored) {
+        assertTrue(observance.test(year),
+            "HariRayaPuasa.test(" + year + ") should return true");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 3: apply() returns null for out-of-range years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "outOfRangeYears")
+    public void testApplyReturnsNullOutOfRange(int year) {
+        assertNull(observance.apply(year),
+            "HariRayaPuasa.apply(" + year + ") should return null (outside coverage)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 4: test() (Predicate) returns false for out-of-range years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "outOfRangeYears")
+    public void testPredicateReturnsFalseOutOfRange(int year) {
+        assertFalse(observance.test(year),
+            "HariRayaPuasa.test(" + year + ") should return false (outside coverage)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 5: null-safety from AbstractObservance contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+            "HariRayaPuasa.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+            "HariRayaPuasa.test(null) must return false per AbstractObservance contract");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 6: Boundary and seam spot checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testOriginalCeilingYear2030() {
+        assertEquals(observance.apply(2030), LocalDate.of(2030, Month.FEBRUARY, 5),
+            "2030 is the original table ceiling; must remain intact after extension");
+    }
+
+    @Test
+    public void testFirstNewYear2031() {
+        assertEquals(observance.apply(2031), LocalDate.of(2031, Month.JANUARY, 25),
+            "2031 is the first newly-added year");
+    }
+
+    @Test
+    public void testMidpointYear2042() {
+        assertEquals(observance.apply(2042), LocalDate.of(2042, Month.SEPTEMBER, 17),
+            "2042 is near the midpoint of the extended range");
+    }
+
+    @Test
+    public void testNewCeilingYear2055() {
+        assertEquals(observance.apply(2055), LocalDate.of(2055, Month.APRIL, 29),
+            "2055 is the new upper bound; must be present and correct");
+    }
+
+    @Test
+    public void testYearJustBeforeLowerBound() {
+        assertNull(observance.apply(2018),
+            "2018 is just before the lower bound; must return null");
+    }
+
+    @Test
+    public void testYearJustAfterUpperBound() {
+        assertNull(observance.apply(2056),
+            "2056 is just after the new upper bound; must return null");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 7: Domain constraint — LocalDate year must match the map key
+    // Catches copy-paste errors where the key year and the LocalDate year diverge
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testDateYearMatchesKey(int year, LocalDate expected) {
+        assertEquals(expected.getYear(), year,
+            "DATES entry keyed " + year + " has LocalDate year " + expected.getYear() +
+            " — likely copy-paste error in LocalDate.of(...)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 8: Structural guard — table covers exactly 37 years (2019–2055)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTableCoversExactly37Years() {
+        long coveredCount = 0;
+        for (int y = 2019; y <= 2055; y++) {
+            if (observance.test(y)) coveredCount++;
+        }
+        assertEquals(coveredCount, 37L,
+            "DATES map must have exactly 37 entries covering 2019–2055 inclusive");
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional: Hari Raya Puasa must not coincide with Vesak Day (data guard)
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testHariRayaPuasaDoesNotCollideWithVesakDay(int year, LocalDate hrpDate) {
+        VesakDay vesak = new VesakDay();
+        LocalDate vesakDate = vesak.apply(year);
+        if (vesakDate != null) {
+            assertNotEquals(hrpDate, vesakDate,
+                "Hari Raya Puasa " + year + " (" + hrpDate + ") must not coincide with " +
+                "Vesak Day (" + vesakDate + ") — possible data entry error");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Additional: Named regression guards for original 12 entries (2019–2030)
+    // Provide unambiguous failure messages if a refactor shifts an existing entry
+    // -------------------------------------------------------------------------
+
+    @Test public void testEntry2019() { assertEquals(observance.apply(2019), LocalDate.of(2019, Month.JUNE,      5), "2019 entry must be unchanged"); }
+    @Test public void testEntry2020() { assertEquals(observance.apply(2020), LocalDate.of(2020, Month.MAY,      24), "2020 entry must be unchanged"); }
+    @Test public void testEntry2021() { assertEquals(observance.apply(2021), LocalDate.of(2021, Month.MAY,      13), "2021 entry must be unchanged"); }
+    @Test public void testEntry2022() { assertEquals(observance.apply(2022), LocalDate.of(2022, Month.MAY,       3), "2022 entry must be unchanged"); }
+    @Test public void testEntry2023() { assertEquals(observance.apply(2023), LocalDate.of(2023, Month.APRIL,    21), "2023 entry must be unchanged"); }
+    @Test public void testEntry2024() { assertEquals(observance.apply(2024), LocalDate.of(2024, Month.APRIL,    10), "2024 entry must be unchanged"); }
+    @Test public void testEntry2025() { assertEquals(observance.apply(2025), LocalDate.of(2025, Month.MARCH,    31), "2025 entry must be unchanged"); }
+    @Test public void testEntry2026() { assertEquals(observance.apply(2026), LocalDate.of(2026, Month.MARCH,    20), "2026 entry must be unchanged"); }
+    @Test public void testEntry2027() { assertEquals(observance.apply(2027), LocalDate.of(2027, Month.MARCH,    10), "2027 entry must be unchanged"); }
+    @Test public void testEntry2028() { assertEquals(observance.apply(2028), LocalDate.of(2028, Month.FEBRUARY, 27), "2028 entry must be unchanged"); }
+    @Test public void testEntry2029() { assertEquals(observance.apply(2029), LocalDate.of(2029, Month.FEBRUARY, 16), "2029 entry must be unchanged"); }
+    @Test public void testEntry2030() { assertEquals(observance.apply(2030), LocalDate.of(2030, Month.FEBRUARY,  5), "2030 entry must be unchanged"); }
+
+}


### PR DESCRIPTION
### Extended Hari Raya Puasa (SG) lookup table through 2055

**Description**

- Added 25 projected entries (2031–2055) to `HariRayaPuasa.java`, bringing the table to 37 total entries (2019–2055)
- Reformatted all existing 2019–2030 entries with right-aligned month/day padding for visual consistency with `VesakDay`
- Updated Javadoc to document both data sources: MOM/MUIS official gazette (2019–2030) and Umm al-Qura tabular calendar with Singapore's Imkan ar-Rukyah +1-day offset (2031–2055)
- Updated Javadoc to document the 2033 double-Eid design decision (two Eid al-Fitr occurrences in Gregorian 2033; only January 4 is modelled due to the single-date-per-year-key constraint)
- Created `HariRayaPuasaTest.java` with 8 test groups: all 37 year/date pairs, predicate interface, out-of-range nulls, null safety, 6 boundary spot checks, year-key/LocalDate-year consistency guard, structural count guard, anti-collision with VesakDay, and 12 named regression guards for the original 2019–2030 entries
- Added `testHariRayaPuasa2055PresentAndCorrect` and `testHariRayaPuasa2056AbsentSilently` integration tests to `HolidayCalendarServiceSGTest`
- Updated stale assertion message in `testDataValidThroughReturnedYear` to accurately reflect which tables bound the `dataValidThrough()` value at 2030
- `DATA_VALID_THROUGH_YEAR` intentionally remains at 2030 — `dataValidThrough()` is the minimum ceiling across all four lookup-table observances; HariRayaHaji and Deepavali still end at 2030 and will be addressed in follow-on issues

**Related Issue**

- [#112 Extend Hari Raya Puasa (SG) lookup table through 2055](https://github.com/holiday-calendar/holiday-calendar-java/issues/112)

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed