### PR TITLE
#142 Migrate SG non-Gregorian observances to CSV-backed implementation

### DIFF
--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/hindu/Deepavali.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/hindu/Deepavali.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.hindu;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -35,62 +36,25 @@ import java.util.Map;
  * MOM public holiday gazette confirmation. All entries should be verified against MOM
  * announcements as Singapore approaches each year.</p>
  *
+ * <p>Date data is loaded at runtime from {@code deepavali.csv} in this package.</p>
+ *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class Deepavali extends AbstractObservance {
 
-    private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
-        // 2019–2030: Singapore MOM official gazette
-        Map.entry(2019, LocalDate.of(2019, 10, 27)),
-        Map.entry(2020, LocalDate.of(2020, 11, 14)),
-        Map.entry(2021, LocalDate.of(2021, 11,  4)),
-        Map.entry(2022, LocalDate.of(2022, 10, 24)),
-        Map.entry(2023, LocalDate.of(2023, 11, 12)),
-        Map.entry(2024, LocalDate.of(2024, 10, 31)),
-        Map.entry(2025, LocalDate.of(2025, 10, 20)),
-        Map.entry(2026, LocalDate.of(2026, 11,  8)),
-        Map.entry(2027, LocalDate.of(2027, 10, 29)),
-        Map.entry(2028, LocalDate.of(2028, 10, 17)),
-        Map.entry(2029, LocalDate.of(2029, 11,  5)),
-        Map.entry(2030, LocalDate.of(2030, 10, 26)),
-        // 2031–2055: Tamil Panchang projection (1st day of Tamil month Karthigai, SGT),
-        // cross-referenced with Drik Panchang astronomical tables; verify against MOM
-        // gazette as each year is officially published.
-        Map.entry(2031, LocalDate.of(2031, 11, 14)),
-        Map.entry(2032, LocalDate.of(2032, 11,  2)),
-        Map.entry(2033, LocalDate.of(2033, 10, 23)),
-        Map.entry(2034, LocalDate.of(2034, 11, 10)),
-        Map.entry(2035, LocalDate.of(2035, 10, 31)),
-        Map.entry(2036, LocalDate.of(2036, 10, 19)),
-        Map.entry(2037, LocalDate.of(2037, 11,  7)),
-        Map.entry(2038, LocalDate.of(2038, 10, 27)),
-        Map.entry(2039, LocalDate.of(2039, 10, 16)),
-        Map.entry(2040, LocalDate.of(2040, 11,  3)),
-        Map.entry(2041, LocalDate.of(2041, 10, 24)),
-        Map.entry(2042, LocalDate.of(2042, 11, 11)),
-        Map.entry(2043, LocalDate.of(2043, 11,  1)),
-        Map.entry(2044, LocalDate.of(2044, 10, 20)),
-        Map.entry(2045, LocalDate.of(2045, 11,  8)),
-        Map.entry(2046, LocalDate.of(2046, 10, 29)),
-        Map.entry(2047, LocalDate.of(2047, 10, 19)),
-        Map.entry(2048, LocalDate.of(2048, 11,  5)),
-        Map.entry(2049, LocalDate.of(2049, 10, 25)),
-        Map.entry(2050, LocalDate.of(2050, 10, 15)),
-        Map.entry(2051, LocalDate.of(2051, 11,  3)),
-        Map.entry(2052, LocalDate.of(2052, 10, 22)),
-        Map.entry(2053, LocalDate.of(2053, 11, 10)),
-        Map.entry(2054, LocalDate.of(2054, 10, 30)),
-        Map.entry(2055, LocalDate.of(2055, 10, 19))
-    );
+    private static final class DatesHolder {
+        static final Map<Integer, LocalDate> DATA =
+            CsvObservanceLoader.loadSingle(Deepavali.class, "deepavali.csv");
+    }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return DATES.get(year);
+        return DatesHolder.DATA.get(year);
     }
 
     @Override
     protected boolean isValidYear(int year) {
-        return DATES.containsKey(year);
+        return DatesHolder.DATA.containsKey(year);
     }
 
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaHaji.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaHaji.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.islamic;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -39,64 +40,25 @@ import java.util.Map;
  * 5 Jan is used as Singapore's gazetted public holiday per MUIS convention. As a
  * result, the 2040 entry falls in December.</p>
  *
+ * <p>Date data is loaded at runtime from {@code hari-raya-haji.csv} in this package.</p>
+ *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HariRayaHaji extends AbstractObservance {
 
-    private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
-        // 2019–2030: Singapore MOM official gazette
-        Map.entry(2019, LocalDate.of(2019, 8, 11)),
-        Map.entry(2020, LocalDate.of(2020, 7, 31)),
-        Map.entry(2021, LocalDate.of(2021, 7, 20)),
-        Map.entry(2022, LocalDate.of(2022, 7, 10)),
-        Map.entry(2023, LocalDate.of(2023, 6, 29)),
-        Map.entry(2024, LocalDate.of(2024, 6, 17)),
-        Map.entry(2025, LocalDate.of(2025, 6,  7)),
-        Map.entry(2026, LocalDate.of(2026, 5, 27)),
-        Map.entry(2027, LocalDate.of(2027, 5, 16)),
-        Map.entry(2028, LocalDate.of(2028, 5,  5)),
-        Map.entry(2029, LocalDate.of(2029, 4, 24)),
-        Map.entry(2030, LocalDate.of(2030, 4, 13)),
-        // 2031–2055: Tabular Islamic calendar projection (10 Dhu al-Hijjah, Küçük 30-year cycle,
-        // epoch 1 Muharram 1 AH = JDN 1948439); actual dates subject to MUIS local moon-sighting
-        // confirmation and may differ by ±1 day. Verify against official MUIS gazette annually.
-        // 2039 has two 10 Dhu al-Hijjah occurrences (5 Jan AH 1460; 25 Dec AH 1461);
-        // 5 Jan is used as Singapore's gazetted public holiday. 2040 falls in December accordingly.
-        Map.entry(2031, LocalDate.of(2031, 4,  2)),
-        Map.entry(2032, LocalDate.of(2032, 3, 21)),
-        Map.entry(2033, LocalDate.of(2033, 3, 11)),
-        Map.entry(2034, LocalDate.of(2034, 2, 28)),
-        Map.entry(2035, LocalDate.of(2035, 2, 17)),
-        Map.entry(2036, LocalDate.of(2036, 2,  7)),
-        Map.entry(2037, LocalDate.of(2037, 1, 26)),
-        Map.entry(2038, LocalDate.of(2038, 1, 16)),
-        Map.entry(2039, LocalDate.of(2039, 1,  5)),
-        Map.entry(2040, LocalDate.of(2040, 12, 14)),
-        Map.entry(2041, LocalDate.of(2041, 12,  3)),
-        Map.entry(2042, LocalDate.of(2042, 11, 22)),
-        Map.entry(2043, LocalDate.of(2043, 11, 12)),
-        Map.entry(2044, LocalDate.of(2044, 10, 31)),
-        Map.entry(2045, LocalDate.of(2045, 10, 21)),
-        Map.entry(2046, LocalDate.of(2046, 10, 10)),
-        Map.entry(2047, LocalDate.of(2047,  9, 29)),
-        Map.entry(2048, LocalDate.of(2048,  9, 18)),
-        Map.entry(2049, LocalDate.of(2049,  9,  7)),
-        Map.entry(2050, LocalDate.of(2050,  8, 27)),
-        Map.entry(2051, LocalDate.of(2051,  8, 17)),
-        Map.entry(2052, LocalDate.of(2052,  8,  5)),
-        Map.entry(2053, LocalDate.of(2053,  7, 25)),
-        Map.entry(2054, LocalDate.of(2054,  7, 15)),
-        Map.entry(2055, LocalDate.of(2055,  7,  4))
-    );
+    private static final class DatesHolder {
+        static final Map<Integer, LocalDate> DATA =
+            CsvObservanceLoader.loadSingle(HariRayaHaji.class, "hari-raya-haji.csv");
+    }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return DATES.get(year);
+        return DatesHolder.DATA.get(year);
     }
 
     @Override
     protected boolean isValidYear(int year) {
-        return DATES.containsKey(year);
+        return DatesHolder.DATA.containsKey(year);
     }
 
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaPuasa.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/islamic/HariRayaPuasa.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.islamic;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -33,69 +34,32 @@ import java.util.Map;
  * public holiday gazette notifications and MUIS (Majlis Ugama Islam Singapura) announcements.
  * Dates for 2031–2055 are projected from the Umm al-Qura tabular Islamic calendar
  * (1 Shawwal AH, adjusted to SGT via Singapore's Imkan ar-Rukyah +1-day offset); verify
- * against MUIS/MOM gazette announcements at https://data.gov.sg/collections/691/view as
+ * against MUIS/MOM gazette announcements at <a href="https://data.gov.sg/collections/691/view">...</a> as
  * each year is officially published.</p>
  *
  * <p>Note: Gregorian year 2033 contains two Eid al-Fitr occurrences (~January 4 and
- * ~December 24). This map records only the first (January) occurrence; the December
+ * ~December 24). Only the first (January) occurrence is recorded; the December
  * occurrence cannot be represented under the single-date-per-year-key design.</p>
+ *
+ * <p>Date data is loaded at runtime from {@code hari-raya-puasa.csv} in this package.</p>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HariRayaPuasa extends AbstractObservance {
 
-    private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
-        // 2019–2030: Singapore MOM/MUIS official gazette
-        Map.entry(2019, LocalDate.of(2019,  6,  5)),
-        Map.entry(2020, LocalDate.of(2020,  5, 24)),
-        Map.entry(2021, LocalDate.of(2021,  5, 13)),
-        Map.entry(2022, LocalDate.of(2022,  5,  3)),
-        Map.entry(2023, LocalDate.of(2023,  4, 21)),
-        Map.entry(2024, LocalDate.of(2024,  4, 10)),
-        Map.entry(2025, LocalDate.of(2025,  3, 31)),
-        Map.entry(2026, LocalDate.of(2026,  3, 20)),
-        Map.entry(2027, LocalDate.of(2027,  3, 10)),
-        Map.entry(2028, LocalDate.of(2028,  2, 27)),
-        Map.entry(2029, LocalDate.of(2029,  2, 16)),
-        Map.entry(2030, LocalDate.of(2030,  2,  5)),
-        // 2031–2055: Umm al-Qura tabular Islamic calendar (1 Shawwal AH, adjusted to SGT
-        // via Singapore's Imkan ar-Rukyah +1-day offset); verify against MUIS/MOM gazette
-        // as each year is officially published. 2033 records only the January occurrence.
-        Map.entry(2031, LocalDate.of(2031,  1, 25)),
-        Map.entry(2032, LocalDate.of(2032,  1, 15)),
-        Map.entry(2033, LocalDate.of(2033,  1,  4)),
-        Map.entry(2034, LocalDate.of(2034, 12, 13)),
-        Map.entry(2035, LocalDate.of(2035, 12,  2)),
-        Map.entry(2036, LocalDate.of(2036, 11, 20)),
-        Map.entry(2037, LocalDate.of(2037, 11, 10)),
-        Map.entry(2038, LocalDate.of(2038, 10, 30)),
-        Map.entry(2039, LocalDate.of(2039, 10, 20)),
-        Map.entry(2040, LocalDate.of(2040, 10,  9)),
-        Map.entry(2041, LocalDate.of(2041,  9, 28)),
-        Map.entry(2042, LocalDate.of(2042,  9, 17)),
-        Map.entry(2043, LocalDate.of(2043,  9,  6)),
-        Map.entry(2044, LocalDate.of(2044,  8, 25)),
-        Map.entry(2045, LocalDate.of(2045,  8, 15)),
-        Map.entry(2046, LocalDate.of(2046,  8,  5)),
-        Map.entry(2047, LocalDate.of(2047,  7, 25)),
-        Map.entry(2048, LocalDate.of(2048,  7, 14)),
-        Map.entry(2049, LocalDate.of(2049,  7,  3)),
-        Map.entry(2050, LocalDate.of(2050,  6, 22)),
-        Map.entry(2051, LocalDate.of(2051,  6, 11)),
-        Map.entry(2052, LocalDate.of(2052,  5, 31)),
-        Map.entry(2053, LocalDate.of(2053,  5, 20)),
-        Map.entry(2054, LocalDate.of(2054,  5, 10)),
-        Map.entry(2055, LocalDate.of(2055,  4, 29))
-    );
+    private static final class DatesHolder {
+        static final Map<Integer, LocalDate> DATA =
+            CsvObservanceLoader.loadSingle(HariRayaPuasa.class, "hari-raya-puasa.csv");
+    }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return DATES.get(year);
+        return DatesHolder.DATA.get(year);
     }
 
     @Override
     protected boolean isValidYear(int year) {
-        return DATES.containsKey(year);
+        return DatesHolder.DATA.containsKey(year);
     }
 
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/lunar/VesakDay.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/lunar/VesakDay.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.lunar;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
 
 import java.time.LocalDate;
 import java.util.Map;
@@ -36,61 +37,25 @@ import java.util.Map;
  * lunisolar month 4 in SGT), pending official MOM gazette confirmation. All entries
  * should be verified against MOM announcements as Singapore approaches each year.</p>
  *
+ * <p>Date data is loaded at runtime from {@code vesak-day.csv} in this package.</p>
+ *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class VesakDay extends AbstractObservance {
 
-    private static final Map<Integer, LocalDate> DATES = Map.ofEntries(
-        // 2019–2030: Singapore MOM official gazette
-        Map.entry(2019, LocalDate.of(2019, 5, 19)),
-        Map.entry(2020, LocalDate.of(2020, 5,  7)),
-        Map.entry(2021, LocalDate.of(2021, 5, 26)),
-        Map.entry(2022, LocalDate.of(2022, 5, 15)),
-        Map.entry(2023, LocalDate.of(2023, 6,  2)),
-        Map.entry(2024, LocalDate.of(2024, 5, 22)),
-        Map.entry(2025, LocalDate.of(2025, 5, 12)),
-        Map.entry(2026, LocalDate.of(2026, 5, 31)),
-        Map.entry(2027, LocalDate.of(2027, 5, 20)),
-        Map.entry(2028, LocalDate.of(2028, 5,  8)),
-        Map.entry(2029, LocalDate.of(2029, 5, 27)),
-        Map.entry(2030, LocalDate.of(2030, 5, 16)),
-        // 2031–2055: HKO Gregorian-Lunar Conversion Tables (M4 day 15 in SGT);
-        // verify against MOM gazette as each year is officially published.
-        Map.entry(2031, LocalDate.of(2031, 6,  4)),
-        Map.entry(2032, LocalDate.of(2032, 5, 23)),
-        Map.entry(2033, LocalDate.of(2033, 5, 13)),
-        Map.entry(2034, LocalDate.of(2034, 6,  1)),
-        Map.entry(2035, LocalDate.of(2035, 5, 22)),
-        Map.entry(2036, LocalDate.of(2036, 5, 10)),
-        Map.entry(2037, LocalDate.of(2037, 5, 29)),
-        Map.entry(2038, LocalDate.of(2038, 5, 18)),
-        Map.entry(2039, LocalDate.of(2039, 5,  7)),
-        Map.entry(2040, LocalDate.of(2040, 5, 25)),
-        Map.entry(2041, LocalDate.of(2041, 5, 14)),
-        Map.entry(2042, LocalDate.of(2042, 6,  2)),
-        Map.entry(2043, LocalDate.of(2043, 5, 23)),
-        Map.entry(2044, LocalDate.of(2044, 5, 12)),
-        Map.entry(2045, LocalDate.of(2045, 5, 31)),
-        Map.entry(2046, LocalDate.of(2046, 5, 20)),
-        Map.entry(2047, LocalDate.of(2047, 5,  9)),
-        Map.entry(2048, LocalDate.of(2048, 5, 27)), // computed via Xiaoman method; HKO 2048e PDF is image-rendered
-        Map.entry(2049, LocalDate.of(2049, 5, 16)),
-        Map.entry(2050, LocalDate.of(2050, 6,  4)),
-        Map.entry(2051, LocalDate.of(2051, 5, 24)),
-        Map.entry(2052, LocalDate.of(2052, 5, 13)),
-        Map.entry(2053, LocalDate.of(2053, 6,  1)),
-        Map.entry(2054, LocalDate.of(2054, 5, 22)),
-        Map.entry(2055, LocalDate.of(2055, 5, 11))
-    );
+    private static final class DatesHolder {
+        static final Map<Integer, LocalDate> DATA =
+            CsvObservanceLoader.loadSingle(VesakDay.class, "vesak-day.csv");
+    }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return DATES.get(year);
+        return DatesHolder.DATA.get(year);
     }
 
     @Override
     protected boolean isValidYear(int year) {
-        return DATES.containsKey(year);
+        return DatesHolder.DATA.containsKey(year);
     }
 
 }

--- a/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/hindu/deepavali.csv
+++ b/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/hindu/deepavali.csv
@@ -1,0 +1,54 @@
+# Deepavali (Diwali) — Singapore public holiday dates
+# The Hindu Festival of Lights. In Singapore, Deepavali is observed on the first
+# day of the Tamil month of Karthigai and is officially gazetted by the Singapore
+# government each year.
+#
+# 2019–2030: Singapore Ministry of Manpower (MOM) official gazette.
+# 2031–2055: Derived from Tamil Panchang calculations (Karthigai month
+#            commencement / Karthigai Amavasai, IST/SGT) cross-referenced with
+#            Drik Panchang astronomical tables; verify against MOM gazette as
+#            each year is officially published.
+#
+# Format: year,YYYY-MM-DD,source
+#
+# 2019–2030: Singapore MOM official gazette
+2019,2019-10-27,MOM gazette
+2020,2020-11-14,MOM gazette
+2021,2021-11-04,MOM gazette
+2022,2022-10-24,MOM gazette
+2023,2023-11-12,MOM gazette
+2024,2024-10-31,MOM gazette
+2025,2025-10-20,MOM gazette
+2026,2026-11-08,MOM gazette
+2027,2027-10-29,MOM gazette
+2028,2028-10-17,MOM gazette
+2029,2029-11-05,MOM gazette
+2030,2030-10-26,MOM gazette
+# 2031–2055: Tamil Panchang projection (1st day of Tamil month Karthigai, SGT),
+# cross-referenced with Drik Panchang astronomical tables; verify against MOM
+# gazette as each year is officially published.
+2031,2031-11-14,Tamil Panchang / Drik Panchang projection
+2032,2032-11-02,Tamil Panchang / Drik Panchang projection
+2033,2033-10-23,Tamil Panchang / Drik Panchang projection
+2034,2034-11-10,Tamil Panchang / Drik Panchang projection
+2035,2035-10-31,Tamil Panchang / Drik Panchang projection
+2036,2036-10-19,Tamil Panchang / Drik Panchang projection
+2037,2037-11-07,Tamil Panchang / Drik Panchang projection
+2038,2038-10-27,Tamil Panchang / Drik Panchang projection
+2039,2039-10-16,Tamil Panchang / Drik Panchang projection
+2040,2040-11-03,Tamil Panchang / Drik Panchang projection
+2041,2041-10-24,Tamil Panchang / Drik Panchang projection
+2042,2042-11-11,Tamil Panchang / Drik Panchang projection
+2043,2043-11-01,Tamil Panchang / Drik Panchang projection
+2044,2044-10-20,Tamil Panchang / Drik Panchang projection
+2045,2045-11-08,Tamil Panchang / Drik Panchang projection
+2046,2046-10-29,Tamil Panchang / Drik Panchang projection
+2047,2047-10-19,Tamil Panchang / Drik Panchang projection
+2048,2048-11-05,Tamil Panchang / Drik Panchang projection
+2049,2049-10-25,Tamil Panchang / Drik Panchang projection
+2050,2050-10-15,Tamil Panchang / Drik Panchang projection
+2051,2051-11-03,Tamil Panchang / Drik Panchang projection
+2052,2052-10-22,Tamil Panchang / Drik Panchang projection
+2053,2053-11-10,Tamil Panchang / Drik Panchang projection
+2054,2054-10-30,Tamil Panchang / Drik Panchang projection
+2055,2055-10-19,Tamil Panchang / Drik Panchang projection

--- a/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/islamic/hari-raya-haji.csv
+++ b/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/islamic/hari-raya-haji.csv
@@ -1,0 +1,60 @@
+# Hari Raya Haji (Eid al-Adha) — Singapore public holiday dates
+# The Feast of Sacrifice on the 10th day of Dhu al-Hijjah. The observed date is
+# officially gazetted by the Singapore government and follows the local lunar
+# sighting, which may differ from tabular Islamic calendar calculations.
+#
+# 2019–2030: Singapore Ministry of Manpower (MOM) official gazette.
+# 2031–2055: Derived from the tabular Islamic calendar (Küçük 30-year leap cycle,
+#            10 Dhu al-Hijjah, SGT); actual dates subject to MUIS (Majlis Ugama
+#            Islam Singapura) local moon-sighting confirmation and may differ by
+#            ±1 day. Verify against official MUIS gazette annually.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (5 Jan AH 1460 and 25 Dec AH 1461). 5 Jan 2039 is used as Singapore's gazetted
+# public holiday per MUIS convention. As a consequence, the 2040 entry falls in
+# December (14 Dec 2040) rather than earlier in the year — this is correct.
+#
+# Format: year,YYYY-MM-DD,source
+#
+# 2019–2030: Singapore MOM official gazette
+2019,2019-08-11,MOM gazette
+2020,2020-07-31,MOM gazette
+2021,2021-07-20,MOM gazette
+2022,2022-07-10,MOM gazette
+2023,2023-06-29,MOM gazette
+2024,2024-06-17,MOM gazette
+2025,2025-06-07,MOM gazette
+2026,2026-05-27,MOM gazette
+2027,2027-05-16,MOM gazette
+2028,2028-05-05,MOM gazette
+2029,2029-04-24,MOM gazette
+2030,2030-04-13,MOM gazette
+# 2031–2055: Tabular Islamic calendar (10 Dhu al-Hijjah, Küçük 30-year cycle,
+# epoch 1 Muharram 1 AH = JDN 1948439); verify against MUIS gazette annually.
+2031,2031-04-02,Küçük tabular projection
+2032,2032-03-21,Küçük tabular projection
+2033,2033-03-11,Küçük tabular projection
+2034,2034-02-28,Küçük tabular projection
+2035,2035-02-17,Küçük tabular projection
+2036,2036-02-07,Küçük tabular projection
+2037,2037-01-26,Küçük tabular projection
+2038,2038-01-16,Küçük tabular projection
+# 2039: two 10 Dhu al-Hijjah occurrences (5 Jan AH 1460; 25 Dec AH 1461); 5 Jan used per MUIS convention
+2039,2039-01-05,Küçük tabular projection (5 Jan AH 1460; second occurrence 25 Dec AH 1461 omitted)
+# 2040: falls in December because the January slot was consumed by the 2039 double-occurrence
+2040,2040-12-14,Küçük tabular projection (December — consequence of 2039 double-occurrence)
+2041,2041-12-03,Küçük tabular projection
+2042,2042-11-22,Küçük tabular projection
+2043,2043-11-12,Küçük tabular projection
+2044,2044-10-31,Küçük tabular projection
+2045,2045-10-21,Küçük tabular projection
+2046,2046-10-10,Küçük tabular projection
+2047,2047-09-29,Küçük tabular projection
+2048,2048-09-18,Küçük tabular projection
+2049,2049-09-07,Küçük tabular projection
+2050,2050-08-27,Küçük tabular projection
+2051,2051-08-17,Küçük tabular projection
+2052,2052-08-05,Küçük tabular projection
+2053,2053-07-25,Küçük tabular projection
+2054,2054-07-15,Küçük tabular projection
+2055,2055-07-04,Küçük tabular projection

--- a/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/islamic/hari-raya-puasa.csv
+++ b/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/islamic/hari-raya-puasa.csv
@@ -1,0 +1,62 @@
+# Hari Raya Puasa (Eid al-Fitr) — Singapore public holiday dates
+# Marks the end of Ramadan. The observed date is officially gazetted by the
+# Singapore government and follows the local lunar sighting, which may differ
+# from tabular Islamic calendar calculations.
+#
+# 2019–2030: Singapore Ministry of Manpower (MOM) official gazette and
+#            MUIS (Majlis Ugama Islam Singapura) announcements.
+# 2031–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (1 Shawwal AH, adjusted to SGT via Singapore's Imkan ar-Rukyah
+#            +1-day offset); verify against MUIS/MOM gazette announcements at
+#            https://data.gov.sg/collections/691/view as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 4 and ~December 24). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design. If the design is ever extended to support multiple dates per
+# year, the December 2033 occurrence should be added.
+#
+# Format: year,YYYY-MM-DD,source
+#
+# 2019–2030: Singapore MOM/MUIS official gazette
+2019,2019-06-05,MOM/MUIS gazette
+2020,2020-05-24,MOM/MUIS gazette
+2021,2021-05-13,MOM/MUIS gazette
+2022,2022-05-03,MOM/MUIS gazette
+2023,2023-04-21,MOM/MUIS gazette
+2024,2024-04-10,MOM/MUIS gazette
+2025,2025-03-31,MOM/MUIS gazette
+2026,2026-03-20,MOM/MUIS gazette
+2027,2027-03-10,MOM/MUIS gazette
+2028,2028-02-27,MOM/MUIS gazette
+2029,2029-02-16,MOM/MUIS gazette
+2030,2030-02-05,MOM/MUIS gazette
+# 2031–2055: Umm al-Qura tabular Islamic calendar (1 Shawwal AH, adjusted to SGT
+# via Singapore's Imkan ar-Rukyah +1-day offset); verify against MUIS/MOM gazette
+# as each year is officially published.
+2031,2031-01-25,Umm al-Qura projection
+2032,2032-01-15,Umm al-Qura projection
+# 2033 records only the January occurrence; ~December 24 cannot be stored (single key per year)
+2033,2033-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-13,Umm al-Qura projection
+2035,2035-12-02,Umm al-Qura projection
+2036,2036-11-20,Umm al-Qura projection
+2037,2037-11-10,Umm al-Qura projection
+2038,2038-10-30,Umm al-Qura projection
+2039,2039-10-20,Umm al-Qura projection
+2040,2040-10-09,Umm al-Qura projection
+2041,2041-09-28,Umm al-Qura projection
+2042,2042-09-17,Umm al-Qura projection
+2043,2043-09-06,Umm al-Qura projection
+2044,2044-08-25,Umm al-Qura projection
+2045,2045-08-15,Umm al-Qura projection
+2046,2046-08-05,Umm al-Qura projection
+2047,2047-07-25,Umm al-Qura projection
+2048,2048-07-14,Umm al-Qura projection
+2049,2049-07-03,Umm al-Qura projection
+2050,2050-06-22,Umm al-Qura projection
+2051,2051-06-11,Umm al-Qura projection
+2052,2052-05-31,Umm al-Qura projection
+2053,2053-05-20,Umm al-Qura projection
+2054,2054-05-10,Umm al-Qura projection
+2055,2055-04-29,Umm al-Qura projection

--- a/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/lunar/vesak-day.csv
+++ b/holiday-calendar-apac/src/main/resources/org/holiday/calendar/observance/lunar/vesak-day.csv
@@ -1,0 +1,52 @@
+# Vesak Day (Buddha's Birthday) — Singapore public holiday dates
+# Vesak Day falls on the full moon of the fourth month of the Chinese lunisolar
+# calendar, observed on the date officially gazetted by the Singapore government.
+#
+# 2019–2030: Singapore Ministry of Manpower (MOM) official gazette
+# 2031–2055: Hong Kong Observatory Gregorian-Lunar Calendar Conversion Tables
+#            (day 15 of Chinese lunisolar month 4 in SGT); verify against MOM
+#            gazette as each year is officially published.
+#
+# Format: year,YYYY-MM-DD,source
+#
+# 2019–2030: Singapore MOM official gazette
+2019,2019-05-19,MOM gazette
+2020,2020-05-07,MOM gazette
+2021,2021-05-26,MOM gazette
+2022,2022-05-15,MOM gazette
+2023,2023-06-02,MOM gazette
+2024,2024-05-22,MOM gazette
+2025,2025-05-12,MOM gazette
+2026,2026-05-31,MOM gazette
+2027,2027-05-20,MOM gazette
+2028,2028-05-08,MOM gazette
+2029,2029-05-27,MOM gazette
+2030,2030-05-16,MOM gazette
+# 2031–2055: HKO Gregorian-Lunar Conversion Tables (M4 day 15 in SGT);
+# verify against MOM gazette as each year is officially published.
+2031,2031-06-04,HKO conversion table
+2032,2032-05-23,HKO conversion table
+2033,2033-05-13,HKO conversion table
+2034,2034-06-01,HKO conversion table
+2035,2035-05-22,HKO conversion table
+2036,2036-05-10,HKO conversion table
+2037,2037-05-29,HKO conversion table
+2038,2038-05-18,HKO conversion table
+2039,2039-05-07,HKO conversion table
+2040,2040-05-25,HKO conversion table
+2041,2041-05-14,HKO conversion table
+2042,2042-06-02,HKO conversion table
+2043,2043-05-23,HKO conversion table
+2044,2044-05-12,HKO conversion table
+2045,2045-05-31,HKO conversion table
+2046,2046-05-20,HKO conversion table
+2047,2047-05-09,HKO conversion table
+# 2048: computed via Xiaoman method; HKO 2048e PDF is image-rendered
+2048,2048-05-27,Xiaoman method (HKO 2048e PDF image-rendered)
+2049,2049-05-16,HKO conversion table
+2050,2050-06-04,HKO conversion table
+2051,2051-05-24,HKO conversion table
+2052,2052-05-13,HKO conversion table
+2053,2053-06-01,HKO conversion table
+2054,2054-05-22,HKO conversion table
+2055,2055-05-11,HKO conversion table

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/islamic/HariRayaHajiTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/islamic/HariRayaHajiTest.java
@@ -209,7 +209,17 @@ public class HariRayaHajiTest {
     }
 
     // -------------------------------------------------------------------------
-    // Group 8: Structural guard — table covers exactly 37 years (2019–2055)
+    // Group 8: Date year must match the key year for all covered years
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "allCoveredYears")
+    public void testDateYearMatchesKey(int year, LocalDate expected) {
+        assertEquals(expected.getYear(), year,
+            "HariRayaHaji date year must match the key year for " + year);
+    }
+
+    // -------------------------------------------------------------------------
+    // Group 9: Structural guard — table covers exactly 37 years (2019–2055)
     // -------------------------------------------------------------------------
 
     @Test


### PR DESCRIPTION
### Migrate SG non-Gregorian observances to CSV-backed implementation

**Description**

- Replaced hardcoded `Map.ofEntries(...)` date tables in `VesakDay`, `HariRayaPuasa`, `HariRayaHaji`, and `Deepavali` with lazy `DatesHolder` inner classes that load from CSV via `CsvObservanceLoader.loadSingle()`
- Created four companion CSV resource files in the same package directory as each observance class, with source attribution comments and inline notes for all special cases (HariRayaPuasa 2033 two-occurrence, HariRayaHaji 2039/2040 double-occurrence, VesakDay 2048 Xiaoman method)
- Retained Javadoc source attribution in each class; removed duplicate date tables; added CSV resource reference
- Added `testDateYearMatchesKey` to `HariRayaHajiTest` to guard against the 2039/2040 December transcription risk

**Related Issue**

- [#142 Migrate SG non-Gregorian observances to CSV-backed implementation](https://github.com/holiday-calendar/holiday-calendar-java/issues/142)

**Type of Change**

- [x] Code refactor

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed