### PR TITLE
#143 Automate README.md version synchronisation with POM

### DIFF
--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -41,3 +41,13 @@ jobs:
         env:
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
         run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar -Dsonar.projectKey=holiday-calendar_holiday-calendar-java
+      - name: Show README.md diff (diagnostic)
+        if: always()
+        run: git diff README.md
+      - name: Verify README.md matches generated output
+        run: |
+          git diff --exit-code README.md || {
+            echo "::error file=README.md::README.md was modified by the build but not committed."
+            echo "Run 'mvn validate -N' from the repo root and commit the updated README.md."
+            exit 1
+          }

--- a/.gitignore
+++ b/.gitignore
@@ -234,3 +234,6 @@ gradle-app.setting
 # Eclipse Gradle plugin generated files
 # Eclipse Core
 # JDT-specific (Eclipse Java Development Tools)
+
+### Claude Code ###
+.claude/

--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,7 @@
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
         <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
+        <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
     </properties>
 
     <dependencyManagement>
@@ -200,8 +201,49 @@
                     <artifactId>maven-site-plugin</artifactId>
                     <version>${maven-site-plugin.version}</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>${maven-resources-plugin.version}</version>
+                    <configuration>
+                        <encoding>${project.build.sourceEncoding}</encoding>
+                        <useDefaultDelimiters>false</useDefaultDelimiters>
+                        <delimiters>
+                            <delimiter>@</delimiter>
+                        </delimiters>
+                    </configuration>
+                </plugin>
             </plugins>
         </pluginManagement>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>filter-readme</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <inherited>false</inherited>
+                        <configuration>
+                            <outputDirectory>${project.basedir}</outputDirectory>
+                            <overwrite>true</overwrite>
+                            <resources>
+                                <resource>
+                                    <directory>${project.basedir}/src/readme</directory>
+                                    <filtering>true</filtering>
+                                    <includes>
+                                        <include>README.md</include>
+                                    </includes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
     </build>
 
     <reporting>

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -63,21 +63,21 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>@project.version@</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>@project.version@</version>
 </dependency>
 
 <!-- APAC calendars: SG, JP, JPY, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.2.0-SNAPSHOT</version>
+  <version>@project.version@</version>
 </dependency>
 ```
 

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -50,6 +50,10 @@
                     <includes>
                         <include>**/*IT.java</include>
                     </includes>
+                    <systemPropertyVariables>
+                        <project.version>${project.version}</project.version>
+                        <project.root.basedir>${project.basedir}/..</project.root.basedir>
+                    </systemPropertyVariables>
                 </configuration>
             </plugin>
             <plugin>

--- a/tests/src/test/java/org/holiday/calendar/ReadmeVersionIT.java
+++ b/tests/src/test/java/org/holiday/calendar/ReadmeVersionIT.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar;
+
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * Verifies that README.md version references stay in sync with the POM version
+ * (GitHub issue #143).
+ *
+ * <p>The build uses maven-resources-plugin filtering to replace
+ * {@code @project.version@} placeholders in {@code src/readme/README.md}
+ * and write the result to {@code README.md} during the {@code validate} phase.
+ *
+ * <p><strong>Must be run via the full reactor</strong> ({@code mvn verify} from
+ * the repository root) so that the root module's {@code validate} phase fires
+ * before this test executes. Running {@code mvn verify -pl tests} in isolation
+ * skips the root module and reads a potentially stale committed README.md.
+ *
+ * <p>Two system properties are injected by Surefire (see {@code tests/pom.xml}):
+ * <ul>
+ *   <li>{@code project.version} — the resolved Maven project version for this build.</li>
+ *   <li>{@code project.root.basedir} — absolute path to the repository root.</li>
+ * </ul>
+ */
+public class ReadmeVersionIT {
+
+    private static final String VERSION_PLACEHOLDER = "@project.version@";
+
+    private String projectVersion;
+    private Path readmePath;
+    private Path templatePath;
+
+    @BeforeClass
+    public void resolveArtifacts() {
+        projectVersion = System.getProperty("project.version");
+        assertNotNull(projectVersion,
+                "System property 'project.version' must be set by maven-surefire-plugin");
+        assertFalse(projectVersion.isBlank(),
+                "System property 'project.version' must not be blank");
+
+        String rootBasedir = System.getProperty("project.root.basedir");
+        assertNotNull(rootBasedir,
+                "System property 'project.root.basedir' must be set by maven-surefire-plugin");
+
+        Path root = Paths.get(rootBasedir).toAbsolutePath().normalize();
+        readmePath   = root.resolve("README.md");
+        templatePath = root.resolve("src/readme/README.md");
+
+        assertTrue(Files.exists(readmePath),
+                "README.md not found at: " + readmePath +
+                " — confirm maven-resources-plugin is configured in the root POM");
+        assertTrue(Files.exists(templatePath),
+                "Template not found at: " + templatePath +
+                " — confirm src/readme/README.md exists in the repository");
+    }
+
+    @Test(description = "All <version> elements in README.md must match the current POM version")
+    public void testReadmeVersionMatchesPomVersion() throws IOException {
+        List<String> lines = Files.readAllLines(readmePath);
+
+        List<String> versionLines = lines.stream()
+                .filter(line -> {
+                    String t = line.strip();
+                    return t.startsWith("<version>") && t.endsWith("</version>");
+                })
+                .toList();
+
+        assertFalse(versionLines.isEmpty(),
+                "README.md contains no <version>…</version> lines — " +
+                "has the Installation section been removed from the template?");
+
+        String expected = "<version>" + projectVersion + "</version>";
+        for (String versionLine : versionLines) {
+            assertEquals(versionLine.strip(), expected,
+                    "README.md version line does not match POM version.\n" +
+                    "  Hint: run 'mvn validate -N' from the repository root and commit the updated README.md.");
+        }
+    }
+
+    @Test(description = "README.md must not contain any un-expanded @project.version@ placeholder tokens")
+    public void testReadmeContainsNoRawPlaceholders() throws IOException {
+        List<String> lines = Files.readAllLines(readmePath);
+
+        List<String> placeholderLines = lines.stream()
+                .filter(line -> line.contains(VERSION_PLACEHOLDER))
+                .toList();
+
+        assertTrue(placeholderLines.isEmpty(),
+                "README.md still contains unexpanded placeholder tokens — " +
+                "maven-resources-plugin filtering did not replace them:\n  " +
+                String.join("\n  ", placeholderLines));
+    }
+
+    @Test(description = "src/readme/README.md must contain exactly 3 @project.version@ placeholder tokens")
+    public void testTemplateContainsVersionPlaceholders() throws IOException {
+        List<String> templateLines = Files.readAllLines(templatePath);
+
+        long placeholderCount = templateLines.stream()
+                .filter(line -> line.contains(VERSION_PLACEHOLDER))
+                .count();
+
+        assertEquals(placeholderCount, 3L,
+                "Expected exactly 3 occurrences of '" + VERSION_PLACEHOLDER +
+                "' in " + templatePath.getFileName() +
+                " (one per dependency block: holiday-calendar-core, holiday-calendar-western, holiday-calendar-apac), " +
+                "but found " + placeholderCount + ".\n" +
+                "  If you added a new dependency block, update this assertion.\n" +
+                "  If placeholders were replaced with a hardcoded version, restore them.");
+    }
+}


### PR DESCRIPTION
### #143 Automate README.md version synchronisation with POM

**Description**

- Adds `maven-resources-plugin` filtering to generate `README.md` from `src/readme/README.md` during the `validate` phase, substituting `@project.version@` for the three hardcoded version literals in the Installation section
- Uses `@` delimiters (`useDefaultDelimiters=false`) to avoid collisions with `${…}` expressions in Markdown code blocks
- Execution is `<inherited>false</inherited>` so only the root module filters the template; child modules are unaffected
- Adds `ReadmeVersionIT` integration test (3 assertions): README version matches POM, no raw placeholders survive filtering, template contains exactly 3 placeholder tokens
- Adds a CI drift check to `maven-build.yml` (`git diff --exit-code README.md`) that fails if a stale README is committed without regenerating

**Related Issue**

- [#143 — Automate README.md version synchronisation with POM](https://github.com/holiday-calendar/holiday-calendar-java/issues/143)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed