### PR TITLE
#125 Fix JP/JPY Saturday national holidays incorrectly rolled to Monday

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJP.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJP.java
@@ -45,7 +45,7 @@ public class HolidayCalendarServiceJP extends AbstractHolidayCalendarService {
         HolidayCalendar base = HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
-                .dateRoll(DateRolls.followingMonday())
+                .dateRoll(DateRolls.sundayToMonday())
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holidays(JapaneseHolidays.baseHolidays())
                 .build();

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJPY.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJPY.java
@@ -69,7 +69,7 @@ public class HolidayCalendarServiceJPY extends AbstractHolidayCalendarService {
         HolidayCalendar base = HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
-                .dateRoll(DateRolls.followingMonday())
+                .dateRoll(DateRolls.sundayToMonday())
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holidays(JapaneseHolidays.baseHolidays())
                 .holiday(yearStartJan2)

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
@@ -22,6 +22,7 @@ import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.HolidayCalendarFactory;
 import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
@@ -210,6 +211,158 @@ public class HolidayCalendarServiceJPTest {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(1995);
         assertFalse(findByName(holidays, "Marine Day").isPresent(),
                     "Marine Day should not appear before 1996");
+    }
+
+    // ── Saturday holidays must NOT roll (issue #125) ─────────────────────────
+
+    @Test
+    public void testNewYearsDaySaturday2028_NoRoll() {
+        // Jan 1 2028 is Saturday — no substitute under Japanese law
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        Optional<HolidayDate> h = findByName(holidays, "New Year's Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2028, Month.JANUARY, 1));
+    }
+
+    @Test
+    public void testShowaDaySaturday2028_NoRoll() {
+        // Apr 29 2028 is Saturday
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        Optional<HolidayDate> h = findByName(holidays, "Showa Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2028, Month.APRIL, 29));
+    }
+
+    @Test
+    public void testChildrensDaySaturday2029_NoRoll() {
+        // May 5 2029 is Saturday
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2029);
+        Optional<HolidayDate> h = findByName(holidays, "Children's Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2029, Month.MAY, 5));
+    }
+
+    @Test
+    public void testEmperorsBirthdaySaturday2030_NoRoll() {
+        // Feb 23 2030 is Saturday
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2030);
+        Optional<HolidayDate> h = findByName(holidays, "Emperor's Birthday");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2030, Month.FEBRUARY, 23));
+    }
+
+    @Test
+    public void testConstitutionMemorialDaySaturday2031_NoRoll() {
+        // May 3 2031 is Saturday
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2031);
+        Optional<HolidayDate> h = findByName(holidays, "Constitution Memorial Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2031, Month.MAY, 3));
+    }
+
+    @Test
+    public void testNewYearsDaySaturday2033_NoRoll() {
+        // Jan 1 2033 is Saturday
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2033);
+        Optional<HolidayDate> h = findByName(holidays, "New Year's Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2033, Month.JANUARY, 1));
+    }
+
+    @Test
+    public void testAutumnalEquinox2034_Saturday_NoRoll() {
+        // Sep 23 2034 is Saturday — equinox dates computed via astronomical formula
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2034);
+        Optional<HolidayDate> h = findByName(holidays, "Autumnal Equinox Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2034, Month.SEPTEMBER, 23));
+    }
+
+    @DataProvider(name = "jpSaturdayHolidays")
+    public Object[][] jpSaturdayHolidays() {
+        return new Object[][] {
+            { 2028, "New Year's Day",             LocalDate.of(2028, 1,  1)  },
+            { 2028, "Showa Day",                  LocalDate.of(2028, 4,  29) },
+            { 2029, "Children's Day",             LocalDate.of(2029, 5,  5)  },
+            { 2030, "Emperor's Birthday",         LocalDate.of(2030, 2,  23) },
+            { 2031, "Constitution Memorial Day",  LocalDate.of(2031, 5,  3)  },
+            { 2033, "New Year's Day",             LocalDate.of(2033, 1,  1)  },
+            { 2034, "National Foundation Day",    LocalDate.of(2034, 2,  11) },
+            { 2034, "Autumnal Equinox Day",       LocalDate.of(2034, 9,  23) },
+        };
+    }
+
+    @Test(dataProvider = "jpSaturdayHolidays")
+    public void testJP_SaturdayHoliday_NoRoll(int year, String name, LocalDate expected) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        Optional<HolidayDate> h = findByName(holidays, name);
+        assertTrue(h.isPresent(), name + " should be present in " + year);
+        assertEquals(h.get().getDate(), expected,
+                name + " on Saturday should remain at natural date");
+    }
+
+    // ── Sunday holidays still roll to Monday (regression guards) ─────────────
+
+    @Test
+    public void testNationalFoundationDaySunday2029_RollsToMonday() {
+        // Feb 11 2029 is Sunday → Feb 12 (Monday)
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2029);
+        Optional<HolidayDate> h = findByName(holidays, "National Foundation Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2029, Month.FEBRUARY, 12));
+    }
+
+    @Test
+    public void testShowaDaySunday2029_RollsToMonday() {
+        // Apr 29 2029 is Sunday → Apr 30 (Monday)
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2029);
+        Optional<HolidayDate> h = findByName(holidays, "Showa Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2029, Month.APRIL, 30));
+    }
+
+    @Test
+    public void testConstitutionMemorialDaySunday2026_RollsToMonday() {
+        // May 3 2026 is Sunday → May 4 (Monday)
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        Optional<HolidayDate> h = findByName(holidays, "Constitution Memorial Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2026, Month.MAY, 4));
+    }
+
+    // ── No spurious sandwiched-day entries (issue #125 secondary effect) ──────
+
+    @Test
+    public void testNoSpuriousSandwichedDay2028() {
+        // Old code: Showa Day (Apr 29 Sat) rolled to May 1; gap to Constitution (May 3) = 2 days
+        // → phantom National Holiday on May 2 (Tuesday). After fix: Apr 29 stays; no 2-day gap.
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        boolean phantomMay2 = holidays.stream()
+                .anyMatch(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                        && hd.getDate().equals(LocalDate.of(2028, Month.MAY, 2)));
+        assertFalse(phantomMay2, "May 2, 2028 must not be a spurious National Holiday");
+    }
+
+    @Test
+    public void testNoSpuriousSandwichedDay2031() {
+        // May 3 (Sat) stays, May 4 (Sun) is the middle, May 5 (Mon) is Children's Day.
+        // Detector sees Sunday in the gap → must NOT inject a National Holiday on May 4.
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2031);
+        boolean phantomMay4 = holidays.stream()
+                .anyMatch(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                        && hd.getDate().equals(LocalDate.of(2031, Month.MAY, 4)));
+        assertFalse(phantomMay4, "May 4, 2031 must not be a spurious National Holiday (middle day is Sunday)");
+    }
+
+    @Test
+    public void testGoldenWeek2031_EntriesOnMayFifth() {
+        // May 3=Sat (Constitution stays), May 4=Sun (Greenery rolls to May 5), May 5=Mon (Children's)
+        // → two HolidayDate entries for May 5 2031
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2031);
+        long count = holidays.stream()
+                .filter(hd -> hd.getDate().equals(LocalDate.of(2031, Month.MAY, 5)))
+                .count();
+        assertEquals(count, 2L, "May 5, 2031 should have exactly 2 holiday entries (Greenery Day + Children's Day)");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
@@ -70,10 +70,7 @@ public class HolidayCalendarServiceJPTest {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(2025);
         for (int i = 1; i < holidays.size(); i++) {
-            assertTrue(
-                holidays.get(i).getDate().compareTo(holidays.get(i - 1).getDate()) >= 0,
-                "Holidays should be in chronological order"
-            );
+            assertFalse(holidays.get(i).getDate().isBefore(holidays.get(i - 1).getDate()), "Holidays should be in chronological order");
         }
     }
 

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
@@ -22,6 +22,7 @@ import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.HolidayCalendarFactory;
 import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
@@ -69,10 +70,7 @@ public class HolidayCalendarServiceJPYTest {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(2025);
         for (int i = 1; i < holidays.size(); i++) {
-            assertTrue(
-                holidays.get(i).getDate().compareTo(holidays.get(i - 1).getDate()) >= 0,
-                "Holidays should be in chronological order"
-            );
+            assertFalse(holidays.get(i).getDate().isBefore(holidays.get(i - 1).getDate()), "Holidays should be in chronological order");
         }
     }
 
@@ -134,6 +132,109 @@ public class HolidayCalendarServiceJPYTest {
                            && hd.getDate().equals(LocalDate.of(2009, Month.SEPTEMBER, 22)))
                 .findFirst();
         assertTrue(sandwiched.isPresent(), "Sep 22, 2009 should be a National Holiday in JPY calendar");
+    }
+
+    // ── Saturday holidays must NOT roll (issue #125) ─────────────────────────
+
+    @DataProvider(name = "jpySaturdayHolidays")
+    public Object[][] jpySaturdayHolidays() {
+        return new Object[][] {
+            { 2028, "New Year's Day",             LocalDate.of(2028, 1,  1)  },
+            { 2028, "Showa Day",                  LocalDate.of(2028, 4,  29) },
+            { 2029, "Children's Day",             LocalDate.of(2029, 5,  5)  },
+            { 2030, "Emperor's Birthday",         LocalDate.of(2030, 2,  23) },
+            { 2031, "Constitution Memorial Day",  LocalDate.of(2031, 5,  3)  },
+            { 2033, "New Year's Day",             LocalDate.of(2033, 1,  1)  },
+            { 2034, "National Foundation Day",    LocalDate.of(2034, 2,  11) },
+            { 2034, "Autumnal Equinox Day",       LocalDate.of(2034, 9,  23) },
+        };
+    }
+
+    @Test(dataProvider = "jpySaturdayHolidays")
+    public void testJPY_SaturdayHoliday_NoRoll(int year, String name, LocalDate expected) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        Optional<HolidayDate> h = findByName(holidays, name);
+        assertTrue(h.isPresent(), name + " should be present in JPY " + year);
+        assertEquals(h.get().getDate(), expected,
+                name + " on Saturday should remain at natural date in JPY calendar");
+    }
+
+    @Test
+    public void testNewYearsDay2028_StaysJanFirst_NoClashWithBOJClosures() {
+        // Jan 1 2028 is Saturday: New Year's Day stays Jan 1 (no roll).
+        // BOJ Year-Start closures (Jan 2, Jan 3) are rollable=false and unaffected.
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        Optional<HolidayDate> newYearsDay = findByName(holidays, "New Year's Day");
+        assertTrue(newYearsDay.isPresent());
+        assertEquals(newYearsDay.get().getDate(), LocalDate.of(2028, Month.JANUARY, 1),
+                "New Year's Day must stay on Jan 1 (Saturday) — no substitute");
+        assertTrue(findByDate(holidays, LocalDate.of(2028, Month.JANUARY, 2)).isPresent(),
+                "Jan 2 BOJ Year-Start Holiday must still be present");
+        assertTrue(findByDate(holidays, LocalDate.of(2028, Month.JANUARY, 3)).isPresent(),
+                "Jan 3 BOJ Year-Start Holiday must still be present");
+    }
+
+    // ── Sunday holidays still roll to Monday (regression guards) ─────────────
+
+    @Test
+    public void testNationalFoundationDaySunday2029_RollsToMonday_JPY() {
+        // Feb 11 2029 is Sunday → Feb 12 (Monday)
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2029);
+        Optional<HolidayDate> h = findByName(holidays, "National Foundation Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2029, Month.FEBRUARY, 12));
+    }
+
+    @Test
+    public void testConstitutionMemorialDaySunday2026_RollsToMonday_JPY() {
+        // May 3 2026 is Sunday → May 4 (Monday)
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        Optional<HolidayDate> h = findByName(holidays, "Constitution Memorial Day");
+        assertTrue(h.isPresent());
+        assertEquals(h.get().getDate(), LocalDate.of(2026, Month.MAY, 4));
+    }
+
+    // ── No spurious sandwiched-day entries (issue #125 secondary effect) ──────
+
+    @Test
+    public void testNoSpuriousSandwichedDay2028_JPY() {
+        // Old code: Showa Day (Apr 29 Sat) rolled to May 1 → phantom National Holiday on May 2.
+        // After fix: Apr 29 stays; no 2-day gap to Constitution (May 3).
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        boolean phantomMay2 = holidays.stream()
+                .anyMatch(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                        && hd.getDate().equals(LocalDate.of(2028, Month.MAY, 2)));
+        assertFalse(phantomMay2, "May 2, 2028 must not be a spurious National Holiday in JPY calendar");
+    }
+
+    @Test
+    public void testNoSpuriousSandwichedDay2031_JPY() {
+        // May 3=Sat (Constitution stays), May 4=Sun (middle), May 5=Mon (Children's).
+        // Middle day is Sunday → detector must NOT inject a National Holiday on May 4.
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2031);
+        boolean phantomMay4 = holidays.stream()
+                .anyMatch(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                        && hd.getDate().equals(LocalDate.of(2031, Month.MAY, 4)));
+        assertFalse(phantomMay4, "May 4, 2031 must not be a spurious National Holiday in JPY calendar");
+    }
+
+    // ── Known pre-existing behavior: Jan 1=Sunday produces duplicate Jan 2 in JPY ──
+    //
+    // When New Year's Day (Jan 1) falls on Sunday it rolls to Jan 2, which is
+    // already occupied by the non-rollable BOJ Year-Start Holiday.  The JPY
+    // output contains two HolidayDate entries for Jan 2 in those years (e.g. 2034).
+    // This is pre-existing behaviour, unaffected by the issue-#125 fix.
+
+    @Test
+    public void testJPY_NewYearsDay2034_DuplicateJan2_KnownBehavior() {
+        // Jan 1 2034 is Sunday → New Year's Day rolls to Jan 2.
+        // BOJ Year-Start Holiday is fixed, rollable=false, also on Jan 2.
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2034);
+        long jan2Count = holidays.stream()
+                .filter(hd -> hd.getDate().equals(LocalDate.of(2034, Month.JANUARY, 2)))
+                .count();
+        assertEquals(jan2Count, 2L,
+                "Jan 2 2034 should have 2 entries (New Year's Day rolled + BOJ Year-Start)");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/function/DateRolls.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/function/DateRolls.java
@@ -57,6 +57,22 @@ public final class DateRolls {
     }
 
     /**
+     * Only Sunday rolls forward to the following Monday; Saturday is returned
+     * unchanged (no substitute observance).
+     *
+     * <p>Implements the Japanese substitute-holiday rule (振替休日): Article 3,
+     * paragraph 2 of the Act on National Holidays (国民の祝日に関する法律, 1948,
+     * amended 2007) creates a make-up Monday only when a national holiday falls
+     * on Sunday. A Saturday holiday has no substitute — it falls on an already-
+     * closed day and is returned at its natural date.
+     *
+     * @see #followingMonday() for a roll that advances both Saturday and Sunday
+     */
+    public static DateRoll sundayToMonday() {
+        return date -> date.getDayOfWeek() == DayOfWeek.SUNDAY ? date.plusDays(1) : date;
+    }
+
+    /**
      * Compose two rolls: apply {@code first}, then apply {@code second}.
      */
     public static DateRoll compose(DateRoll first, DateRoll second) {

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/function/DateRollsTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/function/DateRollsTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.function;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+
+import static org.testng.Assert.assertEquals;
+
+public class DateRollsTest {
+
+    // ── sundayToMonday ────────────────────────────────────────────────────────
+
+    @Test
+    public void testSundayToMonday_Saturday_NoRoll() {
+        // Jan 1 2028 is Saturday — must stay unchanged
+        LocalDate sat = LocalDate.of(2028, 1, 1);
+        assertEquals(DateRolls.sundayToMonday().rollToObservedDate(sat), sat);
+    }
+
+    @Test
+    public void testSundayToMonday_Sunday_RollsToMonday() {
+        // Feb 11 2029 is Sunday → Feb 12 2029 (Monday)
+        LocalDate sun = LocalDate.of(2029, 2, 11);
+        assertEquals(DateRolls.sundayToMonday().rollToObservedDate(sun), LocalDate.of(2029, 2, 12));
+    }
+
+    @DataProvider(name = "weekdays")
+    public Object[][] weekdays() {
+        return new Object[][] {
+            { LocalDate.of(2025, 1, 6)  },  // Monday
+            { LocalDate.of(2025, 1, 7)  },  // Tuesday
+            { LocalDate.of(2025, 1, 8)  },  // Wednesday
+            { LocalDate.of(2025, 1, 9)  },  // Thursday
+            { LocalDate.of(2025, 1, 10) },  // Friday
+        };
+    }
+
+    @Test(dataProvider = "weekdays")
+    public void testSundayToMonday_Weekday_NoRoll(LocalDate weekday) {
+        assertEquals(DateRolls.sundayToMonday().rollToObservedDate(weekday), weekday);
+    }
+
+    // ── regression guards for existing strategies ─────────────────────────────
+
+    @Test
+    public void testFollowingMonday_Saturday_RollsToMonday() {
+        // Jan 1 2028 (Sat) → Jan 3 2028 (Mon)
+        LocalDate sat = LocalDate.of(2028, 1, 1);
+        assertEquals(DateRolls.followingMonday().rollToObservedDate(sat), LocalDate.of(2028, 1, 3));
+    }
+
+    @Test
+    public void testFollowingMonday_Sunday_RollsToMonday() {
+        // Feb 11 2029 (Sun) → Feb 12 2029 (Mon)
+        LocalDate sun = LocalDate.of(2029, 2, 11);
+        assertEquals(DateRolls.followingMonday().rollToObservedDate(sun), LocalDate.of(2029, 2, 12));
+    }
+
+    @Test
+    public void testPreviousFridayOrFollowingMonday_Saturday_RollsToFriday() {
+        // Jan 1 2028 (Sat) → Dec 31 2027 (Fri)
+        LocalDate sat = LocalDate.of(2028, 1, 1);
+        assertEquals(DateRolls.previousFridayOrFollowingMonday().rollToObservedDate(sat), LocalDate.of(2027, 12, 31));
+    }
+
+    @Test
+    public void testPreviousFridayOrFollowingMonday_Sunday_RollsToMonday() {
+        // Feb 11 2029 (Sun) → Feb 12 2029 (Mon)
+        LocalDate sun = LocalDate.of(2029, 2, 11);
+        assertEquals(DateRolls.previousFridayOrFollowingMonday().rollToObservedDate(sun), LocalDate.of(2029, 2, 12));
+    }
+
+    @Test
+    public void testNoRoll_SaturdayUnchanged() {
+        LocalDate sat = LocalDate.of(2028, 1, 1);
+        assertEquals(DateRolls.noRoll().rollToObservedDate(sat), sat);
+    }
+}


### PR DESCRIPTION
### Fix JP/JPY Saturday national holidays incorrectly rolled to Monday

**Description**

- Added `DateRolls.sundayToMonday()` — rolls Sunday → Monday, leaves Saturday unchanged
- Updated `HolidayCalendarServiceJP` and `HolidayCalendarServiceJPY` to use the new strategy instead of `followingMonday()`
- Added `DateRollsTest` (new) covering the new strategy and regression-guarding existing ones
- Extended `HolidayCalendarServiceJPTest` and `HolidayCalendarServiceJPYTest` with Saturday no-roll assertions, Sunday-still-rolls guards, spurious-sandwich negative tests, Golden Week 2031 triple-collision count, equinox-on-Saturday, and BOJ-closure coexistence checks

**Related Issue**

- [#125 — JP/JPY: Saturday national holidays incorrectly receive a Monday substitute](https://github.com/holiday-calendar/holiday-calendar-java/issues/125)

**Type of Change**

- [x] Bug fix

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed