### PR TITLE
#139 Singapore MAS MEPS+ (SGD) holiday calendar

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Key design goals:
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `SG` | Singapore (SGX) Holidays |
+| `SGD` | Singapore (MAS/MEPS+) Holidays |
 | `UK` | United Kingdom National Holidays |
 | `US` | United States National Holidays |
 | `USD` | United States (Federal Reserve) Holidays |
@@ -73,7 +74,7 @@ Then add the modules you need:
   <version>1.2.0-SNAPSHOT</version>
 </dependency>
 
-<!-- APAC calendars: SG, JP, JPY, CNY -->
+<!-- APAC calendars: SG, SGD, JP, JPY, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
@@ -120,7 +121,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "UK", "US", "USD"]
+// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-apac/src/main/java/module-info.java
+++ b/holiday-calendar-apac/src/main/java/module-info.java
@@ -21,8 +21,8 @@
  *
  * <p>Provides holiday calendar implementations and observances for Asia-Pacific
  * countries, including lunar, Islamic, and Hindu calendar-based holidays.
- * Supports Singapore SGX (SG), Tokyo Stock Exchange (JP), Bank of Japan (JPY),
- * and People's Bank of China (CNY).
+ * Supports Singapore SGX (SG), Singapore MAS MEPS+ (SGD), Tokyo Stock Exchange (JP),
+ * Bank of Japan (JPY), and People's Bank of China (CNY).
  */
 module org.holiday.calendar.apac {
     requires org.holiday.calendar.core;
@@ -38,6 +38,7 @@ module org.holiday.calendar.apac {
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceCNY,
         org.holiday.calendar.impl.HolidayCalendarServiceSG,
+        org.holiday.calendar.impl.HolidayCalendarServiceSGD,
         org.holiday.calendar.impl.HolidayCalendarServiceJP,
         org.holiday.calendar.impl.HolidayCalendarServiceJPY;
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSGD.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSGD.java
@@ -25,16 +25,27 @@ import org.holiday.calendar.function.DateRolls;
 import java.util.OptionalInt;
 
 /**
- * Service for provision of Singapore Exchange (SGX) holiday calendar.
+ * Service for provision of the Singapore MAS MEPS+ holiday calendar.
  *
- * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ * <p>Calendar code: {@code SGD}. MEPS+ (MAS Electronic Payment System Plus) is
+ * Singapore's real-time gross settlement (RTGS) system for SGD interbank payments.
+ * Settlement holidays follow Singapore's statutory public holiday schedule.
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — RTGS settlement requires both
+ * counterparties to be available on the same calendar date; there is no roll-forward
+ * convention. All holidays are {@code rollable(false)}.
+ *
+ * <p>Reference: MAS MEPS+ Service Agreement (effective 1 Oct 2025), which defines
+ * "business day" as any Monday–Friday excluding Singapore public holidays.
+ * No additional bank-specific closure days (analogous to BOJ Jan 2, Jan 3, Dec 31)
+ * are published by MAS for MEPS+.
  */
-public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
+public class HolidayCalendarServiceSGD extends AbstractHolidayCalendarService {
 
-    private static final String CODE = "SG";
-    private static final String NAME = "Singapore (SGX) Holidays";
+    private static final String CODE = "SGD";
+    private static final String NAME = "Singapore (MAS/MEPS+) Holidays";
 
-    public HolidayCalendarServiceSG() {
+    public HolidayCalendarServiceSGD() {
         super(CODE, NAME);
     }
 
@@ -48,10 +59,9 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
-                .dateRoll(DateRolls.followingMonday())
+                .dateRoll(DateRolls.noRoll())
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
-                .holidays(SingaporeHolidays.baseHolidays(true))
+                .holidays(SingaporeHolidays.baseHolidays(false))
                 .build();
     }
-
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/SingaporeHolidays.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/SingaporeHolidays.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.hindu.Deepavali;
+import org.holiday.calendar.observance.islamic.HariRayaHaji;
+import org.holiday.calendar.observance.islamic.HariRayaPuasa;
+import org.holiday.calendar.observance.lunar.ChineseNewYearFirstDay;
+import org.holiday.calendar.observance.lunar.ChineseNewYearSecondDay;
+import org.holiday.calendar.observance.lunar.VesakDay;
+
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Singapore statutory public holiday list shared
+ * by the SGX ({@code SG}) and MEPS+ ({@code SGD}) calendars.
+ *
+ * <p>The four gazetted lookup-table observances (VesakDay, HariRayaPuasa,
+ * HariRayaHaji, Deepavali) are populated through {@value DATA_VALID_THROUGH}.
+ * Chinese New Year is computed algorithmically via Time4J and has no upper bound.
+ */
+class SingaporeHolidays {
+
+    // Boundary year through which all four gazetted lookup-table observances
+    // (VesakDay, HariRayaPuasa, HariRayaHaji, Deepavali) are populated.
+    static final int DATA_VALID_THROUGH = 2055;
+
+    private SingaporeHolidays() {}
+
+    /**
+     * Returns the 11 Singapore statutory public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, Labour Day,
+     *                      National Day, Christmas Day) are rollable; all floating
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Chinese New Year (1st Day)")
+                    .description("First day of the Chinese lunisolar new year")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ChineseNewYearFirstDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Chinese New Year (2nd Day)")
+                    .description("Second day of the Chinese lunisolar new year")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ChineseNewYearSecondDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Good Friday")
+                    .description("Commemoration of the crucifixion of Jesus Christ")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new GoodFriday(new WesternEaster()))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Vesak Day")
+                    .description("Commemoration of the birth, enlightenment, and death of Gautama Buddha")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new VesakDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Hari Raya Puasa")
+                    .description("Eid al-Fitr, marking the end of Ramadan")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new HariRayaPuasa())
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("Commemoration of Singapore's independence on 9 August 1965")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.AUGUST, 9)
+                    .build(),
+            Holiday.builder()
+                    .name("Hari Raya Haji")
+                    .description("Eid al-Adha, the Feast of Sacrifice")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new HariRayaHaji())
+                    .build(),
+            Holiday.builder()
+                    .name("Deepavali")
+                    .description("Hindu Festival of Lights")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new Deepavali())
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Celebration of traditional Christmas holiday")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build()
+        );
+    }
+}

--- a/holiday-calendar-apac/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-apac/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,4 +1,5 @@
 org.holiday.calendar.impl.HolidayCalendarServiceCNY
 org.holiday.calendar.impl.HolidayCalendarServiceSG
+org.holiday.calendar.impl.HolidayCalendarServiceSGD
 org.holiday.calendar.impl.HolidayCalendarServiceJP
 org.holiday.calendar.impl.HolidayCalendarServiceJPY

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGDTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGDTest.java
@@ -1,0 +1,223 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceSGDTest {
+
+    private final HolidayCalendarServiceSGD service = new HolidayCalendarServiceSGD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── Identity ──────────────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("SGD"));
+        assertFalse(service.isProvided("SG"), "SGD service must not respond to the SG exchange code");
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "SGD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Singapore (MAS/MEPS+) Holidays");
+    }
+
+    // ── ServiceLoader / factory path ──────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("SGD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "SGD");
+    }
+
+    // ── noRoll() vs followingMonday() — the key behavioural difference ────────
+
+    @Test
+    public void testNoRoll_NewYearsDay2023() {
+        // Jan 1, 2023 is Sunday.
+        // SG (followingMonday) rolls to Jan 2.  SGD (noRoll) stays on Jan 1.
+        HolidayCalendar sgCalendar  = new HolidayCalendarServiceSG().getHolidayCalendar();
+        HolidayCalendar sgdCalendar = service.getHolidayCalendar();
+
+        Optional<HolidayDate> sgNYD = findByName(sgCalendar.calculate(2023), "New Year's Day");
+        Optional<HolidayDate> sgdNYD = findByName(sgdCalendar.calculate(2023), "New Year's Day");
+
+        assertTrue(sgNYD.isPresent());
+        assertTrue(sgdNYD.isPresent());
+        assertEquals(sgNYD.get().getDate(),  LocalDate.of(2023, Month.JANUARY, 2),
+                "SG must roll New Year's Day (Jan 1 Sun 2023) to Jan 2");
+        assertEquals(sgdNYD.get().getDate(), LocalDate.of(2023, Month.JANUARY, 1),
+                "SGD must NOT roll New Year's Day — noRoll() keeps it on Jan 1");
+    }
+
+    @Test
+    public void testNoRoll_NationalDay2020() {
+        // Aug 9, 2020 is Sunday.
+        // SG rolls National Day to Aug 10.  SGD stays on Aug 9.
+        HolidayCalendar sgCalendar  = new HolidayCalendarServiceSG().getHolidayCalendar();
+        HolidayCalendar sgdCalendar = service.getHolidayCalendar();
+
+        Optional<HolidayDate> sgND  = findByName(sgCalendar.calculate(2020), "National Day");
+        Optional<HolidayDate> sgdND = findByName(sgdCalendar.calculate(2020), "National Day");
+
+        assertTrue(sgND.isPresent());
+        assertTrue(sgdND.isPresent());
+        assertEquals(sgND.get().getDate(),  LocalDate.of(2020, Month.AUGUST, 10),
+                "SG must roll National Day (Aug 9 Sun 2020) to Aug 10");
+        assertEquals(sgdND.get().getDate(), LocalDate.of(2020, Month.AUGUST, 9),
+                "SGD must NOT roll National Day — noRoll() keeps it on Aug 9");
+    }
+
+    // ── Holiday list completeness ─────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAllHolidaysPresent2024() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), 11,
+                "Expected all 11 SGD holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testChronologicalOrder() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).getDate().isBefore(holidays.get(i - 1).getDate()),
+                    "SGD holidays must be in chronological order");
+        }
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Chinese New Year (1st Day)"},
+            new Object[]{"Chinese New Year (2nd Day)"},
+            new Object[]{"Good Friday"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Vesak Day"},
+            new Object[]{"Hari Raya Puasa"},
+            new Object[]{"National Day"},
+            new Object[]{"Hari Raya Haji"},
+            new Object[]{"Deepavali"},
+            new Object[]{"Christmas Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "SGD calendar must contain holiday: " + holidayName);
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isPresent(),
+                "SGD calendar has lookup-table holidays; must return a bounded year from dataValidThrough()");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(
+                service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year")),
+                2055,
+                "dataValidThrough() must return 2055 — ceiling of all four lookup-table observances");
+    }
+
+    @Test
+    public void testDataValidThroughMatchesSG() {
+        OptionalInt sgd = service.dataValidThrough();
+        OptionalInt sg  = new HolidayCalendarServiceSG().dataValidThrough();
+        assertEquals(sgd.getAsInt(), sg.getAsInt(),
+                "SGD and SG must share the same dataValidThrough boundary year");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("SGD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(),
+                service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year")),
+                "factory.dataValidThrough(\"SGD\") must delegate to the service");
+    }
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year"));
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
+        assertEquals(holidays.size(), 11,
+                "Expected all 11 SGD holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsLookupTableHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year"));
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidaysAtBoundary = calendar.calculate(boundaryYear);
+        List<HolidayDate> holidaysBeyond = calendar.calculate(boundaryYear + 1);
+        assertTrue(holidaysBeyond.size() < holidaysAtBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (lookup tables exhausted); " +
+                "at boundary: " + holidaysAtBoundary.size() + ", beyond: " + holidaysBeyond.size());
+    }
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findByName(List<HolidayDate> holidays, String name) {
+        return holidays.stream()
+                       .filter(hd -> name.equals(hd.getHoliday().getName()))
+                       .findFirst();
+    }
+}

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -34,6 +34,7 @@ Key design goals:
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `SG` | Singapore (SGX) Holidays |
+| `SGD` | Singapore (MAS/MEPS+) Holidays |
 | `UK` | United Kingdom National Holidays |
 | `US` | United States National Holidays |
 | `USD` | United States (Federal Reserve) Holidays |
@@ -73,7 +74,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- APAC calendars: SG, JP, JPY, CNY -->
+<!-- APAC calendars: SG, SGD, JP, JPY, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
@@ -120,7 +121,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "UK", "US", "USD"]
+// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 17 implemented holiday calendars
+ * 30-year integration test suite validating all 18 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -69,6 +69,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"JP"},
                 new Object[]{"JPY"},
                 new Object[]{"SG"},
+                new Object[]{"SGD"},
                 new Object[]{"UK"},
                 new Object[]{"US"},
                 new Object[]{"USD"}


### PR DESCRIPTION
### #139 Singapore MAS MEPS+ (SGD) holiday calendar

**Description**

- Extracted `SingaporeHolidays` package-private utility class (analogous to `JapaneseHolidays`) holding the 11 Singapore statutory public holidays and the shared `DATA_VALID_THROUGH = 2055` constant; both `SG` and `SGD` delegate to it, eliminating future divergence risk
- Refactored `HolidayCalendarServiceSG` to delegate to `SingaporeHolidays.baseHolidays(true)` — no behaviour change, existing tests confirm this
- Implemented `HolidayCalendarServiceSGD` (code `SGD`) for Singapore MAS MEPS+ settlement calendar: `DateRolls.noRoll()`, all holidays `rollable(false)`, `dataValidThrough()` sourced from shared constant
- Registered `SGD` in `META-INF/services` and `module-info.java` `provides` clause
- Added `HolidayCalendarServiceSGDTest` (15 tests) including SG-vs-SGD roll-contrast tests proving `noRoll()` behaviour differs from `SG`'s `followingMonday()`
- Added `SGD` to `HolidayCalendar30YearIT` data provider (4 new integration test cases over 2026–2055)
- Updated `README.md`, `src/readme/README.md`, and `module-info.java` Javadoc to include `SGD`

**Holiday list note:** The MAS MEPS+ Service Agreement (effective 1 Oct 2025) defines "business day" as any Monday–Friday excluding Singapore public holidays. No additional bank-specific closure days (analogous to BOJ's Jan 2, Jan 3, Dec 31) are published by MAS for MEPS+. The `SGD` holiday list is therefore identical in content to `SG` — only the roll strategy differs.

**Related Issue**

- [#139 — Singapore — Monetary Authority of Singapore (MEPS+)](https://github.com/holiday-calendar/holiday-calendar-java/issues/139)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [x] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed