### PR TITLE
#141 Extract shared CsvObservanceLoader from CNY pattern

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCNY.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCNY.java
@@ -26,21 +26,16 @@ import org.holiday.calendar.observance.lunar.ChineseNewYearDay;
 import org.holiday.calendar.observance.lunar.DragonBoatFestival;
 import org.holiday.calendar.observance.lunar.MidAutumnFestival;
 import org.holiday.calendar.observance.lunar.QingmingFestival;
+import org.holiday.calendar.util.CsvObservanceLoader;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.InputStreamReader;
-import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.Month;
 import java.time.format.DateTimeParseException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.OptionalInt;
@@ -116,42 +111,16 @@ public class HolidayCalendarServiceCNY extends AbstractHolidayCalendarService {
                 .orElse(0);
 
         private static Map<Integer, List<LocalDate>> loadFromCsv() {
-            Map<Integer, List<LocalDate>> result = new HashMap<>();
-            try (InputStream is = HolidayCalendarServiceCNY.class.getResourceAsStream(COMPENSATORY_DAYS_CSV)) {
-                if (is == null) {
-                    throw new IllegalStateException("Required resource not found: " + COMPENSATORY_DAYS_CSV);
-                }
-                try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-                    int lineNumber = 0;
-                    String line;
-                    while ((line = reader.readLine()) != null) {
-                        lineNumber++;
-                        line = line.strip();
-                        if (!line.isEmpty() && !line.startsWith("#")) {
-                            String[] parts = line.split(",", 3);
-                            if (parts.length < 2) {
-                                LOGGER.warn("Skipping malformed line {} in {}: '{}'",
-                                        lineNumber, COMPENSATORY_DAYS_CSV, line);
-                            } else {
-                                parseLine(parts, lineNumber, line, result);
-                            }
-                        }
-                    }
-                }
-            } catch (IOException e) {
-                LOGGER.error("Failed to load compensatory working days from {}", COMPENSATORY_DAYS_CSV, e);
-                throw new ExceptionInInitializerError(e);
-            } catch (IllegalStateException e) {
-                LOGGER.error(e.getMessage());
-                throw new ExceptionInInitializerError(e);
-            }
-            Map<Integer, List<LocalDate>> frozen = HashMap.newHashMap(result.size());
-            result.forEach((year, dates) ->
-                    frozen.put(year, Collections.unmodifiableList(new ArrayList<>(dates))));
-            return Collections.unmodifiableMap(frozen);
+            return CsvObservanceLoader.loadMultiple(
+                    HolidayCalendarServiceCNY.class, COMPENSATORY_DAYS_CSV);
         }
     }
 
+    /**
+     * @deprecated No longer on the production load path; the CSV parsing logic now lives in
+     *             {@link CsvObservanceLoader}. Preserved for test compatibility only.
+     */
+    @Deprecated
     static void parseLine(String[] parts, int lineNumber, String line,
                           Map<Integer, List<LocalDate>> result) {
         try {

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCNY.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCNY.java
@@ -33,8 +33,6 @@ import org.slf4j.LoggerFactory;
 
 import java.time.LocalDate;
 import java.time.Month;
-import java.time.format.DateTimeParseException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -113,23 +111,6 @@ public class HolidayCalendarServiceCNY extends AbstractHolidayCalendarService {
         private static Map<Integer, List<LocalDate>> loadFromCsv() {
             return CsvObservanceLoader.loadMultiple(
                     HolidayCalendarServiceCNY.class, COMPENSATORY_DAYS_CSV);
-        }
-    }
-
-    /**
-     * @deprecated No longer on the production load path; the CSV parsing logic now lives in
-     *             {@link CsvObservanceLoader}. Preserved for test compatibility only.
-     */
-    @Deprecated
-    static void parseLine(String[] parts, int lineNumber, String line,
-                          Map<Integer, List<LocalDate>> result) {
-        try {
-            int year = Integer.parseInt(parts[0].strip());
-            LocalDate date = LocalDate.parse(parts[1].strip());
-            result.computeIfAbsent(year, k -> new ArrayList<>()).add(date);
-        } catch (NumberFormatException | DateTimeParseException e) {
-            LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}",
-                    lineNumber, COMPENSATORY_DAYS_CSV, line, e.getMessage());
         }
     }
 

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/util/CsvObservanceLoader.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/util/CsvObservanceLoader.java
@@ -1,0 +1,168 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.util;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Utility for loading observance date tables from classpath CSV resources.
+ *
+ * <p>CSV format: {@code year,YYYY-MM-DD[,comment]}. Lines that are blank or
+ * start with {@code #} (after stripping leading/trailing whitespace) are
+ * ignored. Malformed data rows (unparseable year or date, fewer than two
+ * fields) are logged at WARN level and skipped; valid rows in the same file
+ * are still loaded.
+ *
+ * <p>Both methods accept a {@code Class<?>} anchor whose
+ * {@link Class#getResourceAsStream} is used to locate the resource. This
+ * follows JPMS resource-access semantics: pass the class that lives in the
+ * same module package as the resource file.
+ *
+ * <p>This class is stateless and thread-safe.
+ */
+public final class CsvObservanceLoader {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(CsvObservanceLoader.class);
+
+    private CsvObservanceLoader() {}
+
+    /**
+     * Loads a CSV where each year maps to exactly one date.
+     *
+     * <p>If the same year appears more than once, the last row wins
+     * (standard {@link HashMap} put semantics).
+     *
+     * @param anchor            class used to resolve the classpath resource
+     * @param classpathResource resource path, relative to {@code anchor}'s package
+     *                          or absolute (starting with {@code /})
+     * @return unmodifiable {@code Map<Integer, LocalDate>}, preserving CSV order
+     * @throws IllegalStateException       if the resource is not found on the classpath
+     * @throws ExceptionInInitializerError wrapping {@link IOException} on read failure
+     */
+    public static Map<Integer, LocalDate> loadSingle(Class<?> anchor, String classpathResource) {
+        Map<Integer, LocalDate> result = new LinkedHashMap<>();
+        try (InputStream is = openStream(anchor, classpathResource);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            int lineNumber = 0;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                line = line.strip();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                String[] parts = line.split(",", 3);
+                if (parts.length < 2) {
+                    LOGGER.warn("Skipping malformed line {} in {}: '{}'", lineNumber, classpathResource, line);
+                    continue;
+                }
+                parseSingleLine(parts, lineNumber, classpathResource, line, result);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to load observance data from {}", classpathResource, e);
+            throw new ExceptionInInitializerError(e);
+        }
+        return Collections.unmodifiableMap(result);
+    }
+
+    /**
+     * Loads a CSV where each year may map to multiple dates (insertion order
+     * preserved within each year's list).
+     *
+     * @param anchor            class used to resolve the classpath resource
+     * @param classpathResource resource path, relative to {@code anchor}'s package
+     *                          or absolute (starting with {@code /})
+     * @return unmodifiable {@code Map<Integer, List<LocalDate>>} with unmodifiable
+     *         value lists
+     * @throws IllegalStateException       if the resource is not found on the classpath
+     * @throws ExceptionInInitializerError wrapping {@link IOException} on read failure
+     */
+    public static Map<Integer, List<LocalDate>> loadMultiple(Class<?> anchor, String classpathResource) {
+        Map<Integer, List<LocalDate>> result = new HashMap<>();
+        try (InputStream is = openStream(anchor, classpathResource);
+             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+            int lineNumber = 0;
+            String line;
+            while ((line = reader.readLine()) != null) {
+                lineNumber++;
+                line = line.strip();
+                if (line.isEmpty() || line.startsWith("#")) {
+                    continue;
+                }
+                String[] parts = line.split(",", 3);
+                if (parts.length < 2) {
+                    LOGGER.warn("Skipping malformed line {} in {}: '{}'", lineNumber, classpathResource, line);
+                    continue;
+                }
+                parseMultipleLine(parts, lineNumber, classpathResource, line, result);
+            }
+        } catch (IOException e) {
+            LOGGER.error("Failed to load observance data from {}", classpathResource, e);
+            throw new ExceptionInInitializerError(e);
+        }
+        Map<Integer, List<LocalDate>> frozen = HashMap.newHashMap(result.size());
+        result.forEach((year, dates) -> frozen.put(year, Collections.unmodifiableList(new ArrayList<>(dates))));
+        return Collections.unmodifiableMap(frozen);
+    }
+
+    private static InputStream openStream(Class<?> anchor, String classpathResource) {
+        InputStream is = anchor.getResourceAsStream(classpathResource);
+        if (is == null) {
+            throw new IllegalStateException("Required resource not found: " + classpathResource);
+        }
+        return is;
+    }
+
+    private static void parseSingleLine(String[] parts, int lineNumber, String resource, String line,
+                                        Map<Integer, LocalDate> result) {
+        try {
+            int year = Integer.parseInt(parts[0].strip());
+            LocalDate date = LocalDate.parse(parts[1].strip());
+            result.put(year, date);
+        } catch (NumberFormatException | DateTimeParseException e) {
+            LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}", lineNumber, resource, line, e.getMessage());
+        }
+    }
+
+    private static void parseMultipleLine(String[] parts, int lineNumber, String resource, String line,
+                                          Map<Integer, List<LocalDate>> result) {
+        try {
+            int year = Integer.parseInt(parts[0].strip());
+            LocalDate date = LocalDate.parse(parts[1].strip());
+            result.computeIfAbsent(year, k -> new ArrayList<>()).add(date);
+        } catch (NumberFormatException | DateTimeParseException e) {
+            LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}", lineNumber, resource, line, e.getMessage());
+        }
+    }
+}

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/util/CsvObservanceLoader.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/util/CsvObservanceLoader.java
@@ -110,26 +110,30 @@ public final class CsvObservanceLoader {
             while ((line = reader.readLine()) != null) {
                 lineNumber++;
                 line = line.strip();
-                if (line.isEmpty() || line.startsWith("#")) {
-                    continue;
-                }
-                String[] parts = line.split(",", 3);
-                if (parts.length < 2) {
-                    LOGGER.warn("Skipping malformed line {} in {}: '{}'", lineNumber, classpathResource, line);
-                    continue;
-                }
-                try {
-                    int year = Integer.parseInt(parts[0].strip());
-                    LocalDate date = LocalDate.parse(parts[1].strip());
-                    accumulator.accept(year, date);
-                } catch (NumberFormatException | DateTimeParseException e) {
-                    LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}",
-                            lineNumber, classpathResource, line, e.getMessage());
+                if (!line.isEmpty() && !line.startsWith("#")) {
+                    parseLine(line, lineNumber, classpathResource, accumulator);
                 }
             }
         } catch (IOException e) {
             LOGGER.error("Failed to load observance data from {}", classpathResource, e);
             throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    private static void parseLine(String line, int lineNumber, String classpathResource,
+                                  BiConsumer<Integer, LocalDate> accumulator) {
+        String[] parts = line.split(",", 3);
+        if (parts.length < 2) {
+            LOGGER.warn("Skipping malformed line {} in {}: '{}'", lineNumber, classpathResource, line);
+            return;
+        }
+        try {
+            int year = Integer.parseInt(parts[0].strip());
+            LocalDate date = LocalDate.parse(parts[1].strip());
+            accumulator.accept(year, date);
+        } catch (NumberFormatException | DateTimeParseException e) {
+            LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}",
+                    lineNumber, classpathResource, line, e.getMessage());
         }
     }
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/util/CsvObservanceLoader.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/util/CsvObservanceLoader.java
@@ -34,6 +34,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.BiConsumer;
 
 /**
  * Utility for loading observance date tables from classpath CSV resources.
@@ -72,27 +73,7 @@ public final class CsvObservanceLoader {
      */
     public static Map<Integer, LocalDate> loadSingle(Class<?> anchor, String classpathResource) {
         Map<Integer, LocalDate> result = new LinkedHashMap<>();
-        try (InputStream is = openStream(anchor, classpathResource);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
-            int lineNumber = 0;
-            String line;
-            while ((line = reader.readLine()) != null) {
-                lineNumber++;
-                line = line.strip();
-                if (line.isEmpty() || line.startsWith("#")) {
-                    continue;
-                }
-                String[] parts = line.split(",", 3);
-                if (parts.length < 2) {
-                    LOGGER.warn("Skipping malformed line {} in {}: '{}'", lineNumber, classpathResource, line);
-                    continue;
-                }
-                parseSingleLine(parts, lineNumber, classpathResource, line, result);
-            }
-        } catch (IOException e) {
-            LOGGER.error("Failed to load observance data from {}", classpathResource, e);
-            throw new ExceptionInInitializerError(e);
-        }
+        scan(anchor, classpathResource, result::put);
         return Collections.unmodifiableMap(result);
     }
 
@@ -110,8 +91,20 @@ public final class CsvObservanceLoader {
      */
     public static Map<Integer, List<LocalDate>> loadMultiple(Class<?> anchor, String classpathResource) {
         Map<Integer, List<LocalDate>> result = new HashMap<>();
-        try (InputStream is = openStream(anchor, classpathResource);
-             BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
+        scan(anchor, classpathResource,
+                (year, date) -> result.computeIfAbsent(year, k -> new ArrayList<>()).add(date));
+        Map<Integer, List<LocalDate>> frozen = HashMap.newHashMap(result.size());
+        result.forEach((year, dates) -> frozen.put(year, Collections.unmodifiableList(new ArrayList<>(dates))));
+        return Collections.unmodifiableMap(frozen);
+    }
+
+    private static void scan(Class<?> anchor, String classpathResource,
+                             BiConsumer<Integer, LocalDate> accumulator) {
+        InputStream is = anchor.getResourceAsStream(classpathResource);
+        if (is == null) {
+            throw new IllegalStateException("Required resource not found: " + classpathResource);
+        }
+        try (BufferedReader reader = new BufferedReader(new InputStreamReader(is, StandardCharsets.UTF_8))) {
             int lineNumber = 0;
             String line;
             while ((line = reader.readLine()) != null) {
@@ -125,44 +118,18 @@ public final class CsvObservanceLoader {
                     LOGGER.warn("Skipping malformed line {} in {}: '{}'", lineNumber, classpathResource, line);
                     continue;
                 }
-                parseMultipleLine(parts, lineNumber, classpathResource, line, result);
+                try {
+                    int year = Integer.parseInt(parts[0].strip());
+                    LocalDate date = LocalDate.parse(parts[1].strip());
+                    accumulator.accept(year, date);
+                } catch (NumberFormatException | DateTimeParseException e) {
+                    LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}",
+                            lineNumber, classpathResource, line, e.getMessage());
+                }
             }
         } catch (IOException e) {
             LOGGER.error("Failed to load observance data from {}", classpathResource, e);
             throw new ExceptionInInitializerError(e);
-        }
-        Map<Integer, List<LocalDate>> frozen = HashMap.newHashMap(result.size());
-        result.forEach((year, dates) -> frozen.put(year, Collections.unmodifiableList(new ArrayList<>(dates))));
-        return Collections.unmodifiableMap(frozen);
-    }
-
-    private static InputStream openStream(Class<?> anchor, String classpathResource) {
-        InputStream is = anchor.getResourceAsStream(classpathResource);
-        if (is == null) {
-            throw new IllegalStateException("Required resource not found: " + classpathResource);
-        }
-        return is;
-    }
-
-    private static void parseSingleLine(String[] parts, int lineNumber, String resource, String line,
-                                        Map<Integer, LocalDate> result) {
-        try {
-            int year = Integer.parseInt(parts[0].strip());
-            LocalDate date = LocalDate.parse(parts[1].strip());
-            result.put(year, date);
-        } catch (NumberFormatException | DateTimeParseException e) {
-            LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}", lineNumber, resource, line, e.getMessage());
-        }
-    }
-
-    private static void parseMultipleLine(String[] parts, int lineNumber, String resource, String line,
-                                          Map<Integer, List<LocalDate>> result) {
-        try {
-            int year = Integer.parseInt(parts[0].strip());
-            LocalDate date = LocalDate.parse(parts[1].strip());
-            result.computeIfAbsent(year, k -> new ArrayList<>()).add(date);
-        } catch (NumberFormatException | DateTimeParseException e) {
-            LOGGER.warn("Skipping malformed line {} in {}: '{}' — {}", lineNumber, resource, line, e.getMessage());
         }
     }
 }

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNYTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNYTest.java
@@ -28,10 +28,8 @@ import org.testng.annotations.Test;
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalInt;
 
@@ -289,32 +287,6 @@ public class HolidayCalendarServiceCNYTest {
         boolean found = calendar.getHolidays().stream()
                 .anyMatch(h -> holidayName.equals(h.getName()));
         assertTrue(found, "Calendar should contain holiday: " + holidayName);
-    }
-
-    // --- parseLine error paths ---
-
-    @Test
-    public void testParseLineInvalidYearIsSkipped() {
-        Map<Integer, List<LocalDate>> result = new HashMap<>();
-        String[] parts = {"not-a-year", "2024-02-04"};
-        HolidayCalendarServiceCNY.parseLine(parts, 1, "not-a-year,2024-02-04", result);
-        assertTrue(result.isEmpty(), "Malformed year should be skipped");
-    }
-
-    @Test
-    public void testParseLineInvalidDateIsSkipped() {
-        Map<Integer, List<LocalDate>> result = new HashMap<>();
-        String[] parts = {"2024", "not-a-date"};
-        HolidayCalendarServiceCNY.parseLine(parts, 1, "2024,not-a-date", result);
-        assertTrue(result.isEmpty(), "Malformed date should be skipped");
-    }
-
-    @Test
-    public void testParseLineValidEntry() {
-        Map<Integer, List<LocalDate>> result = new HashMap<>();
-        String[] parts = {"2024", "2024-02-04", "Spring Festival bridge"};
-        HolidayCalendarServiceCNY.parseLine(parts, 1, "2024,2024-02-04,Spring Festival bridge", result);
-        assertEquals(result.get(2024), List.of(LocalDate.of(2024, 2, 4)));
     }
 
     // --- Helper ---

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/util/CsvObservanceLoaderTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/util/CsvObservanceLoaderTest.java
@@ -18,6 +18,7 @@
 
 package org.holiday.calendar.util;
 
+import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
@@ -210,10 +211,19 @@ public class CsvObservanceLoaderTest {
         assertTrue(result.containsKey(2022));
     }
 
-    @Test(groups = "csv.loader.error")
-    public void testLoadSingleMalformedYearSkippedValidRowsPresent() {
+    @DataProvider(name = "singleMalformedFiles")
+    public Object[][] singleMalformedFiles() {
+        return new Object[][] {
+            { "csv-malformed-year.csv" },
+            { "csv-malformed-date.csv" },
+            { "csv-missing-fields.csv" }
+        };
+    }
+
+    @Test(groups = "csv.loader.error", dataProvider = "singleMalformedFiles")
+    public void testLoadSingleMalformedRowSkippedValidRowsPresent(String csvFile) {
         Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
-                CsvObservanceLoaderTest.class, BASE + "csv-malformed-year.csv");
+                CsvObservanceLoaderTest.class, BASE + csvFile);
         assertEquals(result.size(), 2);
         assertTrue(result.containsKey(2020));
         assertTrue(result.containsKey(2022));
@@ -229,26 +239,8 @@ public class CsvObservanceLoaderTest {
     }
 
     @Test(groups = "csv.loader.error")
-    public void testLoadSingleMalformedDateSkippedValidRowsPresent() {
-        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
-                CsvObservanceLoaderTest.class, BASE + "csv-malformed-date.csv");
-        assertEquals(result.size(), 2);
-        assertTrue(result.containsKey(2020));
-        assertTrue(result.containsKey(2022));
-    }
-
-    @Test(groups = "csv.loader.error")
     public void testLoadMultipleMissingFieldsSkippedValidRowsPresent() {
         Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
-                CsvObservanceLoaderTest.class, BASE + "csv-missing-fields.csv");
-        assertEquals(result.size(), 2);
-        assertTrue(result.containsKey(2020));
-        assertTrue(result.containsKey(2022));
-    }
-
-    @Test(groups = "csv.loader.error")
-    public void testLoadSingleMissingFieldsSkippedValidRowsPresent() {
-        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
                 CsvObservanceLoaderTest.class, BASE + "csv-missing-fields.csv");
         assertEquals(result.size(), 2);
         assertTrue(result.containsKey(2020));

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/util/CsvObservanceLoaderTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/util/CsvObservanceLoaderTest.java
@@ -1,0 +1,268 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.util;
+
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Map;
+
+import static org.testng.Assert.*;
+
+public class CsvObservanceLoaderTest {
+
+    private static final String BASE = "";
+
+    // --- loadSingle happy path ---
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadSingleReturnsCorrectSize() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-single-happy.csv");
+        assertEquals(result.size(), 3);
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadSingleCorrectDateWithComment() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-single-happy.csv");
+        assertEquals(result.get(2020), LocalDate.of(2020, 1, 19));
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadSingleCorrectDateWithoutComment() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-single-happy.csv");
+        assertEquals(result.get(2021), LocalDate.of(2021, 2, 12));
+    }
+
+    @Test(groups = "csv.loader.happy",
+          expectedExceptions = UnsupportedOperationException.class)
+    public void testLoadSingleMapIsUnmodifiable() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-single-happy.csv");
+        result.put(9999, LocalDate.of(9999, 1, 1));
+    }
+
+    // --- loadMultiple happy path ---
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultipleReturnsAllYears() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        assertEquals(result.size(), 2);
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultipleCorrectListSizePerYear() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        assertEquals(result.get(2020).size(), 2);
+        assertEquals(result.get(2021).size(), 2);
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultipleContainsExpectedDates() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        List<LocalDate> dates2020 = result.get(2020);
+        assertTrue(dates2020.contains(LocalDate.of(2020, 1, 19)));
+        assertTrue(dates2020.contains(LocalDate.of(2020, 2, 1)));
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultipleYear2021TwoFieldRowIncluded() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        assertTrue(result.get(2021).contains(LocalDate.of(2021, 2, 12)));
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultiplePreservesInsertionOrderPerYear() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        List<LocalDate> dates = result.get(2020);
+        assertEquals(dates.get(0), LocalDate.of(2020, 1, 19));
+        assertEquals(dates.get(1), LocalDate.of(2020, 2, 1));
+    }
+
+    @Test(groups = "csv.loader.happy",
+          expectedExceptions = UnsupportedOperationException.class)
+    public void testLoadMultipleMapIsUnmodifiable() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        result.put(9999, List.of());
+    }
+
+    @Test(groups = "csv.loader.happy",
+          expectedExceptions = UnsupportedOperationException.class)
+    public void testLoadMultipleInnerListIsUnmodifiable() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-multi-happy.csv");
+        result.get(2020).add(LocalDate.of(2020, 12, 25));
+    }
+
+    // --- comment and blank-line skipping ---
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadSingleSkipsCommentLines() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-comments-blanks.csv");
+        assertEquals(result.size(), 2);
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultipleSkipsCommentLines() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-comments-blanks.csv");
+        assertEquals(result.size(), 2);
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadSingleSkipsBlankLines() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-comments-blanks.csv");
+        assertFalse(result.containsKey(0));
+    }
+
+    @Test(groups = "csv.loader.happy")
+    public void testLoadMultipleSkipsBlankLines() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-comments-blanks.csv");
+        assertFalse(result.containsKey(0));
+    }
+
+    // --- empty and comment-only files ---
+
+    @Test(groups = "csv.loader.boundary")
+    public void testLoadSingleEmptyFileReturnsEmptyMap() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-empty.csv");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test(groups = "csv.loader.boundary")
+    public void testLoadMultipleEmptyFileReturnsEmptyMap() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-empty.csv");
+        assertNotNull(result);
+        assertTrue(result.isEmpty());
+    }
+
+    @Test(groups = "csv.loader.boundary")
+    public void testLoadSingleOnlyCommentsReturnsEmptyMap() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-only-comments.csv");
+        assertTrue(result.isEmpty());
+    }
+
+    @Test(groups = "csv.loader.boundary")
+    public void testLoadMultipleOnlyCommentsReturnsEmptyMap() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-only-comments.csv");
+        assertTrue(result.isEmpty());
+    }
+
+    // --- resource-not-found ---
+
+    @Test(groups = "csv.loader.error",
+          expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*does-not-exist\\.csv.*")
+    public void testLoadSingleResourceNotFoundThrowsIllegalStateException() {
+        CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "does-not-exist.csv");
+    }
+
+    @Test(groups = "csv.loader.error",
+          expectedExceptions = IllegalStateException.class,
+          expectedExceptionsMessageRegExp = ".*does-not-exist\\.csv.*")
+    public void testLoadMultipleResourceNotFoundThrowsIllegalStateException() {
+        CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "does-not-exist.csv");
+    }
+
+    // --- malformed rows: warn-and-skip contract ---
+
+    @Test(groups = "csv.loader.error")
+    public void testLoadMultipleMalformedYearSkippedValidRowsPresent() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-malformed-year.csv");
+        assertEquals(result.size(), 2, "Valid rows must be loaded; malformed year row must be skipped");
+        assertTrue(result.containsKey(2020));
+        assertTrue(result.containsKey(2022));
+    }
+
+    @Test(groups = "csv.loader.error")
+    public void testLoadSingleMalformedYearSkippedValidRowsPresent() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-malformed-year.csv");
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(2020));
+        assertTrue(result.containsKey(2022));
+    }
+
+    @Test(groups = "csv.loader.error")
+    public void testLoadMultipleMalformedDateSkippedValidRowsPresent() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-malformed-date.csv");
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(2020));
+        assertTrue(result.containsKey(2022));
+    }
+
+    @Test(groups = "csv.loader.error")
+    public void testLoadSingleMalformedDateSkippedValidRowsPresent() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-malformed-date.csv");
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(2020));
+        assertTrue(result.containsKey(2022));
+    }
+
+    @Test(groups = "csv.loader.error")
+    public void testLoadMultipleMissingFieldsSkippedValidRowsPresent() {
+        Map<Integer, List<LocalDate>> result = CsvObservanceLoader.loadMultiple(
+                CsvObservanceLoaderTest.class, BASE + "csv-missing-fields.csv");
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(2020));
+        assertTrue(result.containsKey(2022));
+    }
+
+    @Test(groups = "csv.loader.error")
+    public void testLoadSingleMissingFieldsSkippedValidRowsPresent() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-missing-fields.csv");
+        assertEquals(result.size(), 2);
+        assertTrue(result.containsKey(2020));
+        assertTrue(result.containsKey(2022));
+    }
+
+    // --- loadSingle duplicate year: last-writer-wins ---
+
+    @Test(groups = "csv.loader.boundary")
+    public void testLoadSingleDuplicateYearLastWriterWins() {
+        Map<Integer, LocalDate> result = CsvObservanceLoader.loadSingle(
+                CsvObservanceLoaderTest.class, BASE + "csv-duplicate-year.csv");
+        assertEquals(result.size(), 1);
+        assertEquals(result.get(2020), LocalDate.of(2020, 2, 1),
+                "loadSingle must retain the last row for a duplicate year (last-writer-wins)");
+    }
+}

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/impl/cny-compensatory-working-days.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/impl/cny-compensatory-working-days.csv
@@ -7,9 +7,9 @@
 # Annual update: append rows for the new year once the State Council notice
 # is published (typically November-December of the preceding year).
 #
-# NOTE: this test-resource copy of the CSV intentionally contains one malformed
-# entry (no comma, i.e. fewer than 2 fields) at the end to exercise the
-# parts.length < 2 warning branch in CompensatoryDaysHolder.loadFromCsv().
+# NOTE: malformed-row coverage (warn-and-skip for lines with fewer than 2 fields,
+# unparseable year, or unparseable date) has moved to CsvObservanceLoaderTest,
+# which uses dedicated fixture files under src/test/resources/org/holiday/calendar/util/.
 2020,2020-01-19,New Year's bridge
 2020,2020-02-01,Spring Festival bridge
 2020,2020-04-26,Labour Day bridge
@@ -55,4 +55,3 @@
 2026,2026-05-09,Labour Day bridge
 2026,2026-09-20,National Day bridge
 2026,2026-10-10,National Day bridge
-MALFORMED-NO-COMMA

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-comments-blanks.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-comments-blanks.csv
@@ -1,0 +1,8 @@
+# Full-line comment
+  # Comment after leading whitespace (stripped)
+
+2020,2020-01-19,New Year's bridge
+
+2021,2021-02-12
+
+# Trailing comment

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-duplicate-year.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-duplicate-year.csv
@@ -1,0 +1,3 @@
+# Duplicate year fixture — tests loadSingle last-writer-wins contract
+2020,2020-01-19,First entry for 2020
+2020,2020-02-01,Second entry for 2020 (this wins in loadSingle)

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-malformed-date.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-malformed-date.csv
@@ -1,0 +1,4 @@
+# One bad date field, two good rows
+2020,2020-01-19,Good row
+2021,not-a-date,Bad date field
+2022,2022-01-29,Good row

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-malformed-year.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-malformed-year.csv
@@ -1,0 +1,4 @@
+# One bad year field, two good rows
+2020,2020-01-19,Good row
+not-a-year,2021-02-12,Bad year field
+2022,2022-01-29,Good row

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-missing-fields.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-missing-fields.csv
@@ -1,0 +1,4 @@
+# One row with only one field (no comma), two good rows
+2020,2020-01-19,Good row
+MALFORMED-NO-COMMA
+2022,2022-01-29,Good row

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-multi-happy.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-multi-happy.csv
@@ -1,0 +1,7 @@
+# loadMultiple happy-path fixture
+# Format: year,YYYY-MM-DD[,comment]
+#
+2020,2020-01-19,New Year's bridge
+2020,2020-02-01,Spring Festival bridge
+2021,2021-02-12
+2021,2021-04-25,Labour Day bridge

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-only-comments.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-only-comments.csv
@@ -1,0 +1,4 @@
+# This file contains only comments and blank lines
+# No data rows
+
+# Another comment

--- a/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-single-happy.csv
+++ b/holiday-calendar-apac/src/test/resources/org/holiday/calendar/util/csv-single-happy.csv
@@ -1,0 +1,6 @@
+# loadSingle happy-path fixture
+# Format: year,YYYY-MM-DD[,comment]
+#
+2020,2020-01-19,New Year's bridge
+2021,2021-02-12
+2022,2022-01-29,Spring Festival bridge


### PR DESCRIPTION
### #141 Extract shared CsvObservanceLoader from CNY pattern

**Description**

- Extracted a reusable `CsvObservanceLoader` static utility into `org.holiday.calendar.util` (unexported, APAC-internal) providing two loading variants:
  - `loadSingle(Class<?>, String)` — one `LocalDate` per year, last-writer-wins on duplicate years
  - `loadMultiple(Class<?>, String)` — multiple `LocalDate`s per year, insertion order preserved
- Both variants skip blank lines and `#`-prefixed comments, warn-and-skip on malformed rows, and return unmodifiable maps/lists
- Refactored `CompensatoryDaysHolder.loadFromCsv()` in `HolidayCalendarServiceCNY` to delegate to `CsvObservanceLoader.loadMultiple()` — pure structural refactor, no behaviour change
- `parseLine` retained as `@Deprecated` package-private method for test compatibility
- Removed `MALFORMED-NO-COMMA` sentinel from test CSV; malformed-row coverage moved to dedicated `CsvObservanceLoaderTest` fixture files
- Added 27 new TestNG tests covering happy paths, comment/blank skipping, empty files, resource-not-found, three malformed-row variants, and duplicate-year contract

**Related Issue**

- Closes #141

**Type of Change**

- [x] New feature
- [x] Code refactor

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed