### PR TITLE
#133 Fix JPY cascade logic incorrectly bypasses BOJ Year-Start Holiday when rolling New Year's Day

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidayCalendar.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidayCalendar.java
@@ -135,7 +135,9 @@ class JapaneseHolidayCalendar extends HolidayCalendar {
 
     private boolean hasOtherHolidayOn(List<HolidayDate> result, int excludeIndex, LocalDate date) {
         for (int j = 0; j < result.size(); j++) {
-            if (j != excludeIndex && date.equals(result.get(j).date())) {
+            if (j != excludeIndex
+                    && date.equals(result.get(j).date())
+                    && result.get(j).holiday().isRollable()) {   // only rollable national holidays block cascade
                 return true;
             }
         }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYExtendedTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYExtendedTest.java
@@ -81,11 +81,15 @@ public class HolidayCalendarServiceJPYExtendedTest {
     @Test(dataProvider = "allYears2026to2055")
     public void testJan2PresentEveryYear(int year) {
         List<HolidayDate> holidays = calendar.calculate(year);
-        Optional<HolidayDate> h = findByDate(holidays, LocalDate.of(year, Month.JANUARY, 2));
-        assertTrue(h.isPresent(),
+        // In years where Jan 1=Sunday (2034, 2040, 2045, 2051) Jan 2 holds two entries:
+        // New Year's Day (rolled) and Year-Start Holiday.  Use anyMatch to avoid
+        // nondeterministic ordering from findFirst() over a shared-date pair.
+        LocalDate jan2 = LocalDate.of(year, Month.JANUARY, 2);
+        boolean yearStartPresent = holidays.stream()
+                .anyMatch(hd -> jan2.equals(hd.getDate())
+                             && "Year-Start Holiday".equals(hd.getHoliday().getName()));
+        assertTrue(yearStartPresent,
                    year + ": Jan 2 Year-Start Holiday must be present every year");
-        assertEquals(h.get().getHoliday().getName(), "Year-Start Holiday",
-                     year + ": Jan 2 holiday name");
     }
 
     @Test(dataProvider = "allYears2026to2055")
@@ -190,9 +194,8 @@ public class HolidayCalendarServiceJPYExtendedTest {
     // 2030: JP=16 + 3 BOJ = 19
     // 2032: JP=17 (Silver Week sandwich) + 3 BOJ = 20
     // 2035: JP=16 + 3 BOJ = 19
-    // 2040: JP=16 + 3 BOJ = 19.  Jan 1 Sun rolls to Jan 2; cascade incorrectly
-    //        treats Year-Start Holiday as a blocker (tracked defect), so New
-    //        Year's Day cascades to Jan 4 rather than coexisting on Jan 2.
+    // 2040: JP=16 + 3 BOJ = 19.  Jan 1 Sun → New Year's Day co-exists with
+    //        Year-Start Holiday on Jan 2 (fix for #133); no cascade to Jan 4.
     // 2045: JP=16 (Showa Day Apr 29 Sat stays, no Golden Week sandwich) + 3 BOJ = 19
     // 2050: JP=16 + 3 BOJ = 19.  Jan 1 Sat stays Jan 1 (no roll per #125).
     // 2055: JP=16 + 3 BOJ = 19
@@ -218,6 +221,62 @@ public class HolidayCalendarServiceJPYExtendedTest {
         assertEquals(holidays.size(), expected,
                      year + ": expected " + expected + " JPY holidays, got " + holidays.size()
                      + " | dates: " + holidays.stream().map(h -> h.getDate().toString()).toList());
+    }
+
+    // =========================================================================
+    // 4. NEW YEAR'S DAY CO-EXISTS WITH BOJ YEAR-START HOLIDAY ON JAN 2
+    // =========================================================================
+    // When Jan 1 = Sunday, New Year's Day rolls to Jan 2 (Mon).  The BOJ
+    // Year-Start Holiday (rollable=false) also sits on Jan 2.  Under the
+    // Holidays Act Art. 3 §3, only a rollable national holiday on the naive
+    // Monday blocks cascade — a non-rollable BOJ closure must NOT.  Therefore
+    // New Year's Day co-exists with Year-Start Holiday on Jan 2 and does NOT
+    // cascade to Jan 4.  Affected years: 2034, 2040, 2045, 2051.
+    // =========================================================================
+
+    @DataProvider(name = "newYearJan1SundayYears")
+    Iterator<Object[]> newYearJan1SundayYears() {
+        return List.of(
+            new Object[]{2034},
+            new Object[]{2040},
+            new Object[]{2045},
+            new Object[]{2051}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "newYearJan1SundayYears")
+    public void testNewYearsDayCoexistsWithYearStartHolidayOnJan2(int year) {
+        List<HolidayDate> holidays = calendar.calculate(year);
+        LocalDate jan2 = LocalDate.of(year, Month.JANUARY, 2);
+        LocalDate jan3 = LocalDate.of(year, Month.JANUARY, 3);
+        LocalDate jan4 = LocalDate.of(year, Month.JANUARY, 4);
+
+        // New Year's Day must be on Jan 2 (rolled from Jan 1 Sunday)
+        boolean nydOnJan2 = holidays.stream()
+                .anyMatch(hd -> jan2.equals(hd.getDate())
+                             && "New Year's Day".equals(hd.getHoliday().getName()));
+        assertTrue(nydOnJan2, year + ": New Year's Day must be observed on Jan 2, not cascaded to Jan 4");
+
+        // Jan 2 must have exactly 2 entries: New Year's Day + Year-Start Holiday
+        long jan2Count = holidays.stream().filter(hd -> jan2.equals(hd.getDate())).count();
+        assertEquals(jan2Count, 2L,
+                year + ": Jan 2 must have 2 entries (New Year's Day + Year-Start Holiday)");
+
+        // Year-Start Holiday must still be present on Jan 2
+        boolean yearStartOnJan2 = holidays.stream()
+                .anyMatch(hd -> jan2.equals(hd.getDate())
+                             && "Year-Start Holiday".equals(hd.getHoliday().getName()));
+        assertTrue(yearStartOnJan2, year + ": Year-Start Holiday must remain on Jan 2");
+
+        // Jan 3 must have exactly 1 entry (Year-Start Holiday only)
+        long jan3Count = holidays.stream().filter(hd -> jan3.equals(hd.getDate())).count();
+        assertEquals(jan3Count, 1L, year + ": Jan 3 must have exactly 1 entry (Year-Start Holiday)");
+
+        // New Year's Day must NOT cascade to Jan 4
+        boolean nydOnJan4 = holidays.stream()
+                .anyMatch(hd -> jan4.equals(hd.getDate())
+                             && "New Year's Day".equals(hd.getHoliday().getName()));
+        assertFalse(nydOnJan4, year + ": New Year's Day must NOT appear on Jan 4 (no spurious cascade)");
     }
 
     // =========================================================================

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPYTest.java
@@ -331,36 +331,38 @@ public class HolidayCalendarServiceJPYTest {
         assertFalse(phantomMay4, "May 4, 2031 must not be a spurious National Holiday in JPY calendar");
     }
 
-    // ── New Year's Day cascade when Jan 1=Sunday (JPY-specific, issue #126) ──────
+    // ── New Year's Day when Jan 1=Sunday (JPY-specific, issue #133) ─────────────
     //
     // When New Year's Day (Jan 1) falls on Sunday its naive Monday substitute is
-    // Jan 2, which is already a non-rollable BOJ Year-Start Holiday.  Jan 3 is
-    // also a BOJ Year-Start Holiday.  The cascade advances New Year's Day to Jan 4
-    // (the first free weekday), leaving Jan 2 and Jan 3 untouched.
+    // Jan 2, which is also occupied by the non-rollable BOJ Year-Start Holiday.
+    // Under Article 3 §3, cascade only fires when another *rollable* national
+    // holiday blocks the substitute day — a BOJ closure does not qualify.
+    // Therefore New Year's Day co-exists with the Year-Start Holiday on Jan 2;
+    // cascade does NOT advance it to Jan 4.
 
     @DataProvider(name = "jpyNewYearCascadeYears")
     public Object[][] jpyNewYearCascadeYears() {
         return new Object[][] {
-            { 2034, LocalDate.of(2034, Month.JANUARY, 4) },
-            { 2040, LocalDate.of(2040, Month.JANUARY, 4) },
-            { 2045, LocalDate.of(2045, Month.JANUARY, 4) },
-            { 2051, LocalDate.of(2051, Month.JANUARY, 4) },
+            { 2034, LocalDate.of(2034, Month.JANUARY, 2) },
+            { 2040, LocalDate.of(2040, Month.JANUARY, 2) },
+            { 2045, LocalDate.of(2045, Month.JANUARY, 2) },
+            { 2051, LocalDate.of(2051, Month.JANUARY, 2) },
         };
     }
 
     @Test(dataProvider = "jpyNewYearCascadeYears")
-    public void testJPY_NewYearCascade(int year, LocalDate cascaded) {
+    public void testJPY_NewYearCascade(int year, LocalDate observed) {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
-        // New Year's Day must be on the cascaded date
+        // New Year's Day must be on the observed date (Jan 2, rolled from Jan 1 Sun)
         Optional<HolidayDate> nyd = findByName(holidays, "New Year's Day");
         assertTrue(nyd.isPresent(), year + ": New Year's Day must be present");
-        assertEquals(nyd.get().getDate(), cascaded,
-                year + ": New Year's Day (Jan 1 Sun) must cascade to " + cascaded);
-        // Jan 2 must have exactly one entry (BOJ Year-Start only, no duplicate)
+        assertEquals(nyd.get().getDate(), observed,
+                year + ": New Year's Day (Jan 1 Sun) must be observed on " + observed);
+        // Jan 2 must have exactly two entries: New Year's Day + BOJ Year-Start Holiday
         long jan2Count = holidays.stream()
                 .filter(hd -> hd.getDate().equals(LocalDate.of(year, Month.JANUARY, 2)))
                 .count();
-        assertEquals(jan2Count, 1L, year + ": Jan 2 must have exactly 1 entry (BOJ Year-Start only)");
+        assertEquals(jan2Count, 2L, year + ": Jan 2 must have exactly 2 entries (New Year's Day + Year-Start Holiday)");
         // Jan 3 BOJ Year-Start Holiday must still be present
         assertTrue(findByDate(holidays, LocalDate.of(year, Month.JANUARY, 3)).isPresent(),
                 year + ": Jan 3 BOJ Year-Start Holiday must still be present");


### PR DESCRIPTION
### #133 Fix JPY cascade logic incorrectly bypasses BOJ Year-Start Holiday when rolling New Year's Day

**Description**

- Fixed `JapaneseHolidayCalendar.hasOtherHolidayOn()` to only treat **rollable** holidays as cascade blockers, by adding `&& result.get(j).holiday().isRollable()` to the inner-loop condition
- The cascade rule (振替休日, Article 3 §3 of the Holidays Act) requires another *national holiday* to occupy the substitute Monday in order to trigger further cascading; a non-rollable BOJ operational closure does not qualify
- In affected years (2034, 2040, 2045, 2051) New Year's Day now correctly co-exists with the Year-Start Holiday on Jan 2 rather than being spuriously pushed to Jan 4
- Updated `testJPY_NewYearCascade` in `HolidayCalendarServiceJPYTest`: data provider corrected from Jan 4 → Jan 2, `jan2Count` assertion updated from `1L` → `2L`, and comment block updated to reflect correct semantics
- Fixed `testJan2PresentEveryYear` in `HolidayCalendarServiceJPYExtendedTest` to use `anyMatch` instead of `findFirst()` + name assertion, avoiding nondeterministic ordering failures when two entries share Jan 2 in affected years
- Updated stale 2040 comment in `jpyFullYearHolidayCount` provider to remove "tracked defect" language
- Restored Section 4 in `HolidayCalendarServiceJPYExtendedTest`: new `@DataProvider` and `testNewYearsDayCoexistsWithYearStartHolidayOnJan2` test covering all four affected years with explicit co-existence and no-Jan-4 assertions

**Related Issue**

- Fixes #133

**Type of Change**

- [x] Bug fix

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed