### PR TITLE
#116 Extended JP/JPY range tests for 2026–2055 audit

### DIFF
--- a/docs/jp-calendar-audit-2026-2055.md
+++ b/docs/jp-calendar-audit-2026-2055.md
@@ -1,0 +1,103 @@
+# JP / JPY Calendar Audit — 30-Year Data Coverage (Issue #116)
+
+This document summarises the findings and follow-on work from the audit of
+`HolidayCalendarServiceJP` (TSE) and `HolidayCalendarServiceJPY` (BOJ) required
+to confirm correct operation across the 2026–2055 target range.
+
+---
+
+## Audit Checklist Results
+
+| # | Requirement | Finding | Resolution |
+|---|-------------|---------|------------|
+| 1 | **Lookup table check** — confirm whether any holidays rely on lookup tables; extend to 2055 if so | No lookup tables. The vernal and autumnal equinox dates are computed via the NAOJ astronomical formula (valid 1980–2099). All other floating holidays use Happy Monday rules or fixed dates. | Nothing to extend. |
+| 2 | **Substitute holiday rules (振替休日)** — verify correct application for all years in the 30-year window, including edge cases | Two bugs found: (a) Saturday holidays were incorrectly receiving a Monday substitute; (b) cascading substitute was not applied when the immediate Monday was already occupied by another holiday. | Fixed by #125 and #126. The calendar now uses `sundayToMonday()` — only Sunday holidays roll; Saturday holidays remain on their natural date. |
+| 3 | **Sandwich day logic (国民の休日)** — confirm rule is implemented and correct | Working correctly. Silver Week sandwiches (September) and Golden Week sandwiches are generated in the right years. | Verified by extended tests. |
+| 4 | **Special closures** — document how extraordinary one-time closures are represented | The 2019 imperial transition is modelled as two `SpecialAnniversary` entries in `JapaneseHolidays.baseHolidays()`: Emperor's Abdication Day (Apr 30) and Enthronement Day (May 1). | Verified. |
+| 5 | **Range test** — run `calculate(2026, 2055)` and spot-check results | Extended test suite added (PR #134). Two additional defects were uncovered during testing — see below. | PR #134 (extended tests); defects tracked as #132 and #133. |
+| 6 | **Olympic relocations 2021** | Sports Day, Marine Day, and Mountain Day were relocated by special ordinance for the Tokyo 2020 Games (held in 2021). | Fixed by #127. |
+
+---
+
+## Extended Test Coverage (PR #134)
+
+Four new test classes were added to `holiday-calendar-apac`:
+
+| Class | Coverage |
+|-------|----------|
+| `HolidayCalendarServiceJPExtendedTest` | Equinox observed dates all 30 years; Silver Week sandwiches; Golden Week cascades; Emperor's Birthday weekend behaviour; full-year holiday counts 2026–2055; Olympic 2021 overrides |
+| `HolidayCalendarServiceJPYExtendedTest` | BOJ closures (Jan 2, Jan 3, Dec 31) every year 2026–2055; non-rollable weekend spot-checks; JPY full-year counts |
+| `AutumnalEquinoxDayExtendedTest` | Raw NAOJ formula output for every year 2026–2055 |
+| `VernalEquinoxDayExtendedTest` | Raw NAOJ formula output for every year 2026–2055 |
+
+### Saturday no-roll behaviour (post-#125)
+
+Tests were written with the initial assumption that `followingMonday()` was in use
+(Saturday +2 → Monday). After merging the #125 fix, the JP and JPY calendars use
+`sundayToMonday()`: Saturday holidays stay on their natural calendar date. The
+extended tests reflect this corrected behaviour throughout.
+
+---
+
+## Remaining Defects
+
+Two defects were uncovered during range testing and are tracked as separate issues.
+Disabled sentinel tests for both are included in `HolidayCalendarServiceJPExtendedTest`.
+
+### Issue #132 — 2020 Olympic holiday relocations not implemented
+
+The Tokyo Olympic Special Measures Act relocated three holidays in **both** 2020 and
+2021. The 2021 relocations were fixed by #127; the 2020 dates remain wrong.
+
+| Holiday | 2020 Actual (wrong) | 2020 Expected (correct) |
+|---------|---------------------|------------------------|
+| Sports Day | Oct 12 (normal) | Jul 24 |
+| Marine Day | Jul 20 (normal) | Jul 23 |
+| Mountain Day | Aug 11 (normal) | Aug 10 |
+
+**Fix guidance:** Add 2020-year overrides to `SportsDay.java`, `MarineDay.java`, and
+the Mountain Day observance, mirroring the existing 2021 overrides added by #127.
+Re-enable `testSportsDayOlympic2020`, `testMarineDayOlympic2020`, and
+`testMountainDayOlympic2020` in `HolidayCalendarServiceJPExtendedTest` once done.
+
+### Issue #133 — JPY cascade bypasses BOJ Year-Start Holiday
+
+In years where January 1 falls on Sunday, New Year's Day rolls to Monday January 2
+via `sundayToMonday()`. The JPY calendar also has a non-rollable BOJ operational
+closure on January 2 ("Year-Start Holiday"). `JapaneseHolidayCalendar.applyCascade()`
+treats that closure as a blocker, causing New Year's Day to cascade to January 4
+instead of coexisting with the Year-Start Holiday on January 2.
+
+The cascade rule (振替休日, Article 3 §3 of the Holiday Act) triggers only when
+**another national holiday** occupies the Monday substitute. A BOJ operational closure
+is not a national holiday and should not block the roll.
+
+**Affected years (Jan 1 Sunday, 2026–2055):** 2034, 2040, 2045, 2051.
+
+**Current behaviour (buggy):**
+- Jan 2: Year-Start Holiday only
+- Jan 3: Year-Start Holiday
+- Jan 4: New Year's Day (incorrectly cascaded)
+
+**Expected behaviour (correct):**
+- Jan 2: New Year's Day + Year-Start Holiday (coexist)
+- Jan 3: Year-Start Holiday
+
+**Fix guidance:** In `JapaneseHolidayCalendar.findCascadeTarget()`, restrict
+`hasOtherHolidayOn()` to only consider holidays whose raw natural date would
+itself conflict (i.e., rollable national holidays), excluding non-rollable
+operational closures. After fixing, re-enable the New Year's Day collision tests
+in `HolidayCalendarServiceJPYExtendedTest` and update the JPY full-year count
+expectations for the affected years (each gains +1 entry on Jan 2).
+
+---
+
+## Recommended Fix Order
+
+1. Review and merge PR #134 → close issue #116.
+2. Fix issue #132 (Olympic 2020 relocations) — scope is narrow, implementation-only.
+3. Fix issue #133 (JPY cascade) — requires a targeted change to `applyCascade()`
+   logic and updates to the JPY count tests.
+
+Issues #132 and #133 are independent of each other and can be worked in either
+order or in parallel.

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
@@ -1,0 +1,606 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.*;
+
+/**
+ * Extended integration tests for {@link HolidayCalendarServiceJP} covering the
+ * 2026–2055 target range.  These tests complement the baseline coverage in
+ * {@link HolidayCalendarServiceJPTest} and exercise:
+ *
+ * <ol>
+ *   <li>Olympic year overrides for 2020 and 2021</li>
+ *   <li>Vernal Equinox Day — observed dates after Sunday rolling (2026–2055)</li>
+ *   <li>Autumnal Equinox Day — observed dates after Sunday rolling (2026–2055)</li>
+ *   <li>Silver Week sandwich days (2026, 2032, 2037, 2043, 2049, 2054)</li>
+ *   <li>Cascading substitute holidays in Golden Week (9 years in 2026–2055)</li>
+ *   <li>Emperor's Birthday Sunday rolls and Saturday no-rolls (2026–2055)</li>
+ *   <li>Full-year holiday counts for representative years (2026–2055)</li>
+ * </ol>
+ */
+public class HolidayCalendarServiceJPExtendedTest {
+
+    private HolidayCalendar calendar;
+
+    @BeforeClass
+    public void setup() {
+        this.calendar = new HolidayCalendarServiceJP().getHolidayCalendar();
+    }
+
+    // =========================================================================
+    // 1. OLYMPIC YEAR OVERRIDES (2021)
+    // =========================================================================
+    // The Tokyo 2020 Olympics (held in 2021 due to COVID delay) caused three
+    // holidays to be relocated in 2021 by special government ordinance:
+    //   Sports Day (Jul 23), Marine Day (Jul 22), Mountain Day (Aug 9).
+    //
+    // NOTE: The corresponding 2020 Olympic relocations (Sports Day Jul 24,
+    // Marine Day Jul 23, Mountain Day Aug 10) are not yet implemented and are
+    // tracked as a separate defect issue.
+    // =========================================================================
+
+    /**
+     * Sports Day 2021 was relocated from its normal 2nd-Monday-in-October
+     * (Oct 11) to Jul 23 by special ordinance.
+     */
+    @Test
+    public void testSportsDayOlympic2021() {
+        List<HolidayDate> holidays = calendar.calculate(2021);
+        Optional<HolidayDate> h = findByName(holidays, "Sports Day");
+        assertTrue(h.isPresent(), "Sports Day must be present in 2021");
+        assertEquals(h.get().getDate(), LocalDate.of(2021, Month.JULY, 23),
+                     "Sports Day 2021 should be Jul 23 (Olympic relocation)");
+    }
+
+    /**
+     * Marine Day 2021 was relocated from its normal 3rd-Monday-in-July
+     * (Jul 19) to Jul 22 by special ordinance.
+     */
+    @Test
+    public void testMarineDayOlympic2021() {
+        List<HolidayDate> holidays = calendar.calculate(2021);
+        Optional<HolidayDate> h = findByName(holidays, "Marine Day");
+        assertTrue(h.isPresent(), "Marine Day must be present in 2021");
+        assertEquals(h.get().getDate(), LocalDate.of(2021, Month.JULY, 22),
+                     "Marine Day 2021 should be Jul 22 (Olympic relocation)");
+    }
+
+    /**
+     * Mountain Day 2021 was relocated from Aug 11 (Wednesday) to Aug 8
+     * (Sunday); the substitute was therefore observed on Aug 9 (Monday).
+     */
+    @Test
+    public void testMountainDayOlympic2021() {
+        List<HolidayDate> holidays = calendar.calculate(2021);
+        Optional<HolidayDate> h = findByName(holidays, "Mountain Day");
+        assertTrue(h.isPresent(), "Mountain Day must be present in 2021");
+        assertEquals(h.get().getDate(), LocalDate.of(2021, Month.AUGUST, 9),
+                     "Mountain Day 2021 should be Aug 9 (Aug 8 relocated date, Sunday → Monday substitute)");
+    }
+
+    // =========================================================================
+    // 2. VERNAL EQUINOX DAY — OBSERVED DATES 2026–2055
+    // =========================================================================
+    // Tests the end-to-end observed date for Vernal Equinox Day across the
+    // full 30-year range.
+    //
+    // The JP calendar uses {@code sundayToMonday()} (per issue #125): only
+    // Sunday holidays roll to Monday (+1). Saturday holidays remain on their
+    // natural date.
+    //
+    // Sun→Mon rolls: 2027 (Mar 21 Sun→Mar 22 Mon), 2033 (Mar 20 Sun→Mar 21 Mon),
+    // 2044 (Mar 20 Sun→Mar 21 Mon), 2050 (Mar 20 Sun→Mar 21 Mon),
+    // 2055 (Mar 21 Sun→Mar 22 Mon).
+    // Saturday (no roll): 2032 (Mar 20 Sat), 2038 (Mar 20 Sat),
+    // 2043 (Mar 21 Sat), 2049 (Mar 20 Sat).
+    // =========================================================================
+
+    /**
+     * Vernal Equinox Day observed dates 2026–2055.
+     *
+     * <p>The JP calendar uses {@code sundayToMonday()}: Sunday rolls +1 to Monday;
+     * Saturday stays on its natural date (no substitute under Japanese law).
+     */
+    @DataProvider(name = "vernalEquinoxObserved2026to2055")
+    Iterator<Object[]> vernalEquinoxObserved2026to2055() {
+        return List.of(
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 20)},  // Fri
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 22)},  // Sun raw → Mon observed (+1)
+            new Object[]{2028, LocalDate.of(2028, Month.MARCH, 20)},  // Mon
+            new Object[]{2029, LocalDate.of(2029, Month.MARCH, 20)},  // Tue
+            new Object[]{2030, LocalDate.of(2030, Month.MARCH, 20)},  // Wed
+            new Object[]{2031, LocalDate.of(2031, Month.MARCH, 21)},  // Fri
+            new Object[]{2032, LocalDate.of(2032, Month.MARCH, 20)},  // Sat — stays (no roll per #125)
+            new Object[]{2033, LocalDate.of(2033, Month.MARCH, 21)},  // Sun raw → Mon observed (+1)
+            new Object[]{2034, LocalDate.of(2034, Month.MARCH, 20)},  // Mon
+            new Object[]{2035, LocalDate.of(2035, Month.MARCH, 21)},  // Wed
+            new Object[]{2036, LocalDate.of(2036, Month.MARCH, 20)},  // Thu
+            new Object[]{2037, LocalDate.of(2037, Month.MARCH, 20)},  // Fri
+            new Object[]{2038, LocalDate.of(2038, Month.MARCH, 20)},  // Sat — stays (no roll per #125)
+            new Object[]{2039, LocalDate.of(2039, Month.MARCH, 21)},  // Mon
+            new Object[]{2040, LocalDate.of(2040, Month.MARCH, 20)},  // Tue
+            new Object[]{2041, LocalDate.of(2041, Month.MARCH, 20)},  // Wed
+            new Object[]{2042, LocalDate.of(2042, Month.MARCH, 20)},  // Thu
+            new Object[]{2043, LocalDate.of(2043, Month.MARCH, 21)},  // Sat — stays (no roll per #125)
+            new Object[]{2044, LocalDate.of(2044, Month.MARCH, 21)},  // Sun raw → Mon observed (+1)
+            new Object[]{2045, LocalDate.of(2045, Month.MARCH, 20)},  // Mon
+            new Object[]{2046, LocalDate.of(2046, Month.MARCH, 20)},  // Tue
+            new Object[]{2047, LocalDate.of(2047, Month.MARCH, 21)},  // Thu
+            new Object[]{2048, LocalDate.of(2048, Month.MARCH, 20)},  // Fri
+            new Object[]{2049, LocalDate.of(2049, Month.MARCH, 20)},  // Sat — stays (no roll per #125)
+            new Object[]{2050, LocalDate.of(2050, Month.MARCH, 21)},  // Sun raw → Mon observed (+1)
+            new Object[]{2051, LocalDate.of(2051, Month.MARCH, 21)},  // Tue
+            new Object[]{2052, LocalDate.of(2052, Month.MARCH, 20)},  // Wed
+            new Object[]{2053, LocalDate.of(2053, Month.MARCH, 20)},  // Thu
+            new Object[]{2054, LocalDate.of(2054, Month.MARCH, 20)},  // Fri
+            new Object[]{2055, LocalDate.of(2055, Month.MARCH, 22)}   // Sun raw → Mon observed (+1)
+        ).iterator();
+    }
+
+    @Test(dataProvider = "vernalEquinoxObserved2026to2055")
+    public void testVernalEquinoxObservedDate(int year, LocalDate expected) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByName(holidays, "Vernal Equinox Day");
+        assertTrue(h.isPresent(), "Vernal Equinox Day must be present in " + year);
+        assertEquals(h.get().getDate(), expected,
+                     "Vernal Equinox Day observed date for " + year);
+    }
+
+    // =========================================================================
+    // 3. AUTUMNAL EQUINOX DAY — OBSERVED DATES 2026–2055
+    // =========================================================================
+    // The JP calendar uses {@code sundayToMonday()}: only Sunday rolls to Monday.
+    // Saturday holidays remain on their natural date (no substitute per #125).
+    //
+    // Sun→Mon rolls: 2029 (Sep 23 Sun→Sep 24 Mon), 2035 (Sep 23 Sun→Sep 24 Mon),
+    // 2046 (Sep 23 Sun→Sep 24 Mon), 2052 (Sep 22 Sun→Sep 23 Mon).
+    // Saturday (no roll): 2034 (Sep 23 Sat), 2040 (Sep 22 Sat), 2051 (Sep 23 Sat).
+    // =========================================================================
+
+    /**
+     * Autumnal Equinox Day observed dates 2026–2055.
+     *
+     * <p>The JP calendar uses {@code sundayToMonday()}: Sunday rolls +1 to Monday;
+     * Saturday stays on its natural date (no substitute under Japanese law).
+     */
+    @DataProvider(name = "autumnalEquinoxObserved2026to2055")
+    Iterator<Object[]> autumnalEquinoxObserved2026to2055() {
+        return List.of(
+            new Object[]{2026, LocalDate.of(2026, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2027, LocalDate.of(2027, Month.SEPTEMBER, 23)},  // Thu
+            new Object[]{2028, LocalDate.of(2028, Month.SEPTEMBER, 22)},  // Fri
+            new Object[]{2029, LocalDate.of(2029, Month.SEPTEMBER, 24)},  // Sun raw Sep 23 → Mon Sep 24
+            new Object[]{2030, LocalDate.of(2030, Month.SEPTEMBER, 23)},  // Mon
+            new Object[]{2031, LocalDate.of(2031, Month.SEPTEMBER, 23)},  // Tue
+            new Object[]{2032, LocalDate.of(2032, Month.SEPTEMBER, 22)},  // Wed
+            new Object[]{2033, LocalDate.of(2033, Month.SEPTEMBER, 23)},  // Fri
+            new Object[]{2034, LocalDate.of(2034, Month.SEPTEMBER, 23)},  // Sat — stays (no roll per #125)
+            new Object[]{2035, LocalDate.of(2035, Month.SEPTEMBER, 24)},  // Sun raw Sep 23 → Mon Sep 24
+            new Object[]{2036, LocalDate.of(2036, Month.SEPTEMBER, 22)},  // Mon
+            new Object[]{2037, LocalDate.of(2037, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2038, LocalDate.of(2038, Month.SEPTEMBER, 23)},  // Thu
+            new Object[]{2039, LocalDate.of(2039, Month.SEPTEMBER, 23)},  // Fri
+            new Object[]{2040, LocalDate.of(2040, Month.SEPTEMBER, 22)},  // Sat — stays (no roll per #125)
+            new Object[]{2041, LocalDate.of(2041, Month.SEPTEMBER, 23)},  // Mon
+            new Object[]{2042, LocalDate.of(2042, Month.SEPTEMBER, 23)},  // Tue
+            new Object[]{2043, LocalDate.of(2043, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2044, LocalDate.of(2044, Month.SEPTEMBER, 22)},  // Thu
+            new Object[]{2045, LocalDate.of(2045, Month.SEPTEMBER, 22)},  // Fri
+            new Object[]{2046, LocalDate.of(2046, Month.SEPTEMBER, 24)},  // Sun raw Sep 23 → Mon Sep 24
+            new Object[]{2047, LocalDate.of(2047, Month.SEPTEMBER, 23)},  // Mon
+            new Object[]{2048, LocalDate.of(2048, Month.SEPTEMBER, 22)},  // Tue
+            new Object[]{2049, LocalDate.of(2049, Month.SEPTEMBER, 22)},  // Wed
+            new Object[]{2050, LocalDate.of(2050, Month.SEPTEMBER, 23)},  // Fri
+            new Object[]{2051, LocalDate.of(2051, Month.SEPTEMBER, 23)},  // Sat — stays (no roll per #125)
+            new Object[]{2052, LocalDate.of(2052, Month.SEPTEMBER, 23)},  // Sun raw Sep 22 → Mon Sep 23
+            new Object[]{2053, LocalDate.of(2053, Month.SEPTEMBER, 22)},  // Mon
+            new Object[]{2054, LocalDate.of(2054, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2055, LocalDate.of(2055, Month.SEPTEMBER, 23)}   // Thu
+        ).iterator();
+    }
+
+    @Test(dataProvider = "autumnalEquinoxObserved2026to2055")
+    public void testAutumnalEquinoxObservedDate(int year, LocalDate expected) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByName(holidays, "Autumnal Equinox Day");
+        assertTrue(h.isPresent(), "Autumnal Equinox Day must be present in " + year);
+        assertEquals(h.get().getDate(), expected,
+                     "Autumnal Equinox Day observed date for " + year);
+    }
+
+    // =========================================================================
+    // 4. SILVER WEEK — SEPTEMBER SANDWICH DAYS 2026–2055
+    // =========================================================================
+    // Silver Week occurs when Respect for the Aged Day (3rd Monday in September)
+    // and Autumnal Equinox Day (observed) are exactly two days apart, leaving a
+    // weekday sandwiched between them.  Years in 2026–2055: 2026, 2032, 2037,
+    // 2043, 2049, 2054.
+    // =========================================================================
+
+    /**
+     * Years in 2026–2055 where a Silver Week "National Holiday" sandwich occurs.
+     * Each row: year, Respect for the Aged Day date, sandwich date,
+     * Autumnal Equinox observed date.
+     */
+    @DataProvider(name = "silverWeekYears")
+    Iterator<Object[]> silverWeekYears() {
+        return List.of(
+            // year, RespectForAgedDay, sandwichDate, AutumnalEquinox
+            new Object[]{2026,
+                LocalDate.of(2026, Month.SEPTEMBER, 21),  // Mon
+                LocalDate.of(2026, Month.SEPTEMBER, 22),  // Tue sandwich
+                LocalDate.of(2026, Month.SEPTEMBER, 23)}, // Wed
+            new Object[]{2032,
+                LocalDate.of(2032, Month.SEPTEMBER, 20),  // Mon
+                LocalDate.of(2032, Month.SEPTEMBER, 21),  // Tue sandwich
+                LocalDate.of(2032, Month.SEPTEMBER, 22)}, // Wed
+            new Object[]{2037,
+                LocalDate.of(2037, Month.SEPTEMBER, 21),  // Mon
+                LocalDate.of(2037, Month.SEPTEMBER, 22),  // Tue sandwich
+                LocalDate.of(2037, Month.SEPTEMBER, 23)}, // Wed
+            new Object[]{2043,
+                LocalDate.of(2043, Month.SEPTEMBER, 21),  // Mon
+                LocalDate.of(2043, Month.SEPTEMBER, 22),  // Tue sandwich
+                LocalDate.of(2043, Month.SEPTEMBER, 23)}, // Wed
+            new Object[]{2049,
+                LocalDate.of(2049, Month.SEPTEMBER, 20),  // Mon
+                LocalDate.of(2049, Month.SEPTEMBER, 21),  // Tue sandwich
+                LocalDate.of(2049, Month.SEPTEMBER, 22)}, // Wed
+            new Object[]{2054,
+                LocalDate.of(2054, Month.SEPTEMBER, 21),  // Mon
+                LocalDate.of(2054, Month.SEPTEMBER, 22),  // Tue sandwich
+                LocalDate.of(2054, Month.SEPTEMBER, 23)}  // Wed
+        ).iterator();
+    }
+
+    @Test(dataProvider = "silverWeekYears")
+    public void testSilverWeekSandwich(int year, LocalDate rfad, LocalDate sandwich, LocalDate aeq) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+
+        // Verify anchor holidays are present
+        assertTrue(findByDate(holidays, rfad).isPresent(),
+                   year + ": Respect for the Aged Day expected on " + rfad);
+        assertTrue(findByDate(holidays, aeq).isPresent(),
+                   year + ": Autumnal Equinox Day expected on " + aeq);
+
+        // Verify sandwich "National Holiday"
+        Optional<HolidayDate> sw = holidays.stream()
+                .filter(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                           && hd.getDate().equals(sandwich))
+                .findFirst();
+        assertTrue(sw.isPresent(),
+                   year + ": Silver Week sandwich expected on " + sandwich);
+    }
+
+    /**
+     * Confirms no Silver Week sandwich appears in representative non-Silver-Week
+     * years where Respect for the Aged Day and Autumnal Equinox are more than
+     * two days apart.
+     */
+    @DataProvider(name = "nonSilverWeekYears")
+    Iterator<Object[]> nonSilverWeekYears() {
+        return List.of(
+            // diff = 3 or more days between RFAD and AEQ observed date
+            new Object[]{2027},  // diff=3
+            new Object[]{2028},  // diff=4
+            new Object[]{2038},  // diff=3
+            new Object[]{2044},  // diff=3
+            new Object[]{2050},  // diff=4
+            new Object[]{2055}   // diff=3
+        ).iterator();
+    }
+
+    @Test(dataProvider = "nonSilverWeekYears")
+    public void testNoSilverWeekSandwich(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        long septemberSandwiches = holidays.stream()
+                .filter(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                           && hd.getDate().getMonth() == Month.SEPTEMBER)
+                .count();
+        assertEquals(septemberSandwiches, 0L,
+                     year + ": no September National Holiday sandwich expected");
+    }
+
+    // =========================================================================
+    // 4b. SHOWA DAY 2045 — SATURDAY, NO ROLL
+    // =========================================================================
+    // In 2045, Apr 29 (Showa Day) falls on Saturday.  Per the Japanese holiday
+    // law (振替休日 applies only to Sunday), Saturday holidays have no substitute
+    // (issue #125).  Showa Day therefore remains on Apr 29, and no Golden Week
+    // sandwich is generated on May 2.
+    // =========================================================================
+
+    /**
+     * Verifies that in 2045 Showa Day (Apr 29 Sat) stays on its natural date
+     * and does NOT produce a Golden Week sandwich on May 2.
+     */
+    @Test
+    public void testShowaDaySaturday2045_StaysApril29() {
+        List<HolidayDate> holidays = calendar.calculate(2045);
+
+        // Showa Day (Apr 29 Sat) must stay on Apr 29 — no substitute
+        Optional<HolidayDate> showa = holidays.stream()
+                .filter(hd -> "Showa Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(showa.isPresent(), "Showa Day must be present in 2045");
+        assertEquals(showa.get().getDate(), LocalDate.of(2045, Month.APRIL, 29),
+                     "Showa Day 2045 (Saturday Apr 29) must stay on Apr 29 — no substitute per #125");
+
+        // No National Holiday sandwich on May 2 (Showa Day did not roll to May 1)
+        long may2sandwiches = holidays.stream()
+                .filter(hd -> "National Holiday".equals(hd.getHoliday().getName())
+                           && hd.getDate().equals(LocalDate.of(2045, Month.MAY, 2)))
+                .count();
+        assertEquals(may2sandwiches, 0L,
+                     "2045: no Golden Week sandwich on May 2 (Showa Day did not roll)");
+    }
+
+    // =========================================================================
+    // 5. CASCADING SUBSTITUTE HOLIDAYS IN GOLDEN WEEK
+    // =========================================================================
+    // When a Golden Week holiday falls on Sunday and the following Monday is
+    // already occupied by another GW holiday, the substitute must cascade to
+    // the next available weekday.  This is a KNOWN DEFECT in the current
+    // implementation — the tests below pin the CORRECT expected behaviour.
+    //
+    // Two collision patterns occur in 2026–2055:
+    //   (A) May 3 (Constitution Memorial Day) on Sunday → Mon May 4 blocked by
+    //       Greenery Day → Tue May 5 blocked by Children's Day → substitute: May 6
+    //       Years: 2026, 2037, 2043, 2048, 2054
+    //
+    //   (B) May 4 (Greenery Day) on Sunday → Mon May 5 blocked by Children's Day
+    //       → substitute: May 6
+    //       Years: 2031, 2036, 2042, 2053
+    // =========================================================================
+
+    /**
+     * Golden Week cascade cases where Constitution Memorial Day (May 3, Sunday)
+     * has its substitute cascade past May 4 and May 5 to May 6.
+     */
+    @DataProvider(name = "constitutionCascadeYears")
+    Iterator<Object[]> constitutionCascadeYears() {
+        return List.of(
+            new Object[]{2026},  // May 3 Sun, May 4 Mon (Greenery), May 5 Tue (Children's) → sub May 6 Wed
+            new Object[]{2037},  // same pattern
+            new Object[]{2043},  // same pattern
+            new Object[]{2048},  // same pattern
+            new Object[]{2054}   // same pattern
+        ).iterator();
+    }
+
+    @Test(dataProvider = "constitutionCascadeYears")
+    public void testConstitutionMemorialDayCascadeSubstitute(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+
+        // May 3 (natural date) should NOT appear in the output as May 3 —
+        // it falls on Sunday and its substitute cascades to May 6.
+        assertFalse(findByDate(holidays, LocalDate.of(year, Month.MAY, 3)).isPresent(),
+                    year + ": May 3 (Sunday) should not appear as an observed date");
+
+        // May 6 should be the cascaded substitute for Constitution Memorial Day
+        Optional<HolidayDate> sub = findByDate(holidays, LocalDate.of(year, Month.MAY, 6));
+        assertTrue(sub.isPresent(),
+                   year + ": Constitution Memorial Day substitute should be observed on May 6");
+        assertEquals(sub.get().getHoliday().getName(), "Constitution Memorial Day",
+                     year + ": May 6 holiday name should be Constitution Memorial Day");
+
+        // Greenery Day and Children's Day remain on their natural dates
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.MAY, 4)).isPresent(),
+                   year + ": Greenery Day should still be on May 4");
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.MAY, 5)).isPresent(),
+                   year + ": Children's Day should still be on May 5");
+    }
+
+    /**
+     * Golden Week cascade cases where Greenery Day (May 4, Sunday) has its
+     * substitute cascade past May 5 to May 6.
+     */
+    @DataProvider(name = "greeneryCascadeYears")
+    Iterator<Object[]> greeneryCascadeYears() {
+        return List.of(
+            new Object[]{2031},  // May 4 Sun, May 5 Mon (Children's Day) → sub May 6 Tue
+            new Object[]{2036},  // same pattern
+            new Object[]{2042},  // same pattern
+            new Object[]{2053}   // same pattern
+        ).iterator();
+    }
+
+    @Test(dataProvider = "greeneryCascadeYears")
+    public void testGreeneryDayCascadeSubstitute(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+
+        // May 4 (Sunday) should not appear as observed date directly
+        assertFalse(findByDate(holidays, LocalDate.of(year, Month.MAY, 4)).isPresent(),
+                    year + ": May 4 (Sunday) should not appear as an observed date");
+
+        // May 6 should be the cascaded substitute for Greenery Day
+        Optional<HolidayDate> sub = findByDate(holidays, LocalDate.of(year, Month.MAY, 6));
+        assertTrue(sub.isPresent(),
+                   year + ": Greenery Day substitute should be observed on May 6");
+        assertEquals(sub.get().getHoliday().getName(), "Greenery Day",
+                     year + ": May 6 holiday name should be Greenery Day");
+
+        // Children's Day remains on May 5
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.MAY, 5)).isPresent(),
+                   year + ": Children's Day should still be on May 5");
+    }
+
+    // =========================================================================
+    // 6. EMPEROR'S BIRTHDAY WEEKEND BEHAVIOUR (2026–2055)
+    // =========================================================================
+    // Emperor Naruhito's birthday is Feb 23.  The JP calendar uses
+    // {@code sundayToMonday()}: Sunday rolls +1 to Monday; Saturday stays on
+    // its natural date (no substitute under Japanese law, issue #125).
+    //
+    // Sunday years (→ Mon Feb 24): 2031, 2042, 2048, 2053
+    // Saturday years (stays Feb 23): 2030, 2036, 2041, 2047
+    // =========================================================================
+
+    /**
+     * Years where Feb 23 falls on Sunday: Emperor's Birthday rolls to the
+     * following Monday (Feb 24).
+     */
+    @DataProvider(name = "emperorsBirthdaySundayRollYears")
+    Iterator<Object[]> emperorsBirthdaySundayRollYears() {
+        return List.of(
+            new Object[]{2031, LocalDate.of(2031, Month.FEBRUARY, 24)},
+            new Object[]{2042, LocalDate.of(2042, Month.FEBRUARY, 24)},
+            new Object[]{2048, LocalDate.of(2048, Month.FEBRUARY, 24)},
+            new Object[]{2053, LocalDate.of(2053, Month.FEBRUARY, 24)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "emperorsBirthdaySundayRollYears")
+    public void testEmperorsBirthdaySundayRoll(int year, LocalDate expected) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByName(holidays, "Emperor's Birthday");
+        assertTrue(h.isPresent(), year + ": Emperor's Birthday must be present");
+        assertEquals(h.get().getDate(), expected,
+                     year + ": Emperor's Birthday should roll from Sunday Feb 23 to Monday Feb 24");
+    }
+
+    /**
+     * Years where Feb 23 falls on Saturday: Emperor's Birthday stays on its
+     * natural date (Feb 23).  Saturday holidays have no substitute under
+     * Japanese law (振替休日 applies only to Sunday, per issue #125).
+     */
+    @DataProvider(name = "emperorsBirthdaySaturdayYears")
+    Iterator<Object[]> emperorsBirthdaySaturdayYears() {
+        return List.of(
+            new Object[]{2030, LocalDate.of(2030, Month.FEBRUARY, 23)},
+            new Object[]{2036, LocalDate.of(2036, Month.FEBRUARY, 23)},
+            new Object[]{2041, LocalDate.of(2041, Month.FEBRUARY, 23)},
+            new Object[]{2047, LocalDate.of(2047, Month.FEBRUARY, 23)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "emperorsBirthdaySaturdayYears")
+    public void testEmperorsBirthdaySaturday_StaysOnSaturday(int year, LocalDate expected) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByName(holidays, "Emperor's Birthday");
+        assertTrue(h.isPresent(), year + ": Emperor's Birthday must be present");
+        assertEquals(h.get().getDate(), expected,
+                     year + ": Emperor's Birthday (Saturday Feb 23) must stay on Feb 23 — no substitute");
+    }
+
+    // =========================================================================
+    // 7. FULL-YEAR HOLIDAY COUNTS FOR REPRESENTATIVE YEARS
+    // =========================================================================
+    // Validates that the total observed holiday count matches expectation,
+    // guarding against missing entries or spurious sandwich days.
+    //
+    // Counts reflect the CORRECT expected behaviour after both known defects are
+    // fixed (Olympic overrides and cascading substitutes).  Duplicate-date
+    // detection is handled separately by testNoDuplicateDates.
+    //
+    //   2026: 17  (16 base + Silver Week sandwich Sep 22;
+    //               cascade sub May 6 for Constitution Memorial Day)
+    //   2030: 16  (no sandwich; Saturday holidays stay on natural date per #125)
+    //   2032: 17  (16 base + Silver Week sandwich Sep 21)
+    //   2035: 16  (various Sun rolls; no sandwich)
+    //   2040: 16  (New Year's Day Jan 1 Sun rolls Mon Jan 2)
+    //   2045: 16  (Showa Day Apr 29 Sat stays Apr 29 — no sandwich;
+    //               New Year's Day Jan 1 Sun rolls to Jan 2)
+    //   2050: 16  (New Year's Day Jan 1 Sat stays Jan 1 per #125;
+    //               Vernal Equinox Mar 20 Sun rolls Mon Mar 21)
+    //   2055: 16  (Vernal Equinox Mar 21 Sun rolls Mon Mar 22)
+    // =========================================================================
+
+    @DataProvider(name = "fullYearHolidayCount")
+    Iterator<Object[]> fullYearHolidayCount() {
+        return List.of(
+            new Object[]{2026, 17},
+            new Object[]{2030, 16},
+            new Object[]{2032, 17},
+            new Object[]{2035, 16},
+            new Object[]{2040, 16},
+            new Object[]{2045, 16},
+            new Object[]{2050, 16},
+            new Object[]{2055, 16}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "fullYearHolidayCount")
+    public void testFullYearHolidayCount(int year, int expected) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertEquals(holidays.size(), expected,
+                     year + ": expected " + expected + " observed holidays, got " + holidays.size()
+                     + " | dates: " + holidays.stream().map(h -> h.getDate().toString()).toList());
+    }
+
+    /**
+     * Validates that all observed dates within a given year are unique (no
+     * duplicate entries for the same date, which would indicate a defective
+     * roll producing two holidays on the same day).
+     */
+    @DataProvider(name = "yearsForDuplicateCheck")
+    Iterator<Object[]> yearsForDuplicateCheck() {
+        return List.of(
+            new Object[]{2026},
+            new Object[]{2031},
+            new Object[]{2036},
+            new Object[]{2037},
+            new Object[]{2042},
+            new Object[]{2043},
+            new Object[]{2048},
+            new Object[]{2053},
+            new Object[]{2054}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "yearsForDuplicateCheck")
+    public void testNoDuplicateDates(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        long distinctCount = holidays.stream()
+                .map(HolidayDate::getDate)
+                .distinct()
+                .count();
+        assertEquals(distinctCount, (long) holidays.size(),
+                     year + ": holiday list must not contain duplicate observed dates");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Optional<HolidayDate> findByName(List<HolidayDate> holidays, String name) {
+        return holidays.stream()
+                       .filter(hd -> name.equals(hd.getHoliday().getName()))
+                       .findFirst();
+    }
+
+    private Optional<HolidayDate> findByDate(List<HolidayDate> holidays, LocalDate date) {
+        return holidays.stream()
+                       .filter(hd -> date.equals(hd.getDate()))
+                       .findFirst();
+    }
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
@@ -57,16 +57,46 @@ public class HolidayCalendarServiceJPExtendedTest {
     }
 
     // =========================================================================
-    // 1. OLYMPIC YEAR OVERRIDES (2021)
+    // 1. OLYMPIC YEAR OVERRIDES (2020 AND 2021)
     // =========================================================================
-    // The Tokyo 2020 Olympics (held in 2021 due to COVID delay) caused three
-    // holidays to be relocated in 2021 by special government ordinance:
-    //   Sports Day (Jul 23), Marine Day (Jul 22), Mountain Day (Aug 9).
+    // The Tokyo 2020 Olympics special measures act relocated three holidays in
+    // both 2020 and 2021.
     //
-    // NOTE: The corresponding 2020 Olympic relocations (Sports Day Jul 24,
-    // Marine Day Jul 23, Mountain Day Aug 10) are not yet implemented and are
-    // tracked as a separate defect issue.
+    // 2021 relocations (implemented, #127):
+    //   Sports Day → Jul 23, Marine Day → Jul 22, Mountain Day → Aug 9
+    //
+    // 2020 relocations (NOT YET IMPLEMENTED — tracked as a separate defect):
+    //   Sports Day → Jul 24, Marine Day → Jul 23, Mountain Day → Aug 10
+    // The 2020 tests below are disabled and will be re-enabled once fixed.
     // =========================================================================
+
+    // 2020 tests disabled — bug tracked in separate issue
+    @Test(enabled = false)
+    public void testSportsDayOlympic2020() {
+        List<HolidayDate> holidays = calendar.calculate(2020);
+        Optional<HolidayDate> h = findByName(holidays, "Sports Day");
+        assertTrue(h.isPresent(), "Sports Day must be present in 2020");
+        assertEquals(h.get().getDate(), LocalDate.of(2020, Month.JULY, 24),
+                     "Sports Day 2020 should be Jul 24 (Olympic relocation)");
+    }
+
+    @Test(enabled = false)
+    public void testMarineDayOlympic2020() {
+        List<HolidayDate> holidays = calendar.calculate(2020);
+        Optional<HolidayDate> h = findByName(holidays, "Marine Day");
+        assertTrue(h.isPresent(), "Marine Day must be present in 2020");
+        assertEquals(h.get().getDate(), LocalDate.of(2020, Month.JULY, 23),
+                     "Marine Day 2020 should be Jul 23 (Olympic relocation)");
+    }
+
+    @Test(enabled = false)
+    public void testMountainDayOlympic2020() {
+        List<HolidayDate> holidays = calendar.calculate(2020);
+        Optional<HolidayDate> h = findByName(holidays, "Mountain Day");
+        assertTrue(h.isPresent(), "Mountain Day must be present in 2020");
+        assertEquals(h.get().getDate(), LocalDate.of(2020, Month.AUGUST, 10),
+                     "Mountain Day 2020 should be Aug 10 (Olympic relocation)");
+    }
 
     /**
      * Sports Day 2021 was relocated from its normal 2nd-Monday-in-October

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYExtendedTest.java
@@ -1,0 +1,260 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.*;
+
+/**
+ * Extended integration tests for {@link HolidayCalendarServiceJPY} covering the
+ * 2026–2055 target range.
+ *
+ * <p>The JPY (Bank of Japan) calendar adds three non-rollable operational
+ * closures to the base JP national holiday set:
+ * <ul>
+ *   <li>January 2 — Year-Start Holiday</li>
+ *   <li>January 3 — Year-Start Holiday</li>
+ *   <li>December 31 — Year-End Holiday</li>
+ * </ul>
+ * All three are {@code rollable(false)}, meaning they are observed on their
+ * natural calendar date even if that date falls on Saturday or Sunday.
+ *
+ * <p>Tests in this class cover:
+ * <ol>
+ *   <li>Jan 2, Jan 3, and Dec 31 presence across every year 2026–2055</li>
+ *   <li>Non-rollable behaviour of BOJ closures on weekends (spot-checks)</li>
+ *   <li>JPY-specific full-year holiday count (base JP count + 3)</li>
+ *   <li>New Year's Day roll collision with Jan 2 Year-Start Holiday — a known
+ *       cascading-substitute scenario unique to the JPY calendar</li>
+ * </ol>
+ */
+public class HolidayCalendarServiceJPYExtendedTest {
+
+    private HolidayCalendar calendar;
+
+    @BeforeClass
+    public void setup() {
+        this.calendar = new HolidayCalendarServiceJPY().getHolidayCalendar();
+    }
+
+    // =========================================================================
+    // 1. BOJ CLOSURES PRESENT IN EVERY YEAR 2026–2055
+    // =========================================================================
+    // Jan 2, Jan 3, and Dec 31 must appear in every year regardless of
+    // day-of-week.  This sweep confirms complete 30-year coverage.
+    // =========================================================================
+
+    @DataProvider(name = "allYears2026to2055")
+    Iterator<Object[]> allYears2026to2055() {
+        return java.util.stream.IntStream.rangeClosed(2026, 2055)
+                .mapToObj(y -> new Object[]{y})
+                .iterator();
+    }
+
+    @Test(dataProvider = "allYears2026to2055")
+    public void testJan2PresentEveryYear(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByDate(holidays, LocalDate.of(year, Month.JANUARY, 2));
+        assertTrue(h.isPresent(),
+                   year + ": Jan 2 Year-Start Holiday must be present every year");
+        assertEquals(h.get().getHoliday().getName(), "Year-Start Holiday",
+                     year + ": Jan 2 holiday name");
+    }
+
+    @Test(dataProvider = "allYears2026to2055")
+    public void testJan3PresentEveryYear(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByDate(holidays, LocalDate.of(year, Month.JANUARY, 3));
+        assertTrue(h.isPresent(),
+                   year + ": Jan 3 Year-Start Holiday must be present every year");
+        assertEquals(h.get().getHoliday().getName(), "Year-Start Holiday",
+                     year + ": Jan 3 holiday name");
+    }
+
+    @Test(dataProvider = "allYears2026to2055")
+    public void testDec31PresentEveryYear(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByDate(holidays, LocalDate.of(year, Month.DECEMBER, 31));
+        assertTrue(h.isPresent(),
+                   year + ": Dec 31 Year-End Holiday must be present every year");
+        assertEquals(h.get().getHoliday().getName(), "Year-End Holiday",
+                     year + ": Dec 31 holiday name");
+    }
+
+    // =========================================================================
+    // 2. BOJ CLOSURES ARE NON-ROLLABLE — WEEKEND SPOT-CHECKS
+    // =========================================================================
+    // Because rollable=false, a Jan 2 or Jan 3 or Dec 31 falling on Saturday or
+    // Sunday should NOT produce an extra Monday entry; the holiday appears only
+    // on the natural calendar date.
+    // =========================================================================
+
+    /**
+     * Days where Jan 2 falls on Saturday or Sunday in 2026–2055.
+     *
+     * <p>Jan 2 is Saturday in: 2027 (Sat), 2032 (Sat), 2038 (Sat), 2049 (Sat).
+     * Jan 2 is Sunday in: 2028 (Sun), 2033 (Sun), 2039 (Sun), 2044 (Sun), 2050 (Sun).
+     */
+    @DataProvider(name = "jan2OnWeekend")
+    Iterator<Object[]> jan2OnWeekend() {
+        return List.of(
+            new Object[]{2027, LocalDate.of(2027, Month.JANUARY, 2)},  // Saturday
+            new Object[]{2028, LocalDate.of(2028, Month.JANUARY, 2)},  // Sunday
+            new Object[]{2032, LocalDate.of(2032, Month.JANUARY, 2)},  // Saturday (note: Thu)
+            new Object[]{2033, LocalDate.of(2033, Month.JANUARY, 2)}   // Sunday
+        ).iterator();
+    }
+
+    @Test(dataProvider = "jan2OnWeekend")
+    public void testJan2NotRolledOnWeekend(int year, LocalDate naturalDate) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        // The holiday must be on the natural date itself
+        Optional<HolidayDate> h = findByDate(holidays, naturalDate);
+        assertTrue(h.isPresent(),
+                   year + ": Jan 2 Year-Start Holiday should be on its natural date " + naturalDate);
+        // No extra Monday substitute should appear at Jan 3 or Jan 4 for this reason
+        // (Jan 3 is its own Year-Start Holiday, so we check Jan 4 is not an extra entry)
+        long jan2holidayCount = holidays.stream()
+                .filter(hd -> "Year-Start Holiday".equals(hd.getHoliday().getName())
+                           && hd.getDate().equals(naturalDate))
+                .count();
+        assertEquals(jan2holidayCount, 1L,
+                     year + ": exactly one Year-Start Holiday entry on Jan 2");
+    }
+
+    /**
+     * Dec 31 falls on Sunday in 2028, 2034, 2045, 2051; on Saturday in 2027,
+     * 2033, 2039, 2044, 2050.  Verify no Monday roll.
+     */
+    @DataProvider(name = "dec31OnWeekend")
+    Iterator<Object[]> dec31OnWeekend() {
+        return List.of(
+            new Object[]{2027},  // Dec 31 Sat
+            new Object[]{2028},  // Dec 31 Sun
+            new Object[]{2033},  // Dec 31 Sun
+            new Object[]{2034},  // Dec 31 Mon — verify no spurious Tue
+            new Object[]{2039},  // Dec 31 Sat
+            new Object[]{2044},  // Dec 31 Sat
+            new Object[]{2045},  // Dec 31 Sun
+            new Object[]{2050}   // Dec 31 Sat
+        ).iterator();
+    }
+
+    @Test(dataProvider = "dec31OnWeekend")
+    public void testDec31NotRolledOnWeekend(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> h = findByDate(holidays, LocalDate.of(year, Month.DECEMBER, 31));
+        assertTrue(h.isPresent(),
+                   year + ": Dec 31 Year-End Holiday must appear on Dec 31 itself");
+        // Verify no Jan 1 of the following year is produced as a Year-End Holiday roll
+        long nextJan1yearEnd = holidays.stream()
+                .filter(hd -> "Year-End Holiday".equals(hd.getHoliday().getName()))
+                .count();
+        assertEquals(nextJan1yearEnd, 1L,
+                     year + ": exactly one Year-End Holiday entry (no spurious roll)");
+    }
+
+    // =========================================================================
+    // 3. JPY FULL-YEAR HOLIDAY COUNT (representative years)
+    // =========================================================================
+    // JPY count = JP base count + 3 (Jan 2, Jan 3, Dec 31).
+    //
+    // 2026: JP=17 (Silver Week sandwich) + 3 BOJ = 20
+    // 2030: JP=16 + 3 BOJ = 19
+    // 2032: JP=17 (Silver Week sandwich) + 3 BOJ = 20
+    // 2035: JP=16 + 3 BOJ = 19
+    // 2040: JP=16 + 3 BOJ = 19.  Jan 1 Sun rolls to Jan 2; cascade incorrectly
+    //        treats Year-Start Holiday as a blocker (tracked defect), so New
+    //        Year's Day cascades to Jan 4 rather than coexisting on Jan 2.
+    // 2045: JP=16 (Showa Day Apr 29 Sat stays, no Golden Week sandwich) + 3 BOJ = 19
+    // 2050: JP=16 + 3 BOJ = 19.  Jan 1 Sat stays Jan 1 (no roll per #125).
+    // 2055: JP=16 + 3 BOJ = 19
+    // =========================================================================
+
+    @DataProvider(name = "jpyFullYearHolidayCount")
+    Iterator<Object[]> jpyFullYearHolidayCount() {
+        return List.of(
+            new Object[]{2026, 20},  // JP=17 (Silver Week) + 3 BOJ
+            new Object[]{2030, 19},  // JP=16 + 3 BOJ
+            new Object[]{2032, 20},  // JP=17 (Silver Week) + 3 BOJ
+            new Object[]{2035, 19},  // JP=16 + 3 BOJ
+            new Object[]{2040, 19},  // JP=16 + 3 BOJ
+            new Object[]{2045, 19},  // JP=16 (Showa Day Sat, no sandwich) + 3 BOJ
+            new Object[]{2050, 19},  // JP=16 + 3 BOJ (Jan 1 Sat stays Jan 1)
+            new Object[]{2055, 19}   // JP=16 + 3 BOJ
+        ).iterator();
+    }
+
+    @Test(dataProvider = "jpyFullYearHolidayCount")
+    public void testJPYFullYearHolidayCount(int year, int expected) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertEquals(holidays.size(), expected,
+                     year + ": expected " + expected + " JPY holidays, got " + holidays.size()
+                     + " | dates: " + holidays.stream().map(h -> h.getDate().toString()).toList());
+    }
+
+    // =========================================================================
+    // 5. SPOT-CHECK REPRESENTATIVE YEARS — ALL THREE BOJ CLOSURES CORRECT
+    // =========================================================================
+
+    @DataProvider(name = "jpySpotCheckYears")
+    Iterator<Object[]> jpySpotCheckYears() {
+        return List.of(
+            new Object[]{2026},
+            new Object[]{2030},
+            new Object[]{2037},
+            new Object[]{2043},
+            new Object[]{2049},
+            new Object[]{2055}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "jpySpotCheckYears")
+    public void testBOJClosuresSpotCheck(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.JANUARY, 2)).isPresent(),
+                   year + ": Jan 2 Year-Start Holiday present");
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.JANUARY, 3)).isPresent(),
+                   year + ": Jan 3 Year-Start Holiday present");
+        assertTrue(findByDate(holidays, LocalDate.of(year, Month.DECEMBER, 31)).isPresent(),
+                   year + ": Dec 31 Year-End Holiday present");
+    }
+
+    // =========================================================================
+    // Helpers
+    // =========================================================================
+
+    private Optional<HolidayDate> findByDate(List<HolidayDate> holidays, LocalDate date) {
+        return holidays.stream()
+                       .filter(hd -> date.equals(hd.getDate()))
+                       .findFirst();
+    }
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/jp/AutumnalEquinoxDayExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/jp/AutumnalEquinoxDayExtendedTest.java
@@ -1,0 +1,165 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.jp;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Extended parametrized tests for {@link AutumnalEquinoxDay} covering every
+ * year in the 2026–2055 target range.
+ *
+ * <p>Expected raw dates are derived from the NAOJ formula:
+ * <pre>
+ *   day = floor(23.2488 + 0.242194 * (year - 1980) - floor((year - 1980) / 4))
+ * </pre>
+ * The formula yields Sep 22 in 2028, 2032, 2036, 2040, 2044, 2045, 2048, 2049,
+ * 2052, and 2053; all other years in this range give Sep 23.
+ *
+ * <p>Years where the raw date falls on a Sunday (rolls to Monday at service level):
+ * 2029 (Sep 23 Sun → Sep 24 Mon), 2035 (Sep 23 Sun → Sep 24 Mon),
+ * 2046 (Sep 23 Sun → Sep 24 Mon), 2052 (Sep 22 Sun → Sep 23 Mon).
+ * These rolls are tested at the {@link HolidayCalendarServiceJPExtendedTest}
+ * integration level; this class tests only the raw formula output.
+ */
+public class AutumnalEquinoxDayExtendedTest {
+
+    private final AutumnalEquinoxDay observance = new AutumnalEquinoxDay();
+
+    // ── 2026–2055 full parametrized sweep ─────────────────────────────────────
+
+    /**
+     * All 30 autumnal equinox raw dates from 2026 to 2055.
+     *
+     * <p>Sep 22 years: 2028, 2032, 2036, 2040, 2044, 2045, 2048, 2049, 2052, 2053.
+     * Sep 23 years: 2026, 2027, 2029–2031, 2033–2035, 2037–2039, 2041–2043,
+     * 2046–2047, 2050–2051, 2054–2055.
+     */
+    @DataProvider(name = "autumnalEquinox2026to2055")
+    Iterator<Object[]> autumnalEquinox2026to2055() {
+        return List.of(
+            new Object[]{2026, LocalDate.of(2026, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2027, LocalDate.of(2027, Month.SEPTEMBER, 23)},  // Thu
+            new Object[]{2028, LocalDate.of(2028, Month.SEPTEMBER, 22)},  // Fri
+            new Object[]{2029, LocalDate.of(2029, Month.SEPTEMBER, 23)},  // Sun (rolls at service level)
+            new Object[]{2030, LocalDate.of(2030, Month.SEPTEMBER, 23)},  // Mon
+            new Object[]{2031, LocalDate.of(2031, Month.SEPTEMBER, 23)},  // Tue
+            new Object[]{2032, LocalDate.of(2032, Month.SEPTEMBER, 22)},  // Wed
+            new Object[]{2033, LocalDate.of(2033, Month.SEPTEMBER, 23)},  // Fri
+            new Object[]{2034, LocalDate.of(2034, Month.SEPTEMBER, 23)},  // Sat
+            new Object[]{2035, LocalDate.of(2035, Month.SEPTEMBER, 23)},  // Sun (rolls at service level)
+            new Object[]{2036, LocalDate.of(2036, Month.SEPTEMBER, 22)},  // Mon
+            new Object[]{2037, LocalDate.of(2037, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2038, LocalDate.of(2038, Month.SEPTEMBER, 23)},  // Thu
+            new Object[]{2039, LocalDate.of(2039, Month.SEPTEMBER, 23)},  // Fri
+            new Object[]{2040, LocalDate.of(2040, Month.SEPTEMBER, 22)},  // Sat
+            new Object[]{2041, LocalDate.of(2041, Month.SEPTEMBER, 23)},  // Mon
+            new Object[]{2042, LocalDate.of(2042, Month.SEPTEMBER, 23)},  // Tue
+            new Object[]{2043, LocalDate.of(2043, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2044, LocalDate.of(2044, Month.SEPTEMBER, 22)},  // Thu
+            new Object[]{2045, LocalDate.of(2045, Month.SEPTEMBER, 22)},  // Fri
+            new Object[]{2046, LocalDate.of(2046, Month.SEPTEMBER, 23)},  // Sun (rolls at service level)
+            new Object[]{2047, LocalDate.of(2047, Month.SEPTEMBER, 23)},  // Mon
+            new Object[]{2048, LocalDate.of(2048, Month.SEPTEMBER, 22)},  // Tue
+            new Object[]{2049, LocalDate.of(2049, Month.SEPTEMBER, 22)},  // Wed
+            new Object[]{2050, LocalDate.of(2050, Month.SEPTEMBER, 23)},  // Fri
+            new Object[]{2051, LocalDate.of(2051, Month.SEPTEMBER, 23)},  // Sat
+            new Object[]{2052, LocalDate.of(2052, Month.SEPTEMBER, 22)},  // Sun (rolls at service level)
+            new Object[]{2053, LocalDate.of(2053, Month.SEPTEMBER, 22)},  // Mon
+            new Object[]{2054, LocalDate.of(2054, Month.SEPTEMBER, 23)},  // Wed
+            new Object[]{2055, LocalDate.of(2055, Month.SEPTEMBER, 23)}   // Thu
+        ).iterator();
+    }
+
+    /**
+     * Verifies that the NAOJ formula produces the expected raw date for every
+     * year in 2026–2055.
+     */
+    @Test(dataProvider = "autumnalEquinox2026to2055")
+    public void testAutumnalEquinoxRawDate(int year, LocalDate expected) {
+        LocalDate actual = observance.apply(year);
+        assertNotNull(actual, "AutumnalEquinoxDay should not return null for " + year);
+        assertEquals(actual, expected,
+                     "Autumnal Equinox Day raw formula date for " + year);
+    }
+
+    // ── Sep 22 vs Sep 23 boundary spot-checks ─────────────────────────────────
+
+    /**
+     * Verifies the transition between Sep-23 and Sep-22 years at representative
+     * boundaries within the 2026–2055 range.
+     */
+    @DataProvider(name = "autumnalEquinoxDayValueCases")
+    Iterator<Object[]> autumnalEquinoxDayValueCases() {
+        return List.of(
+            // Sep 23 years
+            new Object[]{2026, 23},
+            new Object[]{2030, 23},
+            new Object[]{2037, 23},
+            new Object[]{2047, 23},
+            new Object[]{2054, 23},
+            // Sep 22 years
+            new Object[]{2028, 22},
+            new Object[]{2032, 22},
+            new Object[]{2044, 22},
+            new Object[]{2045, 22},
+            new Object[]{2049, 22}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "autumnalEquinoxDayValueCases")
+    public void testAutumnalEquinoxDayOfMonth(int year, int expectedDay) {
+        assertEquals(observance.apply(year).getDayOfMonth(), expectedDay,
+                     "Autumnal Equinox day-of-month for " + year);
+    }
+
+    // ── Sunday-roll years: raw date is Sunday ─────────────────────────────────
+
+    /**
+     * Confirms that the raw formula output for Sunday-roll years is indeed a
+     * Sunday.  The actual observed (rolled) date is tested at the integration
+     * layer in {@link HolidayCalendarServiceJPExtendedTest}.
+     */
+    @DataProvider(name = "autumnalEquinoxSundayRawYears")
+    Iterator<Object[]> autumnalEquinoxSundayRawYears() {
+        return List.of(
+            new Object[]{2029, LocalDate.of(2029, Month.SEPTEMBER, 23)},
+            new Object[]{2035, LocalDate.of(2035, Month.SEPTEMBER, 23)},
+            new Object[]{2046, LocalDate.of(2046, Month.SEPTEMBER, 23)},
+            new Object[]{2052, LocalDate.of(2052, Month.SEPTEMBER, 22)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "autumnalEquinoxSundayRawYears")
+    public void testAutumnalEquinoxRawDateIsSunday(int year, LocalDate expectedSunday) {
+        LocalDate raw = observance.apply(year);
+        assertEquals(raw, expectedSunday,
+                     "Autumnal Equinox raw date for " + year + " should be a Sunday");
+        assertEquals(raw.getDayOfWeek(), java.time.DayOfWeek.SUNDAY,
+                     "Raw autumnal equinox date for " + year + " must be SUNDAY");
+    }
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/jp/VernalEquinoxDayExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/jp/VernalEquinoxDayExtendedTest.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.jp;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+/**
+ * Extended parametrized tests for {@link VernalEquinoxDay} covering every year
+ * in the 2026–2055 target range.
+ *
+ * <p>Expected dates are derived from the NAOJ formula:
+ * <pre>
+ *   day = floor(20.8431 + 0.242194 * (year - 1980) - floor((year - 1980) / 4))
+ * </pre>
+ * The formula yields March 20 for most years in this range, but gives March 21 in
+ * 2027, 2031, 2035, 2039, 2043, 2047, 2051, and 2055 — all years of the form
+ * (year − 1980) mod 4 == 3.  No March 22 results occur before 2100.
+ *
+ * <p>The rolling of these raw dates (when Sunday → Monday) is tested at the
+ * {@link HolidayCalendarServiceJPExtendedTest} integration level; this class
+ * tests only the observance formula output.
+ */
+public class VernalEquinoxDayExtendedTest {
+
+    private final VernalEquinoxDay observance = new VernalEquinoxDay();
+
+    // ── 2026–2055 full parametrized sweep ─────────────────────────────────────
+
+    /**
+     * All 30 vernal equinox dates from 2026 to 2055.
+     *
+     * <p>Mar 21 years: 2027, 2031, 2035, 2039, 2043, 2047, 2051, 2055.
+     * Mar 20 years: all remaining (2026, 2028–2030, 2032–2034, 2036–2038,
+     * 2040–2042, 2044–2046, 2048–2050, 2052–2054).
+     */
+    @DataProvider(name = "vernalEquinox2026to2055")
+    Iterator<Object[]> vernalEquinox2026to2055() {
+        return List.of(
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 20)},  // Fri
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 21)},  // Sun (rolls at service level)
+            new Object[]{2028, LocalDate.of(2028, Month.MARCH, 20)},  // Mon
+            new Object[]{2029, LocalDate.of(2029, Month.MARCH, 20)},  // Tue
+            new Object[]{2030, LocalDate.of(2030, Month.MARCH, 20)},  // Wed
+            new Object[]{2031, LocalDate.of(2031, Month.MARCH, 21)},  // Fri
+            new Object[]{2032, LocalDate.of(2032, Month.MARCH, 20)},  // Sat (no roll — Sat not rollable)
+            new Object[]{2033, LocalDate.of(2033, Month.MARCH, 20)},  // Sun (rolls at service level)
+            new Object[]{2034, LocalDate.of(2034, Month.MARCH, 20)},  // Mon
+            new Object[]{2035, LocalDate.of(2035, Month.MARCH, 21)},  // Wed
+            new Object[]{2036, LocalDate.of(2036, Month.MARCH, 20)},  // Thu
+            new Object[]{2037, LocalDate.of(2037, Month.MARCH, 20)},  // Fri
+            new Object[]{2038, LocalDate.of(2038, Month.MARCH, 20)},  // Sat
+            new Object[]{2039, LocalDate.of(2039, Month.MARCH, 21)},  // Mon
+            new Object[]{2040, LocalDate.of(2040, Month.MARCH, 20)},  // Tue
+            new Object[]{2041, LocalDate.of(2041, Month.MARCH, 20)},  // Wed
+            new Object[]{2042, LocalDate.of(2042, Month.MARCH, 20)},  // Thu
+            new Object[]{2043, LocalDate.of(2043, Month.MARCH, 21)},  // Sat
+            new Object[]{2044, LocalDate.of(2044, Month.MARCH, 20)},  // Sun (rolls at service level)
+            new Object[]{2045, LocalDate.of(2045, Month.MARCH, 20)},  // Mon
+            new Object[]{2046, LocalDate.of(2046, Month.MARCH, 20)},  // Tue
+            new Object[]{2047, LocalDate.of(2047, Month.MARCH, 21)},  // Thu
+            new Object[]{2048, LocalDate.of(2048, Month.MARCH, 20)},  // Fri
+            new Object[]{2049, LocalDate.of(2049, Month.MARCH, 20)},  // Sat
+            new Object[]{2050, LocalDate.of(2050, Month.MARCH, 20)},  // Sun (rolls at service level)
+            new Object[]{2051, LocalDate.of(2051, Month.MARCH, 21)},  // Tue
+            new Object[]{2052, LocalDate.of(2052, Month.MARCH, 20)},  // Wed
+            new Object[]{2053, LocalDate.of(2053, Month.MARCH, 20)},  // Thu
+            new Object[]{2054, LocalDate.of(2054, Month.MARCH, 20)},  // Fri
+            new Object[]{2055, LocalDate.of(2055, Month.MARCH, 21)}   // Sun (rolls at service level)
+        ).iterator();
+    }
+
+    /**
+     * Verifies that the NAOJ formula produces the expected raw date for every
+     * year in 2026–2055.  Raw means the formula output before any Sunday roll.
+     */
+    @Test(dataProvider = "vernalEquinox2026to2055")
+    public void testVernalEquinoxRawDate(int year, LocalDate expected) {
+        LocalDate actual = observance.apply(year);
+        assertNotNull(actual, "VernalEquinoxDay should not return null for " + year);
+        assertEquals(actual, expected,
+                     "Vernal Equinox Day raw formula date for " + year);
+    }
+
+    // ── Boundary spot-checks: Mar 20 vs Mar 21 years ─────────────────────────
+
+    /**
+     * Spot-checks that verify the formula transition from Mar 20 to Mar 21 at
+     * the four-year cycle boundary (2030→2031, 2034→2035, 2046→2047).
+     */
+    @DataProvider(name = "vernalEquinoxBoundaryPairs")
+    Iterator<Object[]> vernalEquinoxBoundaryPairs() {
+        return List.of(
+            // Year before Mar-21 / Year of Mar-21
+            new Object[]{2030, 20, 2031, 21},
+            new Object[]{2034, 20, 2035, 21},
+            new Object[]{2046, 20, 2047, 21},
+            new Object[]{2050, 20, 2051, 21}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "vernalEquinoxBoundaryPairs")
+    public void testVernalEquinoxBoundaryTransition(int yearBefore, int dayBefore,
+                                                     int yearAfter, int dayAfter) {
+        assertEquals(observance.apply(yearBefore).getDayOfMonth(), dayBefore,
+                     "Vernal Equinox should be Mar " + dayBefore + " in " + yearBefore);
+        assertEquals(observance.apply(yearAfter).getDayOfMonth(), dayAfter,
+                     "Vernal Equinox should be Mar " + dayAfter + " in " + yearAfter);
+    }
+}


### PR DESCRIPTION
## Summary

- Adds four extended test classes that complete the 30-year audit of `HolidayCalendarServiceJP` and `HolidayCalendarServiceJPY` required by issue #116
- All 1,001 APAC module tests pass
- Two remaining defects uncovered during the audit are filed as new sub-issues (#132, #133) with disabled sentinel tests in place

## New Test Classes

| Class | What it covers |
|-------|----------------|
| `HolidayCalendarServiceJPExtendedTest` | Equinox observed dates all 30 years; Silver Week sandwiches; Golden Week cascades; Emperor's Birthday weekend; full-year counts 2026–2055; Olympic 2021 overrides |
| `HolidayCalendarServiceJPYExtendedTest` | BOJ closures (Jan 2, Jan 3, Dec 31) every year 2026–2055; non-rollable weekend spot-checks; JPY full-year counts |
| `AutumnalEquinoxDayExtendedTest` | Raw NAOJ formula output for every year 2026–2055 |
| `VernalEquinoxDayExtendedTest` | Raw NAOJ formula output for every year 2026–2055 |

## Audit Findings

| # | Finding | Status |
|---|---------|--------|
| 1 | No lookup tables — NAOJ formula valid through 2099 | ✅ Nothing to extend |
| 2 | Saturday no-roll (`sundayToMonday()`) — correct per Japanese law | ✅ Fixed by #125 |
| 3 | Cascading 振替休日 when Monday is occupied | ✅ Fixed by #126 |
| 4 | Sandwich day (国民の休日) logic | ✅ Working correctly |
| 5 | Special closures (2019 imperial transition) | ✅ Modelled as `SpecialAnniversary` |
| 6 | Olympic 2021 relocations | ✅ Fixed by #127 |
| 7 | Olympic 2020 relocations | ❌ New issue #132 |
| 8 | JPY cascade bypasses BOJ Year-Start Holiday | ❌ New issue #133 |

## Test plan

- [x] `mvn -pl holiday-calendar-apac test` — 1,001 tests, 0 failures
- [x] 4 extended test classes run clean (304 test invocations)
- [x] Disabled sentinels for issues #132 and #133 in place