### PR TITLE
#140 China national public holidays calendar (CN)

### DIFF
--- a/holiday-calendar-apac/src/main/java/module-info.java
+++ b/holiday-calendar-apac/src/main/java/module-info.java
@@ -22,7 +22,7 @@
  * <p>Provides holiday calendar implementations and observances for Asia-Pacific
  * countries, including lunar, Islamic, and Hindu calendar-based holidays.
  * Supports Singapore SGX (SG), Singapore MAS MEPS+ (SGD), Tokyo Stock Exchange (JP),
- * Bank of Japan (JPY), and People's Bank of China (CNY).
+ * Bank of Japan (JPY), People's Bank of China (CNY), and China national (CN).
  */
 module org.holiday.calendar.apac {
     requires org.holiday.calendar.core;
@@ -40,5 +40,6 @@ module org.holiday.calendar.apac {
         org.holiday.calendar.impl.HolidayCalendarServiceSG,
         org.holiday.calendar.impl.HolidayCalendarServiceSGD,
         org.holiday.calendar.impl.HolidayCalendarServiceJP,
-        org.holiday.calendar.impl.HolidayCalendarServiceJPY;
+        org.holiday.calendar.impl.HolidayCalendarServiceJPY,
+        org.holiday.calendar.impl.HolidayCalendarServiceCN;
 }

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCN.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCN.java
@@ -1,0 +1,236 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.lunar.ChineseNewYearDay;
+import org.holiday.calendar.observance.lunar.DragonBoatFestival;
+import org.holiday.calendar.observance.lunar.MidAutumnFestival;
+import org.holiday.calendar.observance.lunar.QingmingFestival;
+
+import java.time.Month;
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of China national public holidays.
+ *
+ * <p>The calendar code is {@code CN}, reflecting the seven statutory public
+ * holidays as defined by China's State Council Ordinance on Public Holidays
+ * for National Festivals and Memorial Days (as amended in 2007 and 2013). It
+ * covers the minimum statutory closure window for each:
+ *
+ * <ul>
+ *   <li>New Year's Day — 1 January</li>
+ *   <li>Spring Festival (Chinese New Year) — Days 1–3 of the 1st lunar month</li>
+ *   <li>Qingming Festival — solar term at ecliptic longitude 15° (~4–5 April)</li>
+ *   <li>Labour Day — 1 May</li>
+ *   <li>Dragon Boat Festival — 5th day of the 5th lunar month</li>
+ *   <li>Mid-Autumn Festival — 15th day of the 8th lunar month</li>
+ *   <li>National Day Golden Week — 1–3 October</li>
+ * </ul>
+ *
+ * <h2>Distinction from CNY</h2>
+ *
+ * <p>This calendar ({@code CN}) models the statutory minimum windows as enacted
+ * in the Ordinance. It differs from {@link HolidayCalendarServiceCNY} ({@code CNY},
+ * the PBOC/CNAPS operational calendar) in three ways:
+ *
+ * <ol>
+ *   <li><strong>Window length</strong> — Spring Festival is 3 days here (Days 1–3)
+ *       versus 7 days in CNY; National Day is 3 days here versus 7 days in CNY.</li>
+ *   <li><strong>Labour Day</strong> — 1 day here (the statutory minimum) versus 3
+ *       days in CNY. The 5-day extended Labour Day window observed in practice since
+ *       2019 arises from the State Council's annual adjustment notice, not the
+ *       Ordinance itself.</li>
+ *   <li><strong>Roll strategy</strong> — {@link DateRolls#followingMonday()} applied
+ *       to single-day holidays; multi-day blocks use {@code rollable(false)}.</li>
+ * </ol>
+ *
+ * <h2>Roll Strategy</h2>
+ *
+ * <p>China's weekend adjustment mechanism (调休, <em>tiaoxiu</em>) is block-based,
+ * not per-day. When Spring Festival or National Day falls on a weekend, the State
+ * Council shifts the <em>entire block</em> into a contiguous window and designates
+ * nearby Saturdays or Sundays as compensatory working days (补班) via its annual
+ * holiday notice. No individual day within the block is independently moved to the
+ * following Monday.
+ *
+ * <p>This library's per-holiday {@link org.holiday.calendar.function.DateRoll} model
+ * cannot replicate that block-shifting mechanism. Applying {@code followingMonday()}
+ * to each day of a multi-day block independently would produce definitively wrong
+ * results (e.g., all three Spring Festival days collapsing to the same date when
+ * Day 1 falls on a Saturday). Therefore:
+ *
+ * <ul>
+ *   <li><strong>Single-day holidays</strong> (New Year's Day, Qingming Festival,
+ *       Labour Day, Dragon Boat Festival, Mid-Autumn Festival) are {@code rollable(true)}
+ *       — {@code followingMonday()} is a sound approximation of the Ordinance's
+ *       per-day substitution rule (Article 3).</li>
+ *   <li><strong>Multi-day blocks</strong> (Spring Festival Days 1–3, National Day
+ *       Days 1–3) are {@code rollable(false)} — dates are reported on their natural
+ *       calendar positions. For precise year-specific adjustments, consult the
+ *       State Council's annual holiday notice (gov.cn); the {@code CNY} calendar's
+ *       {@code getCompensatoryWorkingDays(int)} method provides curated data.</li>
+ * </ul>
+ *
+ * <h2>Data Validity</h2>
+ *
+ * <p>All public holidays are computed algorithmically via Time4J Chinese calendar
+ * mathematics. {@link HolidayCalendar#calculate(int)} is authoritative for any
+ * year with no upper bound; {@link #dataValidThrough()} returns
+ * {@link OptionalInt#empty()} accordingly.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceCN extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "CN";
+    private static final String NAME = "China National Holidays";
+    private static final String NATIONAL_DAY_CONTINUED = "National Day Golden Week (continued)";
+
+    public HolidayCalendarServiceCN() {
+        super(CODE, NAME);
+    }
+
+    /**
+     * Returns {@link OptionalInt#empty()} because all CN public holidays are
+     * computed algorithmically (Time4J Chinese calendar math for floating
+     * holidays; fixed calendar dates for the rest).
+     * {@link HolidayCalendar#calculate(int)} is authoritative for any year
+     * with no upper bound.
+     */
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.empty();
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday newYearsDay = Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JANUARY, 1)
+                .build();
+
+        // Spring Festival (Chinese New Year) — 3-day statutory window.
+        // rollable=false: China's block-shift adjustment cannot be modelled
+        // per-day; dates are reported on their natural lunar calendar positions.
+        final Holiday springFestivalDay1 = Holiday.builder()
+                .name("Spring Festival (Day 1)")
+                .description("First day of the Chinese lunisolar new year")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ChineseNewYearDay(1))
+                .build();
+        final Holiday springFestivalDay2 = Holiday.builder()
+                .name("Spring Festival (Day 2)")
+                .description("Second day of the Chinese lunisolar new year")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ChineseNewYearDay(2))
+                .build();
+        final Holiday springFestivalDay3 = Holiday.builder()
+                .name("Spring Festival (Day 3)")
+                .description("Third day of the Chinese lunisolar new year")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ChineseNewYearDay(3))
+                .build();
+
+        final Holiday qingmingFestival = Holiday.builder()
+                .name("Qingming Festival")
+                .description("Tomb Sweeping Day; solar term at ecliptic longitude 15°")
+                .type(Holiday.Type.FLOATING)
+                .rollable(true)
+                .observance(new QingmingFestival())
+                .build();
+
+        final Holiday labourDay = Holiday.builder()
+                .name("Labour Day")
+                .description("International Workers' Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.MAY, 1)
+                .build();
+
+        final Holiday dragonBoatFestival = Holiday.builder()
+                .name("Dragon Boat Festival")
+                .description("Duanwu; 5th day of the 5th lunar month")
+                .type(Holiday.Type.FLOATING)
+                .rollable(true)
+                .observance(new DragonBoatFestival())
+                .build();
+
+        final Holiday midAutumnFestival = Holiday.builder()
+                .name("Mid-Autumn Festival")
+                .description("15th day of the 8th lunar month; full moon of autumn")
+                .type(Holiday.Type.FLOATING)
+                .rollable(true)
+                .observance(new MidAutumnFestival())
+                .build();
+
+        // National Day Golden Week — 3-day statutory window (1–3 October).
+        // rollable=false: same rationale as Spring Festival above.
+        final Holiday nationalDay1 = Holiday.builder()
+                .name("National Day (Day 1)")
+                .description("Founding of the People's Republic of China, 1 October 1949")
+                .type(Holiday.Type.FIXED)
+                .rollable(false)
+                .monthDay(Month.OCTOBER, 1)
+                .build();
+        final Holiday nationalDay2 = Holiday.builder()
+                .name("National Day (Day 2)")
+                .description(NATIONAL_DAY_CONTINUED)
+                .type(Holiday.Type.FIXED)
+                .rollable(false)
+                .monthDay(Month.OCTOBER, 2)
+                .build();
+        final Holiday nationalDay3 = Holiday.builder()
+                .name("National Day (Day 3)")
+                .description(NATIONAL_DAY_CONTINUED)
+                .type(Holiday.Type.FIXED)
+                .rollable(false)
+                .monthDay(Month.OCTOBER, 3)
+                .build();
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.followingMonday())
+                .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
+                .holiday(newYearsDay)
+                .holiday(springFestivalDay1)
+                .holiday(springFestivalDay2)
+                .holiday(springFestivalDay3)
+                .holiday(qingmingFestival)
+                .holiday(labourDay)
+                .holiday(dragonBoatFestival)
+                .holiday(midAutumnFestival)
+                .holiday(nationalDay1)
+                .holiday(nationalDay2)
+                .holiday(nationalDay3)
+                .build();
+    }
+
+}

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/lunar/ChineseNewYearDay.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/lunar/ChineseNewYearDay.java
@@ -29,9 +29,10 @@ import java.time.LocalDate;
  * holiday window, numbered from Day 1 (the first day of the first lunar month)
  * through Day 7.
  *
- * <p>The seven-day Spring Festival window is the statutory public holiday period
- * in China as published by the State Council. Days are consecutive Gregorian
- * calendar days from Day 1 (Chinese New Year's Day) onward.</p>
+ * <p>Days are consecutive Gregorian calendar days beginning from Day 1
+ * (Chinese New Year's Day). The valid range {@code 1–7} supports both the
+ * three-day statutory minimum window (national {@code CN} calendar, Days 1–3)
+ * and the seven-day PBOC operational window ({@code CNY} calendar, Days 1–7).</p>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -42,7 +43,9 @@ public class ChineseNewYearDay extends AbstractObservance {
     /**
      * Constructs an observance for the given day of the Spring Festival window.
      *
-     * @param dayNumber day within the Spring Festival window, in range {@code 1–7}
+     * @param dayNumber day within the Spring Festival window, in range {@code 1–7};
+     *                  values 1–3 model the statutory national ({@code CN}) calendar,
+     *                  values 1–7 model the PBOC operational ({@code CNY}) calendar
      * @throws IllegalArgumentException if {@code dayNumber} is not in range 1–7
      */
     public ChineseNewYearDay(int dayNumber) {

--- a/holiday-calendar-apac/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-apac/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -3,3 +3,4 @@ org.holiday.calendar.impl.HolidayCalendarServiceSG
 org.holiday.calendar.impl.HolidayCalendarServiceSGD
 org.holiday.calendar.impl.HolidayCalendarServiceJP
 org.holiday.calendar.impl.HolidayCalendarServiceJPY
+org.holiday.calendar.impl.HolidayCalendarServiceCN

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNTest.java
@@ -135,128 +135,61 @@ public class HolidayCalendarServiceCNTest {
     // =========================================================================
 
     /**
-     * Spring Festival Day 1 natural (lunar calendar) dates.
+     * Spring Festival natural (lunar calendar) dates for Days 1–3.
      * Spring Festival is {@code rollable(false)}: China's block-shift mechanism
      * cannot be replicated per-day, so dates are reported on their natural positions.
      */
-    @DataProvider(name = "springFestivalDay1Dates")
-    public Object[][] springFestivalDay1Dates() {
+    @DataProvider(name = "springFestivalDates")
+    public Object[][] springFestivalDates() {
         return new Object[][] {
-            {2024, LocalDate.of(2024, Month.FEBRUARY, 10)}, // Sat Feb 10 — stays (rollable=false)
-            {2025, LocalDate.of(2025, Month.JANUARY,  29)}, // Wed Jan 29 — stays
-            {2026, LocalDate.of(2026, Month.FEBRUARY, 17)}, // Tue Feb 17 — stays
-            {2027, LocalDate.of(2027, Month.FEBRUARY,  6)}, // Sat Feb  6 — stays (rollable=false)
+            {"Spring Festival (Day 1)", 2024, LocalDate.of(2024, Month.FEBRUARY, 10)}, // Sat — stays
+            {"Spring Festival (Day 1)", 2025, LocalDate.of(2025, Month.JANUARY,  29)}, // Wed — stays
+            {"Spring Festival (Day 1)", 2026, LocalDate.of(2026, Month.FEBRUARY, 17)}, // Tue — stays
+            {"Spring Festival (Day 1)", 2027, LocalDate.of(2027, Month.FEBRUARY,  6)}, // Sat — stays
+            {"Spring Festival (Day 2)", 2024, LocalDate.of(2024, Month.FEBRUARY, 11)}, // Sun — stays
+            {"Spring Festival (Day 2)", 2025, LocalDate.of(2025, Month.JANUARY,  30)},
+            {"Spring Festival (Day 2)", 2026, LocalDate.of(2026, Month.FEBRUARY, 18)},
+            {"Spring Festival (Day 2)", 2027, LocalDate.of(2027, Month.FEBRUARY,  7)}, // Sun — stays
+            {"Spring Festival (Day 3)", 2024, LocalDate.of(2024, Month.FEBRUARY, 12)},
+            {"Spring Festival (Day 3)", 2025, LocalDate.of(2025, Month.JANUARY,  31)},
+            {"Spring Festival (Day 3)", 2026, LocalDate.of(2026, Month.FEBRUARY, 19)},
+            {"Spring Festival (Day 3)", 2027, LocalDate.of(2027, Month.FEBRUARY,  8)},
         };
     }
 
-    @Test(dataProvider = "springFestivalDay1Dates",
-          description = "Spring Festival Day 1 observed date matches expected post-roll date")
-    public void testSpringFestivalDay1Date(int year, LocalDate expectedObservedDate) {
+    @Test(dataProvider = "springFestivalDates",
+          description = "Spring Festival date matches expected natural date (rollable=false)")
+    public void testSpringFestivalDate(String holidayName, int year, LocalDate expectedDate) {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, "Spring Festival (Day 1)", expectedObservedDate,
-                "Spring Festival (Day 1) " + year);
+        assertHolidayDate(holidays, holidayName, expectedDate, holidayName + " " + year);
     }
 
-    @DataProvider(name = "springFestivalDay2Dates")
-    public Object[][] springFestivalDay2Dates() {
+    // =========================================================================
+    // 4–6. SINGLE-DAY FLOATING HOLIDAY GOLDEN-MASTER DATES
+    // =========================================================================
+
+    @DataProvider(name = "floatingHolidayDates")
+    public Object[][] floatingHolidayDates() {
         return new Object[][] {
-            {2024, LocalDate.of(2024, Month.FEBRUARY, 11)},
-            {2025, LocalDate.of(2025, Month.JANUARY,  30)},
-            {2026, LocalDate.of(2026, Month.FEBRUARY, 18)},
-            {2027, LocalDate.of(2027, Month.FEBRUARY,  7)},
+            {"Qingming Festival",    2024, LocalDate.of(2024, Month.APRIL,      4)}, // Thu — no roll
+            {"Qingming Festival",    2025, LocalDate.of(2025, Month.APRIL,      4)}, // Fri — no roll
+            {"Qingming Festival",    2026, LocalDate.of(2026, Month.APRIL,      6)}, // Mon — no roll
+            {"Dragon Boat Festival", 2024, LocalDate.of(2024, Month.JUNE,      10)}, // Mon — no roll
+            {"Dragon Boat Festival", 2025, LocalDate.of(2025, Month.JUNE,       2)}, // raw Sat May 31 → Mon
+            {"Dragon Boat Festival", 2026, LocalDate.of(2026, Month.JUNE,      19)}, // Fri — no roll
+            {"Mid-Autumn Festival",  2024, LocalDate.of(2024, Month.SEPTEMBER, 17)}, // Tue — no roll
+            {"Mid-Autumn Festival",  2025, LocalDate.of(2025, Month.OCTOBER,    6)}, // Mon — no roll
+            {"Mid-Autumn Festival",  2026, LocalDate.of(2026, Month.SEPTEMBER, 25)}, // Fri — no roll
         };
     }
 
-    @Test(dataProvider = "springFestivalDay2Dates",
-          description = "Spring Festival Day 2 observed date matches expected post-roll date")
-    public void testSpringFestivalDay2Date(int year, LocalDate expectedObservedDate) {
+    @Test(dataProvider = "floatingHolidayDates",
+          description = "Floating holiday date matches expected post-roll observed date")
+    public void testFloatingHolidayDate(String holidayName, int year, LocalDate expectedDate) {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, "Spring Festival (Day 2)", expectedObservedDate,
-                "Spring Festival (Day 2) " + year);
-    }
-
-    @DataProvider(name = "springFestivalDay3Dates")
-    public Object[][] springFestivalDay3Dates() {
-        return new Object[][] {
-            {2024, LocalDate.of(2024, Month.FEBRUARY, 12)},
-            {2025, LocalDate.of(2025, Month.JANUARY,  31)},
-            {2026, LocalDate.of(2026, Month.FEBRUARY, 19)},
-            {2027, LocalDate.of(2027, Month.FEBRUARY,  8)},
-        };
-    }
-
-    @Test(dataProvider = "springFestivalDay3Dates",
-          description = "Spring Festival Day 3 observed date matches expected post-roll date")
-    public void testSpringFestivalDay3Date(int year, LocalDate expectedObservedDate) {
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, "Spring Festival (Day 3)", expectedObservedDate,
-                "Spring Festival (Day 3) " + year);
-    }
-
-    // =========================================================================
-    // 4. QINGMING FESTIVAL GOLDEN-MASTER DATES
-    // =========================================================================
-
-    @DataProvider(name = "qingmingDates")
-    public Object[][] qingmingDates() {
-        return new Object[][] {
-            {2024, LocalDate.of(2024, Month.APRIL,  4)}, // Thu — no roll
-            {2025, LocalDate.of(2025, Month.APRIL,  4)}, // Fri — no roll
-            {2026, LocalDate.of(2026, Month.APRIL,  6)}, // Mon Apr 6 — no roll
-        };
-    }
-
-    @Test(dataProvider = "qingmingDates",
-          description = "Qingming Festival date matches the solar-term calculation for each year")
-    public void testQingmingDate(int year, LocalDate expectedDate) {
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, "Qingming Festival", expectedDate, "Qingming Festival " + year);
-    }
-
-    // =========================================================================
-    // 5. DRAGON BOAT FESTIVAL GOLDEN-MASTER DATES
-    // =========================================================================
-
-    @DataProvider(name = "dragonBoatDates")
-    public Object[][] dragonBoatDates() {
-        return new Object[][] {
-            {2024, LocalDate.of(2024, Month.JUNE,  10)}, // Mon — no roll
-            {2025, LocalDate.of(2025, Month.JUNE,   2)}, // raw Sat May 31 → Mon Jun 2 (rollable=true)
-            {2026, LocalDate.of(2026, Month.JUNE,  19)}, // Fri — no roll
-        };
-    }
-
-    @Test(dataProvider = "dragonBoatDates",
-          description = "Dragon Boat Festival date matches the 5th-day-of-5th-lunar-month calculation")
-    public void testDragonBoatDate(int year, LocalDate expectedDate) {
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, "Dragon Boat Festival", expectedDate, "Dragon Boat Festival " + year);
-    }
-
-    // =========================================================================
-    // 6. MID-AUTUMN FESTIVAL GOLDEN-MASTER DATES
-    // =========================================================================
-
-    @DataProvider(name = "midAutumnDates")
-    public Object[][] midAutumnDates() {
-        return new Object[][] {
-            {2024, LocalDate.of(2024, Month.SEPTEMBER, 17)}, // Tue — no roll
-            {2025, LocalDate.of(2025, Month.OCTOBER,    6)}, // Mon Oct 6 — no roll
-            {2026, LocalDate.of(2026, Month.SEPTEMBER, 25)}, // Fri Sep 25 — no roll
-        };
-    }
-
-    @Test(dataProvider = "midAutumnDates",
-          description = "Mid-Autumn Festival date matches the 15th-day-of-8th-lunar-month calculation")
-    public void testMidAutumnDate(int year, LocalDate expectedDate) {
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, "Mid-Autumn Festival", expectedDate, "Mid-Autumn Festival " + year);
+        assertHolidayDate(holidays, holidayName, expectedDate, holidayName + " " + year);
     }
 
     // =========================================================================

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNTest.java
@@ -1,0 +1,539 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+/**
+ * Unit tests for {@link HolidayCalendarServiceCN} — the China National Public
+ * Holidays calendar (code {@code CN}).
+ *
+ * <p>This calendar covers the 11-entry statutory schedule as defined by China's
+ * State Council for the purposes of national public holidays. Single-day holidays
+ * use {@code DateRolls.followingMonday()} with {@code rollable(true)}; multi-day
+ * blocks (Spring Festival Days 1–3, National Day Days 1–3) are {@code rollable(false)}
+ * because China's block-shift adjustment mechanism cannot be modelled per-day.
+ * This contrasts with the PBOC/CNAPS calendar ({@code CNY}) that uses
+ * {@code DateRolls.noRoll()} with {@code rollable(false)} for all entries.
+ *
+ * <p>Test categories:
+ * <ol>
+ *   <li>Service metadata — code, region, dataValidThrough</li>
+ *   <li>Holiday count — exactly 11 entries per year</li>
+ *   <li>Spring Festival golden-master dates (2024–2027)</li>
+ *   <li>Qingming Festival golden-master dates (2024–2026)</li>
+ *   <li>Dragon Boat Festival golden-master dates (2024–2026)</li>
+ *   <li>Mid-Autumn Festival golden-master dates (2024–2026)</li>
+ *   <li>Fixed National Day dates — Oct 1, 2, 3 always present</li>
+ *   <li>Roll behavior — Saturday/Sunday holidays advance to following Monday</li>
+ *   <li>Roll collision — two holidays landing on the same rolled date</li>
+ *   <li>Chronological ordering — list remains sorted after rolling</li>
+ *   <li>Factory discovery — ServiceLoader finds the CN registration</li>
+ * </ol>
+ */
+public class HolidayCalendarServiceCNTest {
+
+    private HolidayCalendarServiceCN service;
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setup() {
+        this.service = new HolidayCalendarServiceCN();
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // =========================================================================
+    // 1. SERVICE METADATA
+    // =========================================================================
+
+    @Test(description = "isProvided() returns true for CN and false for unrelated codes")
+    public void testIsProvided() {
+        assertTrue(service.isProvided("CN"),  "isProvided(\"CN\") must return true");
+        assertFalse(service.isProvided("CNY"), "isProvided(\"CNY\") must return false — different service");
+        assertFalse(service.isProvided("SG"),  "isProvided(\"SG\") must return false");
+        assertFalse(service.isProvided("US"),  "isProvided(\"US\") must return false");
+    }
+
+    @Test(description = "getCode() returns the calendar code CN")
+    public void testGetCode() {
+        assertEquals(service.getCode(), "CN");
+    }
+
+    @Test(description = "getRegion() returns a non-blank human-readable description")
+    public void testGetRegion() {
+        String region = service.getRegion();
+        assertNotNull(region, "getRegion() must not return null");
+        assertFalse(region.isBlank(), "getRegion() must not return a blank string");
+    }
+
+    @Test(description = "dataValidThrough() returns empty — CN calendar is fully algorithmic")
+    public void testDataValidThroughReturnsEmpty() {
+        OptionalInt result = service.dataValidThrough();
+        assertFalse(result.isPresent(),
+                "CN calendar is fully algorithmic; dataValidThrough() must return OptionalInt.empty()");
+    }
+
+    // =========================================================================
+    // 2. HOLIDAY COUNT
+    // =========================================================================
+
+    @DataProvider(name = "yearsForCountCheck")
+    public Object[][] yearsForCountCheck() {
+        return new Object[][] {
+            {2022},
+            {2023},
+            {2024},
+            {2025},
+            {2026},
+            {2027},
+        };
+    }
+
+    @Test(dataProvider = "yearsForCountCheck",
+          description = "calculate(year) returns exactly 11 HolidayDate entries")
+    public void testHolidayCountIsEleven(int year) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertNotNull(holidays, "calculate(" + year + ") must not return null");
+        assertEquals(holidays.size(), 11,
+                "Expected exactly 11 holiday entries for " + year + " but got " + holidays.size());
+    }
+
+    // =========================================================================
+    // 3. SPRING FESTIVAL GOLDEN-MASTER DATES (DAYS 1–3)
+    // =========================================================================
+
+    /**
+     * Spring Festival Day 1 natural (lunar calendar) dates.
+     * Spring Festival is {@code rollable(false)}: China's block-shift mechanism
+     * cannot be replicated per-day, so dates are reported on their natural positions.
+     */
+    @DataProvider(name = "springFestivalDay1Dates")
+    public Object[][] springFestivalDay1Dates() {
+        return new Object[][] {
+            {2024, LocalDate.of(2024, Month.FEBRUARY, 10)}, // Sat Feb 10 — stays (rollable=false)
+            {2025, LocalDate.of(2025, Month.JANUARY,  29)}, // Wed Jan 29 — stays
+            {2026, LocalDate.of(2026, Month.FEBRUARY, 17)}, // Tue Feb 17 — stays
+            {2027, LocalDate.of(2027, Month.FEBRUARY,  6)}, // Sat Feb  6 — stays (rollable=false)
+        };
+    }
+
+    @Test(dataProvider = "springFestivalDay1Dates",
+          description = "Spring Festival Day 1 observed date matches expected post-roll date")
+    public void testSpringFestivalDay1Date(int year, LocalDate expectedObservedDate) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertHolidayDate(holidays, "Spring Festival (Day 1)", expectedObservedDate,
+                "Spring Festival (Day 1) " + year);
+    }
+
+    @DataProvider(name = "springFestivalDay2Dates")
+    public Object[][] springFestivalDay2Dates() {
+        return new Object[][] {
+            {2024, LocalDate.of(2024, Month.FEBRUARY, 11)},
+            {2025, LocalDate.of(2025, Month.JANUARY,  30)},
+            {2026, LocalDate.of(2026, Month.FEBRUARY, 18)},
+            {2027, LocalDate.of(2027, Month.FEBRUARY,  7)},
+        };
+    }
+
+    @Test(dataProvider = "springFestivalDay2Dates",
+          description = "Spring Festival Day 2 observed date matches expected post-roll date")
+    public void testSpringFestivalDay2Date(int year, LocalDate expectedObservedDate) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertHolidayDate(holidays, "Spring Festival (Day 2)", expectedObservedDate,
+                "Spring Festival (Day 2) " + year);
+    }
+
+    @DataProvider(name = "springFestivalDay3Dates")
+    public Object[][] springFestivalDay3Dates() {
+        return new Object[][] {
+            {2024, LocalDate.of(2024, Month.FEBRUARY, 12)},
+            {2025, LocalDate.of(2025, Month.JANUARY,  31)},
+            {2026, LocalDate.of(2026, Month.FEBRUARY, 19)},
+            {2027, LocalDate.of(2027, Month.FEBRUARY,  8)},
+        };
+    }
+
+    @Test(dataProvider = "springFestivalDay3Dates",
+          description = "Spring Festival Day 3 observed date matches expected post-roll date")
+    public void testSpringFestivalDay3Date(int year, LocalDate expectedObservedDate) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertHolidayDate(holidays, "Spring Festival (Day 3)", expectedObservedDate,
+                "Spring Festival (Day 3) " + year);
+    }
+
+    // =========================================================================
+    // 4. QINGMING FESTIVAL GOLDEN-MASTER DATES
+    // =========================================================================
+
+    @DataProvider(name = "qingmingDates")
+    public Object[][] qingmingDates() {
+        return new Object[][] {
+            {2024, LocalDate.of(2024, Month.APRIL,  4)}, // Thu — no roll
+            {2025, LocalDate.of(2025, Month.APRIL,  4)}, // Fri — no roll
+            {2026, LocalDate.of(2026, Month.APRIL,  6)}, // Mon Apr 6 — no roll
+        };
+    }
+
+    @Test(dataProvider = "qingmingDates",
+          description = "Qingming Festival date matches the solar-term calculation for each year")
+    public void testQingmingDate(int year, LocalDate expectedDate) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertHolidayDate(holidays, "Qingming Festival", expectedDate, "Qingming Festival " + year);
+    }
+
+    // =========================================================================
+    // 5. DRAGON BOAT FESTIVAL GOLDEN-MASTER DATES
+    // =========================================================================
+
+    @DataProvider(name = "dragonBoatDates")
+    public Object[][] dragonBoatDates() {
+        return new Object[][] {
+            {2024, LocalDate.of(2024, Month.JUNE,  10)}, // Mon — no roll
+            {2025, LocalDate.of(2025, Month.JUNE,   2)}, // raw Sat May 31 → Mon Jun 2 (rollable=true)
+            {2026, LocalDate.of(2026, Month.JUNE,  19)}, // Fri — no roll
+        };
+    }
+
+    @Test(dataProvider = "dragonBoatDates",
+          description = "Dragon Boat Festival date matches the 5th-day-of-5th-lunar-month calculation")
+    public void testDragonBoatDate(int year, LocalDate expectedDate) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertHolidayDate(holidays, "Dragon Boat Festival", expectedDate, "Dragon Boat Festival " + year);
+    }
+
+    // =========================================================================
+    // 6. MID-AUTUMN FESTIVAL GOLDEN-MASTER DATES
+    // =========================================================================
+
+    @DataProvider(name = "midAutumnDates")
+    public Object[][] midAutumnDates() {
+        return new Object[][] {
+            {2024, LocalDate.of(2024, Month.SEPTEMBER, 17)}, // Tue — no roll
+            {2025, LocalDate.of(2025, Month.OCTOBER,    6)}, // Mon Oct 6 — no roll
+            {2026, LocalDate.of(2026, Month.SEPTEMBER, 25)}, // Fri Sep 25 — no roll
+        };
+    }
+
+    @Test(dataProvider = "midAutumnDates",
+          description = "Mid-Autumn Festival date matches the 15th-day-of-8th-lunar-month calculation")
+    public void testMidAutumnDate(int year, LocalDate expectedDate) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        assertHolidayDate(holidays, "Mid-Autumn Festival", expectedDate, "Mid-Autumn Festival " + year);
+    }
+
+    // =========================================================================
+    // 7. FIXED HOLIDAYS — PRESENT EVERY YEAR
+    // =========================================================================
+
+    @DataProvider(name = "fixedHolidayYears")
+    public Object[][] fixedHolidayYears() {
+        return new Object[][] {
+            {2024}, {2025}, {2026},
+        };
+    }
+
+    @Test(dataProvider = "fixedHolidayYears",
+          description = "New Year's Day (Jan 1) is always defined in the calendar")
+    public void testNewYearsDayDefined(int year) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> "New Year's Day".equals(h.getName()));
+        assertTrue(found, "Calendar must define New Year's Day");
+    }
+
+    @Test(dataProvider = "fixedHolidayYears",
+          description = "Labour Day (May 1) is present in each calculated year")
+    public void testLabourDayPresent(int year) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        Optional<HolidayDate> labourDay = holidays.stream()
+                .filter(hd -> "Labour Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(labourDay.isPresent(), "Labour Day must be present for " + year);
+        assertEquals(labourDay.get().getDate().getMonth(), Month.MAY,
+                "Labour Day must fall in May for " + year);
+    }
+
+    @Test(description = "National Day Day 1 (Oct 1) falls in October in 2024")
+    public void testNationalDayDay1October2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        // 2024-10-01 is a Tuesday — no roll expected
+        assertHolidayDate(holidays, "National Day (Day 1)", LocalDate.of(2024, Month.OCTOBER, 1),
+                "National Day (Day 1) 2024");
+    }
+
+    @Test(description = "National Day Day 2 (Oct 2) is present for 2024")
+    public void testNationalDayDay2October2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertHolidayDate(holidays, "National Day (Day 2)", LocalDate.of(2024, Month.OCTOBER, 2),
+                "National Day (Day 2) 2024");
+    }
+
+    @Test(description = "National Day Day 3 (Oct 3) is present for 2024")
+    public void testNationalDayDay3October2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertHolidayDate(holidays, "National Day (Day 3)", LocalDate.of(2024, Month.OCTOBER, 3),
+                "National Day (Day 3) 2024");
+    }
+
+    // =========================================================================
+    // 8. ROLL BEHAVIOR — FOLLOWING MONDAY STRATEGY
+    // =========================================================================
+
+    @Test(description = "New Year's Day 2023 (Sunday Jan 1) rolls to Monday Jan 2")
+    public void testNewYearsDayRollSunday2023() {
+        // Jan 1 2023 = Sunday → followingMonday → Jan 2
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2023);
+        assertHolidayDate(holidays, "New Year's Day", LocalDate.of(2023, Month.JANUARY, 2),
+                "New Year's Day 2023 (Sunday) roll");
+    }
+
+    @Test(description = "New Year's Day 2022 (Saturday Jan 1) rolls to Monday Jan 3")
+    public void testNewYearsDayRollSaturday2022() {
+        // Jan 1 2022 = Saturday → followingMonday → Jan 3
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2022);
+        assertHolidayDate(holidays, "New Year's Day", LocalDate.of(2022, Month.JANUARY, 3),
+                "New Year's Day 2022 (Saturday) roll");
+    }
+
+    @Test(description = "New Year's Day 2028 (Saturday Jan 1) rolls to Monday Jan 3")
+    public void testNewYearsDayRollSaturday2028() {
+        // Jan 1 2028 = Saturday → followingMonday → Jan 3
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        assertHolidayDate(holidays, "New Year's Day", LocalDate.of(2028, Month.JANUARY, 3),
+                "New Year's Day 2028 (Saturday) roll");
+    }
+
+    @Test(description = "Labour Day 2022 (Sunday May 1) rolls to Monday May 2")
+    public void testLabourDayRollSunday2022() {
+        // May 1 2022 = Sunday → followingMonday → May 2
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2022);
+        assertHolidayDate(holidays, "Labour Day", LocalDate.of(2022, Month.MAY, 2),
+                "Labour Day 2022 (Sunday) roll");
+    }
+
+    @Test(description = "Labour Day 2021 (Saturday May 1) rolls to Monday May 3")
+    public void testLabourDayRollSaturday2021() {
+        // May 1 2021 = Saturday → followingMonday → May 3
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2021);
+        assertHolidayDate(holidays, "Labour Day", LocalDate.of(2021, Month.MAY, 3),
+                "Labour Day 2021 (Saturday) roll");
+    }
+
+    @Test(description = "New Year's Day on weekday (2025, Wednesday) does not roll")
+    public void testNewYearsDayNoRollWeekday2025() {
+        // Jan 1 2025 = Wednesday → no roll
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertHolidayDate(holidays, "New Year's Day", LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) should not roll");
+    }
+
+    // =========================================================================
+    // 9. MULTI-DAY BLOCKS NOT ROLLED — NATURAL DATES PRESERVED
+    // =========================================================================
+
+    /**
+     * 2023: Oct 1 is Sunday. National Day is {@code rollable(false)}, so Day 1
+     * stays on Oct 1 (not moved to Monday Oct 2). This verifies that the
+     * block-shift rationale is implemented correctly — no per-day rolling occurs.
+     */
+    @Test(description = "National Day Day 1 (Oct 1 2023, Sunday) stays on Oct 1 — rollable=false")
+    public void testNationalDayDay1NotRolledSunday2023() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2023);
+        Optional<HolidayDate> day1 = holidays.stream()
+                .filter(hd -> "National Day (Day 1)".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(day1.isPresent(), "National Day (Day 1) must be present for 2023");
+        assertEquals(day1.get().getDate(), LocalDate.of(2023, Month.OCTOBER, 1),
+                "National Day (Day 1) 2023 (Sunday) must stay Oct 1 (rollable=false)");
+    }
+
+    @Test(description = "Spring Festival Day 1 (Feb 10 2024, Saturday) stays on Feb 10 — rollable=false")
+    public void testSpringFestivalDay1NotRolledSaturday2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        Optional<HolidayDate> day1 = holidays.stream()
+                .filter(hd -> "Spring Festival (Day 1)".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(day1.isPresent(), "Spring Festival (Day 1) must be present for 2024");
+        assertEquals(day1.get().getDate(), LocalDate.of(2024, Month.FEBRUARY, 10),
+                "Spring Festival (Day 1) 2024 (Saturday) must stay Feb 10 (rollable=false)");
+    }
+
+    @Test(description = "Spring Festival Day 2 (Feb 11 2024, Sunday) stays on Feb 11 — rollable=false")
+    public void testSpringFestivalDay2NotRolledSunday2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        Optional<HolidayDate> day2 = holidays.stream()
+                .filter(hd -> "Spring Festival (Day 2)".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(day2.isPresent(), "Spring Festival (Day 2) must be present for 2024");
+        assertEquals(day2.get().getDate(), LocalDate.of(2024, Month.FEBRUARY, 11),
+                "Spring Festival (Day 2) 2024 (Sunday) must stay Feb 11 (rollable=false)");
+    }
+
+    // =========================================================================
+    // 10. CHRONOLOGICAL ORDERING — LIST REMAINS SORTED AFTER ROLLING
+    // =========================================================================
+
+    @DataProvider(name = "yearsForOrderCheck")
+    public Iterator<Object[]> yearsForOrderCheck() {
+        return Arrays.asList(
+            new Object[]{2021},
+            new Object[]{2022},
+            new Object[]{2023},
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026},
+            new Object[]{2027},
+            new Object[]{2028}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "yearsForOrderCheck",
+          description = "calculate(year) returns holidays in non-decreasing chronological order")
+    public void testChronologicalOrder(int year) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(year);
+        for (int i = 1; i < holidays.size(); i++) {
+            LocalDate prev = holidays.get(i - 1).getDate();
+            LocalDate curr = holidays.get(i).getDate();
+            assertFalse(curr.isBefore(prev),
+                    "Dates out of order in year " + year + " at index " + i
+                    + ": " + prev + " followed by " + curr);
+        }
+    }
+
+    // =========================================================================
+    // 11. FACTORY DISCOVERY — SERVICELOADER FINDS CN
+    // =========================================================================
+
+    @Test(description = "HolidayCalendarFactory.create(\"CN\") returns a non-null calendar with code CN")
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("CN");
+        assertNotNull(calendar, "factory.create(\"CN\") must not return null");
+        assertEquals(calendar.getCode(), "CN",
+                "factory.create(\"CN\").getCode() must return \"CN\"");
+    }
+
+    @Test(description = "factory.dataValidThrough(\"CN\") returns empty — CN is fully algorithmic")
+    public void testFactoryDataValidThroughCN() {
+        OptionalInt result = factory.dataValidThrough("CN");
+        assertFalse(result.isPresent(),
+                "factory.dataValidThrough(\"CN\") must return OptionalInt.empty() — fully algorithmic");
+    }
+
+    // =========================================================================
+    // 12. HOLIDAY NAME DEFINITIONS — CALENDAR DEFINITION CONTAINS EXPECTED NAMES
+    // =========================================================================
+
+    @DataProvider(name = "expectedHolidayNames")
+    public Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Spring Festival (Day 1)"},
+            new Object[]{"Spring Festival (Day 2)"},
+            new Object[]{"Spring Festival (Day 3)"},
+            new Object[]{"Qingming Festival"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Dragon Boat Festival"},
+            new Object[]{"Mid-Autumn Festival"},
+            new Object[]{"National Day (Day 1)"},
+            new Object[]{"National Day (Day 2)"},
+            new Object[]{"National Day (Day 3)"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames",
+          description = "Calendar definition contains the expected holiday name")
+    public void testHolidayCalendarContainsName(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must define holiday: \"" + holidayName + "\"");
+    }
+
+    // =========================================================================
+    // 13. CN vs CNY DISTINCTION — ROLLABLE FLAG CONTRAST
+    // =========================================================================
+
+    @Test(description = "CN calendar rolls New Year's Day (Sunday); CNY calendar does not")
+    public void testCNRollsWhileCNYDoesNot() {
+        // 2023: Jan 1 = Sunday
+        // CN  (followingMonday, rollable=true)  → observed Jan 2
+        // CNY (noRoll,          rollable=false) → observed Jan 1
+        List<HolidayDate> cnHolidays  = service.getHolidayCalendar().calculate(2023);
+        List<HolidayDate> cnyHolidays = new HolidayCalendarServiceCNY().getHolidayCalendar().calculate(2023);
+
+        LocalDate cnDate  = findDate(cnHolidays,  "New Year's Day");
+        LocalDate cnyDate = findDate(cnyHolidays, "New Year's Day");
+
+        assertEquals(cnDate,  LocalDate.of(2023, Month.JANUARY, 2),
+                "CN calendar must roll Sunday Jan 1 2023 to Monday Jan 2");
+        assertEquals(cnyDate, LocalDate.of(2023, Month.JANUARY, 1),
+                "CNY calendar must not roll Sunday Jan 1 2023 (noRoll strategy)");
+        assertNotEquals(cnDate, cnyDate,
+                "CN and CNY observed dates for New Year's Day 2023 must differ");
+    }
+
+    // =========================================================================
+    // HELPERS
+    // =========================================================================
+
+    private static void assertHolidayDate(List<HolidayDate> holidays,
+                                          String name,
+                                          LocalDate expectedDate,
+                                          String context) {
+        Optional<HolidayDate> found = holidays.stream()
+                .filter(hd -> name.equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(found.isPresent(), context + ": holiday \"" + name + "\" must be present");
+        assertEquals(found.get().getDate(), expectedDate,
+                context + ": observed date mismatch for \"" + name + "\"");
+    }
+
+    private static LocalDate findDate(List<HolidayDate> holidays, String name) {
+        return holidays.stream()
+                .filter(hd -> name.equals(hd.getHoliday().getName()))
+                .map(HolidayDate::getDate)
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Holiday not found: " + name));
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCNTest.java
@@ -131,17 +131,21 @@ public class HolidayCalendarServiceCNTest {
     }
 
     // =========================================================================
-    // 3. SPRING FESTIVAL GOLDEN-MASTER DATES (DAYS 1–3)
+    // 3–6. FLOATING HOLIDAY GOLDEN-MASTER DATES
     // =========================================================================
 
     /**
-     * Spring Festival natural (lunar calendar) dates for Days 1–3.
-     * Spring Festival is {@code rollable(false)}: China's block-shift mechanism
-     * cannot be replicated per-day, so dates are reported on their natural positions.
+     * Golden-master dates for all floating holidays.
+     *
+     * <p>Spring Festival (Days 1–3) is {@code rollable(false)}: China's block-shift
+     * mechanism cannot be replicated per-day, so dates are the natural lunar calendar
+     * positions. Single-day floating holidays (Qingming, Dragon Boat, Mid-Autumn) are
+     * {@code rollable(true)} and show post-roll observed dates.
      */
-    @DataProvider(name = "springFestivalDates")
-    public Object[][] springFestivalDates() {
+    @DataProvider(name = "floatingHolidayDates")
+    public Object[][] floatingHolidayDates() {
         return new Object[][] {
+            // Spring Festival — rollable=false, natural dates
             {"Spring Festival (Day 1)", 2024, LocalDate.of(2024, Month.FEBRUARY, 10)}, // Sat — stays
             {"Spring Festival (Day 1)", 2025, LocalDate.of(2025, Month.JANUARY,  29)}, // Wed — stays
             {"Spring Festival (Day 1)", 2026, LocalDate.of(2026, Month.FEBRUARY, 17)}, // Tue — stays
@@ -154,24 +158,7 @@ public class HolidayCalendarServiceCNTest {
             {"Spring Festival (Day 3)", 2025, LocalDate.of(2025, Month.JANUARY,  31)},
             {"Spring Festival (Day 3)", 2026, LocalDate.of(2026, Month.FEBRUARY, 19)},
             {"Spring Festival (Day 3)", 2027, LocalDate.of(2027, Month.FEBRUARY,  8)},
-        };
-    }
-
-    @Test(dataProvider = "springFestivalDates",
-          description = "Spring Festival date matches expected natural date (rollable=false)")
-    public void testSpringFestivalDate(String holidayName, int year, LocalDate expectedDate) {
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        List<HolidayDate> holidays = calendar.calculate(year);
-        assertHolidayDate(holidays, holidayName, expectedDate, holidayName + " " + year);
-    }
-
-    // =========================================================================
-    // 4–6. SINGLE-DAY FLOATING HOLIDAY GOLDEN-MASTER DATES
-    // =========================================================================
-
-    @DataProvider(name = "floatingHolidayDates")
-    public Object[][] floatingHolidayDates() {
-        return new Object[][] {
+            // Single-day floating holidays — rollable=true, post-roll observed dates
             {"Qingming Festival",    2024, LocalDate.of(2024, Month.APRIL,      4)}, // Thu — no roll
             {"Qingming Festival",    2025, LocalDate.of(2025, Month.APRIL,      4)}, // Fri — no roll
             {"Qingming Festival",    2026, LocalDate.of(2026, Month.APRIL,      6)}, // Mon — no roll
@@ -185,7 +172,7 @@ public class HolidayCalendarServiceCNTest {
     }
 
     @Test(dataProvider = "floatingHolidayDates",
-          description = "Floating holiday date matches expected post-roll observed date")
+          description = "Floating holiday date matches expected observed date")
     public void testFloatingHolidayDate(String holidayName, int year, LocalDate expectedDate) {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> holidays = calendar.calculate(year);

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -34,9 +34,16 @@
             <artifactId>holiday-calendar-apac</artifactId>
             <version>${project.version}</version>
         </dependency>
+
+        <!-- Test dependencies -->
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 18 implemented holiday calendars
+ * 30-year integration test suite validating all 19 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -61,6 +61,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"CAD"},
                 new Object[]{"CH"},
                 new Object[]{"CHF"},
+                new Object[]{"CN"},
                 new Object[]{"CNY"},
                 new Object[]{"DE"},
                 new Object[]{"EUR"},

--- a/tests/src/test/resources/logback-test.xml
+++ b/tests/src/test/resources/logback-test.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+    <!-- Stop output INFO at start -->
+    <statusListener class="ch.qos.logback.core.status.NopStatusListener" />
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <layout class="ch.qos.logback.classic.PatternLayout">
+            <Pattern>
+                %d{HH:mm:ss.SSS} [%t] %-5level %logger{36} - %msg%n
+            </Pattern>
+        </layout>
+    </appender>
+
+    <logger name="org.holiday.calendar" level="debug" additivity="false">
+        <appender-ref ref="CONSOLE"/>
+    </logger>
+
+    <root level="error">
+        <appender-ref ref="CONSOLE"/>
+    </root>
+</configuration>


### PR DESCRIPTION
### China National Public Holidays (CN)

**Description**

- Adds `HolidayCalendarServiceCN` to `holiday-calendar-apac`, serving calendar code `CN`
- Covers all 7 statutory holiday periods (11 entries) from China's State Council Ordinance: New Year's Day, Spring Festival (Days 1–3), Qingming Festival, Labour Day, Dragon Boat Festival, Mid-Autumn Festival, National Day Golden Week (Days 1–3)
- Single-day holidays (`rollable=true`) use `DateRolls.followingMonday()` per the Ordinance's substitution rule; multi-day blocks (`rollable=false`) preserve natural calendar dates — applying per-day rolling to a block would produce wrong results given China's block-shift (调休) mechanism
- Fixes misleading Javadoc in `ChineseNewYearDay` that incorrectly called the 7-day window "statutory"; the constructor range `1–7` now documents the CN (1–3) vs CNY (1–7) distinction
- Registers `HolidayCalendarServiceCN` in `module-info.java` and `META-INF/services`
- Adds `CN` to `HolidayCalendar30YearIT` (now 19 calendars)

**Related Issue**

- [#140 — \[New Market\] China — National Public Holidays](https://github.com/holiday-calendar/holiday-calendar-java/issues/140)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed