### PR TITLE
#132 Fix JP/JPY 2020 Tokyo Olympics holiday relocations

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidays.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidays.java
@@ -145,7 +145,10 @@ class JapaneseHolidays {
                     .type(Holiday.Type.FLOATING)
                     .rollable(true)
                     .observance(y -> {
-                        if (y == 2021) return LocalDate.of(2021, Month.AUGUST, 9);
+                        // Olympic relocations: lambda returns final observed date directly,
+                        // bypassing the rollable(true) pipeline (neither date is a Sunday).
+                        if (y == 2020) return LocalDate.of(2020, Month.AUGUST, 10);
+                        if (y == 2021) return LocalDate.of(2021, Month.AUGUST,  9);
                         return y >= 2016 ? LocalDate.of(y, Month.AUGUST, 11) : null;
                     })
                     .build(),

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/jp/MarineDay.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/jp/MarineDay.java
@@ -40,6 +40,9 @@ public class MarineDay extends AbstractObservance {
 
     @Override
     protected LocalDate computeDate(int year) {
+        if (year == 2020) {
+            return LocalDate.of(2020, Month.JULY, 23);
+        }
         if (year == 2021) {
             return LocalDate.of(2021, Month.JULY, 22);
         }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/jp/SportsDay.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/jp/SportsDay.java
@@ -41,6 +41,9 @@ public class SportsDay extends AbstractObservance {
 
     @Override
     protected LocalDate computeDate(int year) {
+        if (year == 2020) {
+            return LocalDate.of(2020, Month.JULY, 24);
+        }
         if (year == 2021) {
             return LocalDate.of(2021, Month.JULY, 23);
         }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
@@ -70,8 +70,8 @@ public class HolidayCalendarServiceJPExtendedTest {
     // The 2020 tests below are disabled and will be re-enabled once fixed.
     // =========================================================================
 
-    // 2020 tests disabled — bug tracked in separate issue
-    @Test(enabled = false)
+    // 2020 relocations implemented — issue #132
+    @Test
     public void testSportsDayOlympic2020() {
         List<HolidayDate> holidays = calendar.calculate(2020);
         Optional<HolidayDate> h = findByName(holidays, "Sports Day");
@@ -80,7 +80,7 @@ public class HolidayCalendarServiceJPExtendedTest {
                      "Sports Day 2020 should be Jul 24 (Olympic relocation)");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testMarineDayOlympic2020() {
         List<HolidayDate> holidays = calendar.calculate(2020);
         Optional<HolidayDate> h = findByName(holidays, "Marine Day");
@@ -89,7 +89,7 @@ public class HolidayCalendarServiceJPExtendedTest {
                      "Marine Day 2020 should be Jul 23 (Olympic relocation)");
     }
 
-    @Test(enabled = false)
+    @Test
     public void testMountainDayOlympic2020() {
         List<HolidayDate> holidays = calendar.calculate(2020);
         Optional<HolidayDate> h = findByName(holidays, "Mountain Day");

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPExtendedTest.java
@@ -614,7 +614,7 @@ public class HolidayCalendarServiceJPExtendedTest {
                 .map(HolidayDate::getDate)
                 .distinct()
                 .count();
-        assertEquals(distinctCount, (long) holidays.size(),
+        assertEquals(distinctCount, holidays.size(),
                      year + ": holiday list must not contain duplicate observed dates");
     }
 

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
@@ -293,7 +293,7 @@ public class HolidayCalendarServiceJPTest {
     public void testJP_NoDateDuplicatesIn2021() {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2021);
         long uniqueDates = holidays.stream().map(HolidayDate::date).distinct().count();
-        assertEquals(uniqueDates, (long) holidays.size(),
+        assertEquals(uniqueDates, holidays.size(),
                 "2021: no two holidays should share a date");
     }
 

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
@@ -249,12 +249,31 @@ public class HolidayCalendarServiceJPTest {
         assertEquals(count, 0L, "2021: " + name + " must NOT appear on formula date " + formulaDate);
     }
 
+    @DataProvider(name = "jp2020FormulaDatesMustBeAbsent")
+    public Object[][] jp2020FormulaDatesMustBeAbsent() {
+        return new Object[][] {
+            { "Marine Day",   LocalDate.of(2020, Month.JULY,    20) },
+            { "Sports Day",   LocalDate.of(2020, Month.OCTOBER, 12) },
+            { "Mountain Day", LocalDate.of(2020, Month.AUGUST,  11) },
+        };
+    }
+
+    @Test(dataProvider = "jp2020FormulaDatesMustBeAbsent")
+    public void testJP_2020_FormulaDateAbsent(String name, LocalDate formulaDate) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2020);
+        long count = holidays.stream()
+                .filter(hd -> name.equals(hd.getHoliday().getName())
+                           && formulaDate.equals(hd.getDate()))
+                .count();
+        assertEquals(count, 0L, "2020: " + name + " must NOT appear on formula date " + formulaDate);
+    }
+
     @DataProvider(name = "jpBoundaryYears")
     public Object[][] jpBoundaryYears() {
         return new Object[][] {
-            { 2020, "Marine Day",   LocalDate.of(2020, Month.JULY,    20) },
-            { 2020, "Sports Day",   LocalDate.of(2020, Month.OCTOBER, 12) },
-            { 2020, "Mountain Day", LocalDate.of(2020, Month.AUGUST,  11) },
+            { 2020, "Marine Day",   LocalDate.of(2020, Month.JULY,    23) },
+            { 2020, "Sports Day",   LocalDate.of(2020, Month.JULY,    24) },
+            { 2020, "Mountain Day", LocalDate.of(2020, Month.AUGUST,  10) },
             { 2022, "Marine Day",   LocalDate.of(2022, Month.JULY,    18) },
             { 2022, "Sports Day",   LocalDate.of(2022, Month.OCTOBER, 10) },
             { 2022, "Mountain Day", LocalDate.of(2022, Month.AUGUST,  11) },
@@ -262,12 +281,12 @@ public class HolidayCalendarServiceJPTest {
     }
 
     @Test(dataProvider = "jpBoundaryYears")
-    public void testJP_BoundaryYears_FormulaUnchanged(int year, String name, LocalDate expected) {
+    public void testJP_BoundaryYears_OlympicAndFormulaYears(int year, String name, LocalDate expected) {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
         Optional<HolidayDate> h = findByName(holidays, name);
         assertTrue(h.isPresent(), year + ": " + name + " must be present");
         assertEquals(h.get().getDate(), expected,
-                year + ": " + name + " must use formula, not 2021 override");
+                year + ": " + name + " must be on the expected date");
     }
 
     @Test

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
@@ -173,12 +173,51 @@ public class HolidayCalendarServiceJPYTest {
         assertEquals(count, 0L, "2021: " + name + " must NOT appear on formula date " + formulaDate);
     }
 
+    // ── 2020 Tokyo Olympics holiday relocations (issue #132) ─────────────────
+
+    @DataProvider(name = "jpy2020OlympicsHolidays")
+    public Object[][] jpy2020OlympicsHolidays() {
+        return new Object[][] {
+            { "Marine Day",   LocalDate.of(2020, Month.JULY,    23) },
+            { "Sports Day",   LocalDate.of(2020, Month.JULY,    24) },
+            { "Mountain Day", LocalDate.of(2020, Month.AUGUST,  10) },
+        };
+    }
+
+    @Test(dataProvider = "jpy2020OlympicsHolidays")
+    public void testJPY_2020_TokyoOlympicsRelocations(String name, LocalDate expected) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2020);
+        Optional<HolidayDate> h = findByName(holidays, name);
+        assertTrue(h.isPresent(), "2020: " + name + " must be present");
+        assertEquals(h.get().getDate(), expected,
+                "2020: " + name + " must be on relocated date, not formula date");
+    }
+
+    @DataProvider(name = "jpy2020FormulaDatesMustBeAbsent")
+    public Object[][] jpy2020FormulaDatesMustBeAbsent() {
+        return new Object[][] {
+            { "Marine Day",   LocalDate.of(2020, Month.JULY,    20) },
+            { "Sports Day",   LocalDate.of(2020, Month.OCTOBER, 12) },
+            { "Mountain Day", LocalDate.of(2020, Month.AUGUST,  11) },
+        };
+    }
+
+    @Test(dataProvider = "jpy2020FormulaDatesMustBeAbsent")
+    public void testJPY_2020_FormulaDateAbsent(String name, LocalDate formulaDate) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2020);
+        long count = holidays.stream()
+                .filter(hd -> name.equals(hd.getHoliday().getName())
+                           && formulaDate.equals(hd.getDate()))
+                .count();
+        assertEquals(count, 0L, "2020: " + name + " must NOT appear on formula date " + formulaDate);
+    }
+
     @DataProvider(name = "jpyBoundaryYears")
     public Object[][] jpyBoundaryYears() {
         return new Object[][] {
-            { 2020, "Marine Day",   LocalDate.of(2020, Month.JULY,    20) },
-            { 2020, "Sports Day",   LocalDate.of(2020, Month.OCTOBER, 12) },
-            { 2020, "Mountain Day", LocalDate.of(2020, Month.AUGUST,  11) },
+            { 2020, "Marine Day",   LocalDate.of(2020, Month.JULY,    23) },
+            { 2020, "Sports Day",   LocalDate.of(2020, Month.JULY,    24) },
+            { 2020, "Mountain Day", LocalDate.of(2020, Month.AUGUST,  10) },
             { 2022, "Marine Day",   LocalDate.of(2022, Month.JULY,    18) },
             { 2022, "Sports Day",   LocalDate.of(2022, Month.OCTOBER, 10) },
             { 2022, "Mountain Day", LocalDate.of(2022, Month.AUGUST,  11) },
@@ -186,12 +225,12 @@ public class HolidayCalendarServiceJPYTest {
     }
 
     @Test(dataProvider = "jpyBoundaryYears")
-    public void testJPY_BoundaryYears_FormulaUnchanged(int year, String name, LocalDate expected) {
+    public void testJPY_BoundaryYears_OlympicAndFormulaYears(int year, String name, LocalDate expected) {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
         Optional<HolidayDate> h = findByName(holidays, name);
         assertTrue(h.isPresent(), year + ": " + name + " must be present");
         assertEquals(h.get().getDate(), expected,
-                year + ": " + name + " must use formula, not 2021 override");
+                year + ": " + name + " must be on the expected date");
     }
 
     @Test

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
@@ -237,7 +237,7 @@ public class HolidayCalendarServiceJPYTest {
     public void testJPY_NoDateDuplicatesIn2021() {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2021);
         long uniqueDates = holidays.stream().map(HolidayDate::date).distinct().count();
-        assertEquals(uniqueDates, (long) holidays.size(),
+        assertEquals(uniqueDates, holidays.size(),
                 "2021: no two holidays should share a date");
     }
 


### PR DESCRIPTION
### #132 Fix JP/JPY 2020 Tokyo Olympics holiday relocations

**Description**

- Added `year == 2020` guard to `SportsDay.computeDate()` returning Jul 24
- Added `year == 2020` guard to `MarineDay.computeDate()` returning Jul 23
- Added `y == 2020` guard to the Mountain Day lambda in `JapaneseHolidays.baseHolidays()` returning Aug 10, with an inline comment explaining the direct-return bypass idiom (the lambda pre-computes the final observed date, bypassing the `rollable(true)` pipeline since neither 2020 nor 2021 relocated date falls on a Sunday)
- Re-enabled three disabled sentinel tests in `HolidayCalendarServiceJPExtendedTest` (`testSportsDayOlympic2020`, `testMarineDayOlympic2020`, `testMountainDayOlympic2020`)
- Corrected three stale 2020 data rows in `HolidayCalendarServiceJPTest.jpBoundaryYears` and `HolidayCalendarServiceJPYTest.jpyBoundaryYears` that were asserting the pre-fix formula dates; renamed both test methods from `_FormulaUnchanged` to `_OlympicAndFormulaYears`
- Added `testJP_2020_FormulaDateAbsent` (negative assertions that formula dates are absent for JP 2020)
- Added `testJPY_2020_TokyoOlympicsRelocations` and `testJPY_2020_FormulaDateAbsent` for JPY 2020 (the extended test only covers JP)

**Related Issue**

- Fixes #132

**Type of Change**

- [x] Bug fix

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed