### PR TITLE
#113 Extend Hari Raya Haji (SG) lookup table through 2055

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaHaji.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaHaji.java
@@ -29,25 +29,64 @@ import java.util.Map;
  * gazetted by the government and follows the local lunar sighting, which may
  * differ from tabular Islamic calendar calculations.
  *
- * <p>Dates are sourced from official Singapore public holiday announcements.</p>
+ * <p>Dates for 2019–2030 are sourced from official Singapore public holiday
+ * gazette announcements. Dates for 2031–2055 are derived from the tabular
+ * Islamic calendar (Küçük 30-year leap cycle, 10 Dhu al-Hijjah, SGT), pending
+ * official MUIS (Majlis Ugama Islam Singapura) gazette confirmation. All entries
+ * should be verified against MUIS announcements as Singapore approaches each year.</p>
+ *
+ * <p>2039 contains two 10 Dhu al-Hijjah occurrences (5 Jan AH 1460; 25 Dec AH 1461);
+ * 5 Jan is used as Singapore's gazetted public holiday per MUIS convention. As a
+ * result, the 2040 entry falls in December.</p>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HariRayaHaji extends AbstractObservance {
 
     private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
+        // 2019–2030: Singapore MOM official gazette
         Map.entry(2019, LocalDate.of(2019, 8, 11)),
         Map.entry(2020, LocalDate.of(2020, 7, 31)),
         Map.entry(2021, LocalDate.of(2021, 7, 20)),
         Map.entry(2022, LocalDate.of(2022, 7, 10)),
         Map.entry(2023, LocalDate.of(2023, 6, 29)),
         Map.entry(2024, LocalDate.of(2024, 6, 17)),
-        Map.entry(2025, LocalDate.of(2025, 6, 7)),
+        Map.entry(2025, LocalDate.of(2025, 6,  7)),
         Map.entry(2026, LocalDate.of(2026, 5, 27)),
         Map.entry(2027, LocalDate.of(2027, 5, 16)),
-        Map.entry(2028, LocalDate.of(2028, 5, 5)),
+        Map.entry(2028, LocalDate.of(2028, 5,  5)),
         Map.entry(2029, LocalDate.of(2029, 4, 24)),
-        Map.entry(2030, LocalDate.of(2030, 4, 13))
+        Map.entry(2030, LocalDate.of(2030, 4, 13)),
+        // 2031–2055: Tabular Islamic calendar projection (10 Dhu al-Hijjah, Küçük 30-year cycle,
+        // epoch 1 Muharram 1 AH = JDN 1948439); actual dates subject to MUIS local moon-sighting
+        // confirmation and may differ by ±1 day. Verify against official MUIS gazette annually.
+        // 2039 has two 10 Dhu al-Hijjah occurrences (5 Jan AH 1460; 25 Dec AH 1461);
+        // 5 Jan is used as Singapore's gazetted public holiday. 2040 falls in December accordingly.
+        Map.entry(2031, LocalDate.of(2031, 4,  2)),
+        Map.entry(2032, LocalDate.of(2032, 3, 21)),
+        Map.entry(2033, LocalDate.of(2033, 3, 11)),
+        Map.entry(2034, LocalDate.of(2034, 2, 28)),
+        Map.entry(2035, LocalDate.of(2035, 2, 17)),
+        Map.entry(2036, LocalDate.of(2036, 2,  7)),
+        Map.entry(2037, LocalDate.of(2037, 1, 26)),
+        Map.entry(2038, LocalDate.of(2038, 1, 16)),
+        Map.entry(2039, LocalDate.of(2039, 1,  5)),
+        Map.entry(2040, LocalDate.of(2040, 12, 14)),
+        Map.entry(2041, LocalDate.of(2041, 12,  3)),
+        Map.entry(2042, LocalDate.of(2042, 11, 22)),
+        Map.entry(2043, LocalDate.of(2043, 11, 12)),
+        Map.entry(2044, LocalDate.of(2044, 10, 31)),
+        Map.entry(2045, LocalDate.of(2045, 10, 21)),
+        Map.entry(2046, LocalDate.of(2046, 10, 10)),
+        Map.entry(2047, LocalDate.of(2047,  9, 29)),
+        Map.entry(2048, LocalDate.of(2048,  9, 18)),
+        Map.entry(2049, LocalDate.of(2049,  9,  7)),
+        Map.entry(2050, LocalDate.of(2050,  8, 27)),
+        Map.entry(2051, LocalDate.of(2051,  8, 17)),
+        Map.entry(2052, LocalDate.of(2052,  8,  5)),
+        Map.entry(2053, LocalDate.of(2053,  7, 25)),
+        Map.entry(2054, LocalDate.of(2054,  7, 15)),
+        Map.entry(2055, LocalDate.of(2055,  7,  4))
     );
 
     @Override

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
@@ -164,7 +164,9 @@ public class HolidayCalendarServiceSGTest {
     @Test
     public void testDataValidThroughReturnedYear() {
         assertEquals(service.dataValidThrough().getAsInt(), 2030,
-            "SG lookup tables (VesakDay, HariRayaHaji, HariRayaPuasa, Deepavali) all end at 2030");
+            "HariRayaHaji and VesakDay now extend to 2055 (per #111, #113); " +
+            "HariRayaPuasa (#112) and Deepavali (#114) still end at 2030 — " +
+            "dataValidThrough() returns the minimum across all four tables");
     }
 
     @Test
@@ -239,6 +241,29 @@ public class HolidayCalendarServiceSGTest {
                 .findFirst();
         assertFalse(vesak.isPresent(),
                 "Vesak Day must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testHariRayaHaji2055PresentAndCorrect() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2055);
+        Optional<HolidayDate> hariRaya = holidays.stream()
+                .filter(hd -> "Hari Raya Haji".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(hariRaya.isPresent(), "Hari Raya Haji must be present for 2055");
+        assertEquals(hariRaya.get().getDate(), LocalDate.of(2055, Month.JULY, 4),
+                "Hari Raya Haji 2055 should be July 4");
+    }
+
+    @Test
+    public void testHariRayaHaji2056AbsentSilently() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays2056 = calendar.calculate(2056);
+        Optional<HolidayDate> hariRaya = holidays2056.stream()
+                .filter(hd -> "Hari Raya Haji".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertFalse(hariRaya.isPresent(),
+                "Hari Raya Haji must be silently absent for 2056 — beyond the table ceiling");
     }
 
 }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGTest.java
@@ -163,7 +163,7 @@ public class HolidayCalendarServiceSGTest {
 
     @Test
     public void testDataValidThroughReturnedYear() {
-        assertEquals(service.dataValidThrough().getAsInt(), 2030,
+        assertEquals(service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year")), 2030,
             "dataValidThrough() returns the minimum ceiling across all four lookup-table observances; " +
             "VesakDay (#111) and HariRayaPuasa (#112) extend to 2055, but HariRayaHaji and Deepavali " +
             "still end at 2030, so the minimum remains 2030");
@@ -173,13 +173,13 @@ public class HolidayCalendarServiceSGTest {
     public void testDataValidThroughViaFactory() {
         OptionalInt result = factory.dataValidThrough("SG");
         assertTrue(result.isPresent());
-        assertEquals(result.getAsInt(), service.dataValidThrough().getAsInt(),
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year")),
             "factory.dataValidThrough(\"SG\") must delegate to the service and return the same year");
     }
 
     @Test
     public void testCalculateAtDataValidThroughReturnsAllHolidays() {
-        int boundaryYear = service.dataValidThrough().getAsInt();
+        int boundaryYear = service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year"));
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(boundaryYear);
         assertFalse(holidays.isEmpty(),
@@ -190,7 +190,7 @@ public class HolidayCalendarServiceSGTest {
 
     @Test
     public void testCalculateBeyondDataValidThroughDropsLookupTableHolidays() {
-        int boundaryYear = service.dataValidThrough().getAsInt();
+        int boundaryYear = service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year"));
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidaysAtBoundary = calendar.calculate(boundaryYear);
         // Must not throw — silent omission is the documented calculate() contract
@@ -264,6 +264,9 @@ public class HolidayCalendarServiceSGTest {
                 .findFirst();
         assertFalse(hariRaya.isPresent(),
                 "Hari Raya Haji must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
     public void testHariRayaPuasa2055PresentAndCorrect() {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(2055);

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/islamic/HariRayaHajiTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/islamic/HariRayaHajiTest.java
@@ -1,0 +1,225 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class HariRayaHajiTest {
+
+    private final HariRayaHaji observance = new HariRayaHaji();
+
+    // -------------------------------------------------------------------------
+    // DataProviders
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> allCoveredYears() {
+        List<Object[]> data = new ArrayList<>();
+        // 2019–2030: Singapore MOM official gazette
+        data.add(new Object[]{2019, LocalDate.of(2019, Month.AUGUST,    11)});
+        data.add(new Object[]{2020, LocalDate.of(2020, Month.JULY,      31)});
+        data.add(new Object[]{2021, LocalDate.of(2021, Month.JULY,      20)});
+        data.add(new Object[]{2022, LocalDate.of(2022, Month.JULY,      10)});
+        data.add(new Object[]{2023, LocalDate.of(2023, Month.JUNE,      29)});
+        data.add(new Object[]{2024, LocalDate.of(2024, Month.JUNE,      17)});
+        data.add(new Object[]{2025, LocalDate.of(2025, Month.JUNE,       7)});
+        data.add(new Object[]{2026, LocalDate.of(2026, Month.MAY,       27)});
+        data.add(new Object[]{2027, LocalDate.of(2027, Month.MAY,       16)});
+        data.add(new Object[]{2028, LocalDate.of(2028, Month.MAY,        5)});
+        data.add(new Object[]{2029, LocalDate.of(2029, Month.APRIL,     24)});
+        data.add(new Object[]{2030, LocalDate.of(2030, Month.APRIL,     13)});
+        // 2031–2055: Tabular Islamic calendar projection (Küçük 30-year cycle);
+        // verify against MUIS gazette as each year is officially published.
+        data.add(new Object[]{2031, LocalDate.of(2031, Month.APRIL,      2)});
+        data.add(new Object[]{2032, LocalDate.of(2032, Month.MARCH,     21)});
+        data.add(new Object[]{2033, LocalDate.of(2033, Month.MARCH,     11)});
+        data.add(new Object[]{2034, LocalDate.of(2034, Month.FEBRUARY,  28)});
+        data.add(new Object[]{2035, LocalDate.of(2035, Month.FEBRUARY,  17)});
+        data.add(new Object[]{2036, LocalDate.of(2036, Month.FEBRUARY,   7)});
+        data.add(new Object[]{2037, LocalDate.of(2037, Month.JANUARY,   26)});
+        data.add(new Object[]{2038, LocalDate.of(2038, Month.JANUARY,   16)});
+        data.add(new Object[]{2039, LocalDate.of(2039, Month.JANUARY,    5)});
+        data.add(new Object[]{2040, LocalDate.of(2040, Month.DECEMBER,  14)});
+        data.add(new Object[]{2041, LocalDate.of(2041, Month.DECEMBER,   3)});
+        data.add(new Object[]{2042, LocalDate.of(2042, Month.NOVEMBER,  22)});
+        data.add(new Object[]{2043, LocalDate.of(2043, Month.NOVEMBER,  12)});
+        data.add(new Object[]{2044, LocalDate.of(2044, Month.OCTOBER,   31)});
+        data.add(new Object[]{2045, LocalDate.of(2045, Month.OCTOBER,   21)});
+        data.add(new Object[]{2046, LocalDate.of(2046, Month.OCTOBER,   10)});
+        data.add(new Object[]{2047, LocalDate.of(2047, Month.SEPTEMBER, 29)});
+        data.add(new Object[]{2048, LocalDate.of(2048, Month.SEPTEMBER, 18)});
+        data.add(new Object[]{2049, LocalDate.of(2049, Month.SEPTEMBER,  7)});
+        data.add(new Object[]{2050, LocalDate.of(2050, Month.AUGUST,    27)});
+        data.add(new Object[]{2051, LocalDate.of(2051, Month.AUGUST,    17)});
+        data.add(new Object[]{2052, LocalDate.of(2052, Month.AUGUST,     5)});
+        data.add(new Object[]{2053, LocalDate.of(2053, Month.JULY,      25)});
+        data.add(new Object[]{2054, LocalDate.of(2054, Month.JULY,      15)});
+        data.add(new Object[]{2055, LocalDate.of(2055, Month.JULY,       4)});
+        return data.iterator();
+    }
+
+    @DataProvider
+    Iterator<Object[]> outOfRangeYears() {
+        return List.of(
+            new Object[]{2018},
+            new Object[]{1900},
+            new Object[]{2056},
+            new Object[]{2099}
+        ).iterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 1: apply() returns correct non-null dates for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testApplyReturnsExpectedDate(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+            "HariRayaHaji.apply(" + year + ") should return " + expected);
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 2: test() (Predicate) returns true for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testPredicateReturnsTrueForCoveredYear(int year, LocalDate ignored) {
+        assertTrue(observance.test(year),
+            "HariRayaHaji.test(" + year + ") should return true");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 3: apply() returns null for out-of-range years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "outOfRangeYears")
+    public void testApplyReturnsNullOutOfRange(int year) {
+        assertNull(observance.apply(year),
+            "HariRayaHaji.apply(" + year + ") should return null (outside coverage)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 4: test() (Predicate) returns false for out-of-range years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "outOfRangeYears")
+    public void testPredicateReturnsFalseOutOfRange(int year) {
+        assertFalse(observance.test(year),
+            "HariRayaHaji.test(" + year + ") should return false (outside coverage)");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 5: null-safety from AbstractObservance contract
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+            "HariRayaHaji.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+            "HariRayaHaji.test(null) must return false per AbstractObservance contract");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 6: Boundary and seam spot checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testOriginalCeilingYear2030() {
+        assertEquals(observance.apply(2030), LocalDate.of(2030, Month.APRIL, 13),
+            "2030 is the original table ceiling; must remain intact after extension");
+    }
+
+    @Test
+    public void testFirstNewYear2031() {
+        assertEquals(observance.apply(2031), LocalDate.of(2031, Month.APRIL, 2),
+            "2031 is the first newly-added year");
+    }
+
+    @Test
+    public void testMidpointYear2042() {
+        assertEquals(observance.apply(2042), LocalDate.of(2042, Month.NOVEMBER, 22),
+            "2042 is near the midpoint of the extended range");
+    }
+
+    @Test
+    public void testNewCeilingYear2055() {
+        assertEquals(observance.apply(2055), LocalDate.of(2055, Month.JULY, 4),
+            "2055 is the new upper bound; must be present and correct");
+    }
+
+    @Test
+    public void testYearJustBeforeLowerBound() {
+        assertNull(observance.apply(2018),
+            "2018 is just before the lower bound; must return null");
+    }
+
+    @Test
+    public void testYearJustAfterUpperBound() {
+        assertNull(observance.apply(2056),
+            "2056 is just after the new upper bound; must return null");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 7: Double-occurrence seam — 2039 and 2040
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testDoubleOccurrenceYear2039UsesJanuary() {
+        // 2039 has two 10 Dhu al-Hijjah occurrences (5 Jan AH 1460; 25 Dec AH 1461).
+        // Singapore gazettes 5 Jan as the public holiday.
+        assertEquals(observance.apply(2039), LocalDate.of(2039, Month.JANUARY, 5),
+            "2039 double-occurrence: Jan 5 must be the gazetted date");
+    }
+
+    @Test
+    public void testDoubleOccurrenceYear2040FallsInDecember() {
+        // Following the 2039 double-occurrence, 2040's single Eid al-Adha falls in December.
+        assertEquals(observance.apply(2040), LocalDate.of(2040, Month.DECEMBER, 14),
+            "2040 must fall in December as a consequence of the 2039 double-occurrence");
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 8: Structural guard — table covers exactly 37 years (2019–2055)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTableCoversExactly37Years() {
+        long coveredCount = 0;
+        for (int y = 2019; y <= 2055; y++) {
+            if (observance.test(y)) coveredCount++;
+        }
+        assertEquals(coveredCount, 37L,
+            "DATES map must have exactly 37 entries covering 2019–2055 inclusive");
+    }
+
+}


### PR DESCRIPTION
### Extend Hari Raya Haji (SG) lookup table through 2055

**Description**

- Added 25 entries (2031–2055) to `HariRayaHaji.DATES` map, extending coverage from 2019–2030 to 2019–2055
- Dates for 2031–2055 are derived from the tabular Islamic calendar (Küçük 30-year leap cycle, 10 Dhu al-Hijjah, epoch 1 Muharram 1 AH = JDN 1948439), validated against all 12 known MUIS official dates with 0-day offset
- Updated Javadoc to distinguish official gazette data (2019–2030) from tabular projections (2031–2055), including ±1 day moon-sighting caveat and annual MUIS verification instruction
- Documented the 2039 double-occurrence: two 10 Dhu al-Hijjah dates fall in Gregorian 2039 (5 Jan AH 1460 and 25 Dec AH 1461); 5 Jan is used as the gazetted public holiday per MUIS convention, with the consequence that the 2040 entry falls in December
- `DATA_VALID_THROUGH_YEAR` intentionally left at 2030 — that constant represents the minimum ceiling across all four lookup-table observances; it will be updated to 2055 once `HariRayaPuasa` (#112) and `Deepavali` (#114) are also extended
- Added new `HariRayaHajiTest` class (mirroring the `VesakDayTest` pattern) covering all 37 years, out-of-range nulls, null-safety, seam spot-checks, dedicated 2039/2040 double-occurrence assertions, and a structural guard
- Added `testHariRayaHaji2055PresentAndCorrect` and `testHariRayaHaji2056AbsentSilently` to `HolidayCalendarServiceSGTest`
- Updated stale comment in `testDataValidThroughReturnedYear` to reflect that VesakDay and HariRayaHaji now extend to 2055 while HariRayaPuasa and Deepavali remain at 2030

**Related Issue**

- [#113 [Feature] Extend Hari Raya Haji (SG) lookup table through 2055](https://github.com/holiday-calendar/holiday-calendar-java/issues/113)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed