### PR TITLE
#126 Fix JP/JPY cascading 振替休日 when substitute Monday is already a holiday

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidayCalendar.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidayCalendar.java
@@ -95,54 +95,61 @@ class JapaneseHolidayCalendar extends HolidayCalendar {
 
     private List<HolidayDate> applyCascade(List<HolidayDate> base, int year) {
         List<HolidayDate> result = new ArrayList<>(base);
-        // occupiedDates drives the candidate-advance loop.  It is a Set, so when two
-        // holidays share a date before cascade it stores that date only once; we therefore
-        // use a separate list scan to detect a collision with a different holiday.
         Set<LocalDate> occupiedDates = new HashSet<>();
         for (HolidayDate hd : base) {
             occupiedDates.add(hd.date());
         }
 
         for (int i = 0; i < result.size(); i++) {
-            HolidayDate hd = result.get(i);
-            Holiday h = hd.holiday();
-
-            if (!h.isRollable()) continue;
-
-            LocalDate rawDate = h.dateForYear(year).orElse(null);
-            if (rawDate == null || rawDate.getDayOfWeek() != DayOfWeek.SUNDAY) continue;
-
-            LocalDate expectedMonday = rawDate.plusDays(1);
-            if (!hd.date().equals(expectedMonday)) continue;
-
-            // Check whether any OTHER holiday occupies expectedMonday.  We scan the
-            // result list directly rather than using occupiedDates because the Set stores
-            // each date once — two holidays sharing the same date would produce a single
-            // entry, making it impossible to distinguish "self" from "other".
-            boolean hasOtherHolidayOnMonday = false;
-            for (int j = 0; j < result.size(); j++) {
-                if (j != i && expectedMonday.equals(result.get(j).date())) {
-                    hasOtherHolidayOnMonday = true;
-                    break;
-                }
+            LocalDate cascaded = findCascadeTarget(result, i, year, occupiedDates);
+            if (cascaded != null) {
+                result.set(i, new HolidayDate(result.get(i).holiday(), cascaded));
+                occupiedDates.add(cascaded);
             }
-            if (!hasOtherHolidayOnMonday) continue;
-
-            // True collision: advance day-by-day to the next free weekday within the same year.
-            // expectedMonday stays in occupiedDates because the other holiday still occupies it.
-            LocalDate candidate = expectedMonday.plusDays(1);
-            while (candidate.getYear() == year
-                    && (occupiedDates.contains(candidate)
-                        || candidate.getDayOfWeek() == DayOfWeek.SATURDAY
-                        || candidate.getDayOfWeek() == DayOfWeek.SUNDAY)) {
-                candidate = candidate.plusDays(1);
-            }
-            if (candidate.getYear() != year) continue;
-
-            result.set(i, new HolidayDate(h, candidate));
-            occupiedDates.add(candidate);
         }
 
         return result.stream().sorted(Comparator.comparing(HolidayDate::date)).toList();
+    }
+
+    private LocalDate findCascadeTarget(List<HolidayDate> result, int i, int year,
+                                        Set<LocalDate> occupiedDates) {
+        HolidayDate hd = result.get(i);
+        Holiday h = hd.holiday();
+
+        if (!h.isRollable()) return null;
+
+        LocalDate rawDate = h.dateForYear(year).orElse(null);
+        if (rawDate == null || rawDate.getDayOfWeek() != DayOfWeek.SUNDAY) return null;
+
+        LocalDate expectedMonday = rawDate.plusDays(1);
+        if (!hd.date().equals(expectedMonday)) return null;
+
+        // Scan the list rather than occupiedDates: the Set stores each date once, so
+        // two holidays sharing the same date look identical in the Set — we need to
+        // know whether a *different* holiday occupies expectedMonday.
+        if (!hasOtherHolidayOn(result, i, expectedMonday)) return null;
+
+        // expectedMonday stays in occupiedDates (the other holiday still occupies it).
+        return firstFreeWeekday(expectedMonday, year, occupiedDates);
+    }
+
+    private boolean hasOtherHolidayOn(List<HolidayDate> result, int excludeIndex, LocalDate date) {
+        for (int j = 0; j < result.size(); j++) {
+            if (j != excludeIndex && date.equals(result.get(j).date())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private LocalDate firstFreeWeekday(LocalDate after, int year, Set<LocalDate> occupiedDates) {
+        LocalDate candidate = after.plusDays(1);
+        while (candidate.getYear() == year
+                && (occupiedDates.contains(candidate)
+                    || candidate.getDayOfWeek() == DayOfWeek.SATURDAY
+                    || candidate.getDayOfWeek() == DayOfWeek.SUNDAY)) {
+            candidate = candidate.plusDays(1);
+        }
+        return candidate.getYear() == year ? candidate : null;
     }
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidayCalendar.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidayCalendar.java
@@ -27,7 +27,9 @@ import java.time.LocalDate;
 import java.time.temporal.ChronoUnit;
 import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * A {@link HolidayCalendar} for Japanese holiday schedules that applies the
@@ -50,17 +52,26 @@ class JapaneseHolidayCalendar extends HolidayCalendar {
     }
 
     /**
-     * Calculates holidays for the given year, then injects any sandwiched days
+     * Calculates holidays for the given year, applies the cascading 振替休日 rule
+     * (2007 Holiday Act amendment, Article 3 §3), then injects any sandwiched days
      * (国民の休日) that arise between consecutive holidays.
+     *
+     * <p>Cascade rule: when a national holiday falls on Sunday and its naive Monday
+     * substitute is already occupied by another holiday, the substitute advances
+     * day-by-day to the next weekday that is not itself a holiday.  The scan runs
+     * before sandwich detection so that cascaded dates are visible to the sandwich
+     * detector.  Only Sunday→Monday rolls trigger a cascade; Saturday holidays are
+     * unaffected (they stay on their natural date per issue #125).
      */
     @Override
     public List<HolidayDate> calculate(int year) {
         List<HolidayDate> base = super.calculate(year);
-        List<HolidayDate> result = new ArrayList<>(base);
+        List<HolidayDate> cascaded = applyCascade(base, year);
 
-        for (int i = 0; i < base.size() - 1; i++) {
-            LocalDate d1 = base.get(i).date();
-            LocalDate d2 = base.get(i + 1).date();
+        List<HolidayDate> result = new ArrayList<>(cascaded);
+        for (int i = 0; i < cascaded.size() - 1; i++) {
+            LocalDate d1 = cascaded.get(i).date();
+            LocalDate d2 = cascaded.get(i + 1).date();
             if (ChronoUnit.DAYS.between(d1, d2) == 2) {
                 LocalDate middle = d1.plusDays(1);
                 DayOfWeek dow = middle.getDayOfWeek();
@@ -80,5 +91,58 @@ class JapaneseHolidayCalendar extends HolidayCalendar {
         return result.stream()
                      .sorted(Comparator.comparing(HolidayDate::date))
                      .toList();
+    }
+
+    private List<HolidayDate> applyCascade(List<HolidayDate> base, int year) {
+        List<HolidayDate> result = new ArrayList<>(base);
+        // occupiedDates drives the candidate-advance loop.  It is a Set, so when two
+        // holidays share a date before cascade it stores that date only once; we therefore
+        // use a separate list scan to detect a collision with a different holiday.
+        Set<LocalDate> occupiedDates = new HashSet<>();
+        for (HolidayDate hd : base) {
+            occupiedDates.add(hd.date());
+        }
+
+        for (int i = 0; i < result.size(); i++) {
+            HolidayDate hd = result.get(i);
+            Holiday h = hd.holiday();
+
+            if (!h.isRollable()) continue;
+
+            LocalDate rawDate = h.dateForYear(year).orElse(null);
+            if (rawDate == null || rawDate.getDayOfWeek() != DayOfWeek.SUNDAY) continue;
+
+            LocalDate expectedMonday = rawDate.plusDays(1);
+            if (!hd.date().equals(expectedMonday)) continue;
+
+            // Check whether any OTHER holiday occupies expectedMonday.  We scan the
+            // result list directly rather than using occupiedDates because the Set stores
+            // each date once — two holidays sharing the same date would produce a single
+            // entry, making it impossible to distinguish "self" from "other".
+            boolean hasOtherHolidayOnMonday = false;
+            for (int j = 0; j < result.size(); j++) {
+                if (j != i && expectedMonday.equals(result.get(j).date())) {
+                    hasOtherHolidayOnMonday = true;
+                    break;
+                }
+            }
+            if (!hasOtherHolidayOnMonday) continue;
+
+            // True collision: advance day-by-day to the next free weekday within the same year.
+            // expectedMonday stays in occupiedDates because the other holiday still occupies it.
+            LocalDate candidate = expectedMonday.plusDays(1);
+            while (candidate.getYear() == year
+                    && (occupiedDates.contains(candidate)
+                        || candidate.getDayOfWeek() == DayOfWeek.SATURDAY
+                        || candidate.getDayOfWeek() == DayOfWeek.SUNDAY)) {
+                candidate = candidate.plusDays(1);
+            }
+            if (candidate.getYear() != year) continue;
+
+            result.set(i, new HolidayDate(h, candidate));
+            occupiedDates.add(candidate);
+        }
+
+        return result.stream().sorted(Comparator.comparing(HolidayDate::date)).toList();
     }
 }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
@@ -319,12 +319,18 @@ public class HolidayCalendarServiceJPTest {
     }
 
     @Test
-    public void testConstitutionMemorialDaySunday2026_RollsToMonday() {
-        // May 3 2026 is Sunday → May 4 (Monday)
+    public void testConstitutionMemorialDaySunday2026_CascadesToMayFifth() {
+        // May 3 2026 is Sunday → naive roll to May 4 (Monday), but May 4 is already
+        // Greenery Day → cascade to May 6 (Wednesday)
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
         Optional<HolidayDate> h = findByName(holidays, "Constitution Memorial Day");
         assertTrue(h.isPresent());
-        assertEquals(h.get().getDate(), LocalDate.of(2026, Month.MAY, 4));
+        assertEquals(h.get().getDate(), LocalDate.of(2026, Month.MAY, 6));
+        // Greenery Day stays on May 4; May 4 must have exactly one entry
+        long may4Count = holidays.stream()
+                .filter(hd -> hd.getDate().equals(LocalDate.of(2026, Month.MAY, 4)))
+                .count();
+        assertEquals(may4Count, 1L, "May 4 2026 must have exactly 1 entry (Greenery Day only)");
     }
 
     // ── No spurious sandwiched-day entries (issue #125 secondary effect) ──────
@@ -352,14 +358,54 @@ public class HolidayCalendarServiceJPTest {
     }
 
     @Test
-    public void testGoldenWeek2031_EntriesOnMayFifth() {
-        // May 3=Sat (Constitution stays), May 4=Sun (Greenery rolls to May 5), May 5=Mon (Children's)
-        // → two HolidayDate entries for May 5 2031
+    public void testGoldenWeek2031_GreeneryDayCascadesToMaySixth() {
+        // May 3=Sat (Constitution stays), May 4=Sun (Greenery naive roll → May 5), May 5=Mon (Children's)
+        // → collision: Greenery cascades to May 6 (Wednesday)
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2031);
-        long count = holidays.stream()
+        Optional<HolidayDate> greenery = findByName(holidays, "Greenery Day");
+        assertTrue(greenery.isPresent());
+        assertEquals(greenery.get().getDate(), LocalDate.of(2031, Month.MAY, 6),
+                "Greenery Day (May 4 Sun) must cascade to May 6 — May 5 is already Children's Day");
+        // May 5 must have exactly one entry (Children's Day only)
+        long may5Count = holidays.stream()
                 .filter(hd -> hd.getDate().equals(LocalDate.of(2031, Month.MAY, 5)))
                 .count();
-        assertEquals(count, 2L, "May 5, 2031 should have exactly 2 holiday entries (Greenery Day + Children's Day)");
+        assertEquals(may5Count, 1L, "May 5 2031 must have exactly 1 entry (Children's Day only)");
+    }
+
+    // ── Cascading substitute holiday rule — issue #126 ────────────────────────
+
+    @DataProvider(name = "jpGoldenWeekCascadeYears")
+    public Object[][] jpGoldenWeekCascadeYears() {
+        return new Object[][] {
+            { 2026, "Constitution Memorial Day", LocalDate.of(2026, Month.MAY, 4), LocalDate.of(2026, Month.MAY, 6) },
+            { 2031, "Greenery Day",              LocalDate.of(2031, Month.MAY, 5), LocalDate.of(2031, Month.MAY, 6) },
+            { 2036, "Greenery Day",              LocalDate.of(2036, Month.MAY, 5), LocalDate.of(2036, Month.MAY, 6) },
+            { 2037, "Constitution Memorial Day", LocalDate.of(2037, Month.MAY, 4), LocalDate.of(2037, Month.MAY, 6) },
+            { 2042, "Greenery Day",              LocalDate.of(2042, Month.MAY, 5), LocalDate.of(2042, Month.MAY, 6) },
+            { 2043, "Constitution Memorial Day", LocalDate.of(2043, Month.MAY, 4), LocalDate.of(2043, Month.MAY, 6) },
+            { 2048, "Constitution Memorial Day", LocalDate.of(2048, Month.MAY, 4), LocalDate.of(2048, Month.MAY, 6) },
+            { 2053, "Greenery Day",              LocalDate.of(2053, Month.MAY, 5), LocalDate.of(2053, Month.MAY, 6) },
+            { 2054, "Constitution Memorial Day", LocalDate.of(2054, Month.MAY, 4), LocalDate.of(2054, Month.MAY, 6) },
+        };
+    }
+
+    @Test(dataProvider = "jpGoldenWeekCascadeYears")
+    public void testJP_GoldenWeekCascade(int year, String name, LocalDate collision, LocalDate cascaded) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        // Cascaded date is present under the correct holiday name
+        Optional<HolidayDate> hd = holidays.stream()
+                .filter(h -> name.equals(h.getHoliday().getName()) && cascaded.equals(h.getDate()))
+                .findFirst();
+        assertTrue(hd.isPresent(), year + ": " + name + " must be observed on " + cascaded);
+        // Holiday does not appear at the naive collision date
+        long countAtCollision = holidays.stream()
+                .filter(h -> name.equals(h.getHoliday().getName()) && collision.equals(h.getDate()))
+                .count();
+        assertEquals(countAtCollision, 0L, year + ": " + name + " must not appear at " + collision);
+        // No date appears more than once in the full list
+        long uniqueDates = holidays.stream().map(HolidayDate::date).distinct().count();
+        assertEquals(uniqueDates, holidays.size(), year + ": no two holidays should share a date");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
@@ -186,12 +186,18 @@ public class HolidayCalendarServiceJPYTest {
     }
 
     @Test
-    public void testConstitutionMemorialDaySunday2026_RollsToMonday_JPY() {
-        // May 3 2026 is Sunday → May 4 (Monday)
+    public void testConstitutionMemorialDaySunday2026_CascadesToMaySixth_JPY() {
+        // May 3 2026 is Sunday → naive roll to May 4 (Monday), but May 4 is already
+        // Greenery Day → cascade to May 6 (Wednesday)
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
         Optional<HolidayDate> h = findByName(holidays, "Constitution Memorial Day");
         assertTrue(h.isPresent());
-        assertEquals(h.get().getDate(), LocalDate.of(2026, Month.MAY, 4));
+        assertEquals(h.get().getDate(), LocalDate.of(2026, Month.MAY, 6));
+        // May 4 must have exactly one entry (Greenery Day only)
+        long may4Count = holidays.stream()
+                .filter(hd -> hd.getDate().equals(LocalDate.of(2026, Month.MAY, 4)))
+                .count();
+        assertEquals(may4Count, 1L, "May 4 2026 must have exactly 1 entry (Greenery Day only) in JPY");
     }
 
     // ── No spurious sandwiched-day entries (issue #125 secondary effect) ──────
@@ -218,23 +224,74 @@ public class HolidayCalendarServiceJPYTest {
         assertFalse(phantomMay4, "May 4, 2031 must not be a spurious National Holiday in JPY calendar");
     }
 
-    // ── Known pre-existing behavior: Jan 1=Sunday produces duplicate Jan 2 in JPY ──
+    // ── New Year's Day cascade when Jan 1=Sunday (JPY-specific, issue #126) ──────
     //
-    // When New Year's Day (Jan 1) falls on Sunday it rolls to Jan 2, which is
-    // already occupied by the non-rollable BOJ Year-Start Holiday.  The JPY
-    // output contains two HolidayDate entries for Jan 2 in those years (e.g. 2034).
-    // This is pre-existing behaviour, unaffected by the issue-#125 fix.
+    // When New Year's Day (Jan 1) falls on Sunday its naive Monday substitute is
+    // Jan 2, which is already a non-rollable BOJ Year-Start Holiday.  Jan 3 is
+    // also a BOJ Year-Start Holiday.  The cascade advances New Year's Day to Jan 4
+    // (the first free weekday), leaving Jan 2 and Jan 3 untouched.
 
-    @Test
-    public void testJPY_NewYearsDay2034_DuplicateJan2_KnownBehavior() {
-        // Jan 1 2034 is Sunday → New Year's Day rolls to Jan 2.
-        // BOJ Year-Start Holiday is fixed, rollable=false, also on Jan 2.
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2034);
+    @DataProvider(name = "jpyNewYearCascadeYears")
+    public Object[][] jpyNewYearCascadeYears() {
+        return new Object[][] {
+            { 2034, LocalDate.of(2034, Month.JANUARY, 4) },
+            { 2040, LocalDate.of(2040, Month.JANUARY, 4) },
+            { 2045, LocalDate.of(2045, Month.JANUARY, 4) },
+            { 2051, LocalDate.of(2051, Month.JANUARY, 4) },
+        };
+    }
+
+    @Test(dataProvider = "jpyNewYearCascadeYears")
+    public void testJPY_NewYearCascade(int year, LocalDate cascaded) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        // New Year's Day must be on the cascaded date
+        Optional<HolidayDate> nyd = findByName(holidays, "New Year's Day");
+        assertTrue(nyd.isPresent(), year + ": New Year's Day must be present");
+        assertEquals(nyd.get().getDate(), cascaded,
+                year + ": New Year's Day (Jan 1 Sun) must cascade to " + cascaded);
+        // Jan 2 must have exactly one entry (BOJ Year-Start only, no duplicate)
         long jan2Count = holidays.stream()
-                .filter(hd -> hd.getDate().equals(LocalDate.of(2034, Month.JANUARY, 2)))
+                .filter(hd -> hd.getDate().equals(LocalDate.of(year, Month.JANUARY, 2)))
                 .count();
-        assertEquals(jan2Count, 2L,
-                "Jan 2 2034 should have 2 entries (New Year's Day rolled + BOJ Year-Start)");
+        assertEquals(jan2Count, 1L, year + ": Jan 2 must have exactly 1 entry (BOJ Year-Start only)");
+        // Jan 3 BOJ Year-Start Holiday must still be present
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.JANUARY, 3)).isPresent(),
+                year + ": Jan 3 BOJ Year-Start Holiday must still be present");
+    }
+
+    // ── Golden Week cascade years (inherited from JP, issue #126) ─────────────
+
+    @DataProvider(name = "jpyGoldenWeekCascadeYears")
+    public Object[][] jpyGoldenWeekCascadeYears() {
+        return new Object[][] {
+            { 2026, "Constitution Memorial Day", LocalDate.of(2026, Month.MAY, 4), LocalDate.of(2026, Month.MAY, 6) },
+            { 2031, "Greenery Day",              LocalDate.of(2031, Month.MAY, 5), LocalDate.of(2031, Month.MAY, 6) },
+            { 2036, "Greenery Day",              LocalDate.of(2036, Month.MAY, 5), LocalDate.of(2036, Month.MAY, 6) },
+            { 2037, "Constitution Memorial Day", LocalDate.of(2037, Month.MAY, 4), LocalDate.of(2037, Month.MAY, 6) },
+            { 2042, "Greenery Day",              LocalDate.of(2042, Month.MAY, 5), LocalDate.of(2042, Month.MAY, 6) },
+            { 2043, "Constitution Memorial Day", LocalDate.of(2043, Month.MAY, 4), LocalDate.of(2043, Month.MAY, 6) },
+            { 2048, "Constitution Memorial Day", LocalDate.of(2048, Month.MAY, 4), LocalDate.of(2048, Month.MAY, 6) },
+            { 2053, "Greenery Day",              LocalDate.of(2053, Month.MAY, 5), LocalDate.of(2053, Month.MAY, 6) },
+            { 2054, "Constitution Memorial Day", LocalDate.of(2054, Month.MAY, 4), LocalDate.of(2054, Month.MAY, 6) },
+        };
+    }
+
+    @Test(dataProvider = "jpyGoldenWeekCascadeYears")
+    public void testJPY_GoldenWeekCascade(int year, String name, LocalDate collision, LocalDate cascaded) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        // Cascaded date is present under the correct holiday name
+        Optional<HolidayDate> hd = holidays.stream()
+                .filter(h -> name.equals(h.getHoliday().getName()) && cascaded.equals(h.getDate()))
+                .findFirst();
+        assertTrue(hd.isPresent(), year + ": " + name + " must be observed on " + cascaded + " in JPY");
+        // Holiday does not appear at the naive collision date
+        long countAtCollision = holidays.stream()
+                .filter(h -> name.equals(h.getHoliday().getName()) && collision.equals(h.getDate()))
+                .count();
+        assertEquals(countAtCollision, 0L, year + ": " + name + " must not appear at " + collision + " in JPY");
+        // No date appears more than once in the full list
+        long uniqueDates = holidays.stream().map(HolidayDate::date).distinct().count();
+        assertEquals(uniqueDates, holidays.size(), year + ": no two JPY holidays should share a date");
     }
 
     // ── Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
### Fix cascading substitute holiday rule for JP and JPY calendars

**Description**

- Added `applyCascade()` to `JapaneseHolidayCalendar` implementing Japan's 2007 Holiday Act amendment (Article 3 §3): when a national holiday falls on Sunday and its naive Monday substitute is already occupied by another holiday, the substitute advances day-by-day to the next available non-holiday weekday
- Cascade is inserted between `super.calculate()` (base roll) and the sandwich-day scan so cascaded dates are visible to the sandwich detector
- Only Sunday→Monday rolls trigger the cascade; Saturday holidays are unaffected (per issue #125)
- JPY's non-rollable BOJ Year-Start Holidays (Jan 2/3) correctly block the cascade for New Year's Day in years 2034, 2040, 2045, 2051
- Cross-year cascades are silently suppressed (substitute not emitted for that year)
- Updated 4 existing tests that documented pre-fix (buggy) behaviour
- Added 22 new parametrised tests covering all 9 Golden Week cascade years and 4 JPY New Year cascade years

**Related Issue**

- [#126 JP/JPY: Cascading 振替休日 not applied when substitute Monday is already a holiday](https://github.com/holiday-calendar/holiday-calendar-java/issues/126)

**Type of Change**

- [x] Bug fix

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed