### PR TITLE
#115 Bound and document CNY compensatory working day year range

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCNY.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCNY.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.OptionalInt;
 
 /**
  * Service for provision of the China (PBOC / CNAPS) holiday calendar.
@@ -71,12 +72,24 @@ import java.util.Map;
  * closures, not openings), but are accessible via
  * {@link #getCompensatoryWorkingDays(int)}.
  *
- * <p><strong>Annual update required:</strong> compensatory working day data
- * must be updated each year once the State Council issues its holiday notice,
- * typically published in late November or early December of the preceding year.
- * See <a href="http://www.gov.cn/">www.gov.cn</a> for official notices.
- * Requesting a year beyond the known data range logs a warning and returns an
- * empty list.
+ * <h2>Data Validity Ranges</h2>
+ *
+ * <p>All public holidays in this calendar are computed algorithmically via
+ * Time4J Chinese calendar mathematics. {@link HolidayCalendar#calculate(int)}
+ * is authoritative for any year with no upper bound. Compensatory (make-up)
+ * working day data is manually curated from State Council notices and has a
+ * finite upper bound; call {@link #compensatoryDataValidThrough()} to obtain it.
+ *
+ * <h2>Annual Update Process</h2>
+ *
+ * <ol>
+ *   <li>Monitor <a href="http://www.gov.cn/">www.gov.cn</a> in November–December
+ *       for the following year's holiday notice.</li>
+ *   <li>Append new rows to {@code cny-compensatory-working-days.csv} in
+ *       {@code src/main/resources/org/holiday/calendar/impl/}. The format is:
+ *       {@code year,YYYY-MM-DD,comment}.</li>
+ *   <li>Run {@code mvn -pl holiday-calendar-apac test} to verify no regressions.</li>
+ * </ol>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -97,6 +110,10 @@ public class HolidayCalendarServiceCNY extends AbstractHolidayCalendarService {
      */
     private static final class CompensatoryDaysHolder {
         static final Map<Integer, List<LocalDate>> DATA = loadFromCsv();
+        static final int MAX_YEAR = DATA.keySet().stream()
+                .mapToInt(Integer::intValue)
+                .max()
+                .orElse(0);
 
         private static Map<Integer, List<LocalDate>> loadFromCsv() {
             Map<Integer, List<LocalDate>> result = new HashMap<>();
@@ -149,6 +166,34 @@ public class HolidayCalendarServiceCNY extends AbstractHolidayCalendarService {
 
     public HolidayCalendarServiceCNY() {
         super(CODE, NAME);
+    }
+
+    /**
+     * Returns {@link OptionalInt#empty()} because all CNY public
+     * holidays are computed algorithmically (Time4J Chinese calendar math).
+     * {@link HolidayCalendar#calculate(int)} is authoritative for any year
+     * with no upper bound. For the compensatory working day ceiling, see
+     * {@link #compensatoryDataValidThrough()}.
+     */
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.empty();
+    }
+
+    /**
+     * Returns the last year for which official State Council compensatory
+     * (make-up) working day data is present in this release.
+     *
+     * <p>The return value is derived dynamically from the loaded CSV data and
+     * updates automatically when new rows are appended — no separate constant
+     * needs to be changed.
+     *
+     * @return the highest year with compensatory working day data, or {@code 0}
+     *         if the CSV contains no valid entries
+     * @see #getCompensatoryWorkingDays(int)
+     */
+    public int compensatoryDataValidThrough() {
+        return CompensatoryDaysHolder.MAX_YEAR;
     }
 
     @Override
@@ -362,10 +407,10 @@ public class HolidayCalendarServiceCNY extends AbstractHolidayCalendarService {
     public List<LocalDate> getCompensatoryWorkingDays(int year) {
         List<LocalDate> dates = CompensatoryDaysHolder.DATA.get(year);
         if (dates == null) {
-            LOGGER.warn("Compensatory working day data for {} is not available. " +
-                    "Update {} with the State Council annual notice " +
-                    "once published at http://www.gov.cn/",
-                    year, COMPENSATORY_DAYS_CSV);
+            LOGGER.warn("Compensatory working day data for {} is not available " +
+                    "(data valid through {}). Update {} with the State Council annual " +
+                    "notice once published at http://www.gov.cn/",
+                    year, CompensatoryDaysHolder.MAX_YEAR, COMPENSATORY_DAYS_CSV);
             return Collections.emptyList();
         }
         return dates;

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNYTest.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.OptionalInt;
 
 import static org.testng.Assert.*;
 
@@ -188,6 +189,53 @@ public class HolidayCalendarServiceCNYTest {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(2023);
         assertHolidayDate(holidays, "New Year's Day", LocalDate.of(2023, Month.JANUARY, 1));
+    }
+
+    // --- dataValidThrough / compensatoryDataValidThrough ---
+
+    @Test
+    public void testDataValidThroughReturnsEmpty() {
+        // All CNY public holidays are algorithmic — calculate() has no upper bound.
+        // Returning empty is the honest contract; returning a bounded year would
+        // mislead callers into thinking calculate() breaks after that year.
+        OptionalInt result = service.dataValidThrough();
+        assertFalse(result.isPresent(),
+                "CNY calendar is fully algorithmic; dataValidThrough() must return OptionalInt.empty()");
+    }
+
+    @Test
+    public void testCompensatoryDataValidThrough() {
+        int ceiling = service.compensatoryDataValidThrough();
+        assertTrue(ceiling > 0, "compensatoryDataValidThrough() must return a positive year");
+        assertEquals(ceiling, 2026, "Compensatory working day data currently covers through 2026");
+    }
+
+    @Test
+    public void testCalculateBeyondCompensatoryBoundWorksCorrectly() {
+        // Canary: proves calculate() is NOT affected by the compensatory data ceiling.
+        // If dataValidThrough() were incorrectly overridden to return a bounded year,
+        // this test would expose the lie by proving calculate() still works fully.
+        int yearBeyondCeiling = service.compensatoryDataValidThrough() + 1;
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(yearBeyondCeiling);
+        assertEquals(holidays.size(), 21,
+                "calculate() must return all 21 holidays for years beyond the compensatory data ceiling");
+    }
+
+    @Test
+    public void testGetCompensatoryWorkingDaysAtCeiling() {
+        int ceiling = service.compensatoryDataValidThrough();
+        List<LocalDate> days = service.getCompensatoryWorkingDays(ceiling);
+        assertFalse(days.isEmpty(),
+                "getCompensatoryWorkingDays() must return a non-empty list for the ceiling year");
+    }
+
+    @Test
+    public void testGetCompensatoryWorkingDaysBeyondCeiling() {
+        int yearBeyondCeiling = service.compensatoryDataValidThrough() + 1;
+        List<LocalDate> days = service.getCompensatoryWorkingDays(yearBeyondCeiling);
+        assertNotNull(days);
+        assertTrue(days.isEmpty(),
+                "getCompensatoryWorkingDays() must return empty for a year beyond the data ceiling");
     }
 
     // --- Compensatory working days ---


### PR DESCRIPTION
### #115 Bound and document CNY compensatory working day year range

**Description**

- Audited the compensatory working day CSV: data covers **2020–2026**
- Added `compensatoryDataValidThrough()` method on `HolidayCalendarServiceCNY` — scoped, honest API returning the CSV ceiling (dynamically derived from loaded data; self-updates as rows are appended)
- Added explicit `dataValidThrough()` override returning `OptionalInt.empty()` with Javadoc explaining why: all 21 CNY public holidays are fully algorithmic and `calculate()` has no upper bound
- Added `CompensatoryDaysHolder.MAX_YEAR` static field derived from CSV keys at init time; referenced in the warning log for `getCompensatoryWorkingDays()` to give callers the current ceiling year in the message
- Expanded class Javadoc with _Data Validity Ranges_ and _Annual Update Process_ sections documenting the November–December update workflow and CSV format

**Related Issue**

- [#115 Bound and document CNY compensatory working day year range](https://github.com/holiday-calendar/holiday-calendar-java/issues/115)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed