### PR TITLE
Fix README.md version sync after 1.3.0-SNAPSHOT bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,21 +65,21 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.2.0</version>
+  <version>1.3.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
### Fix README.md version sync after 1.3.0-SNAPSHOT bump

**Description**

- The version bump to `1.3.0-SNAPSHOT` (commit `7ca1feb`) was not accompanied by a Maven build, leaving `README.md` showing `1.2.0` in all three dependency `<version>` tags
- Running `mvn clean install` triggers the `filter-readme` execution (maven-resources-plugin, `validate` phase), which copies `src/readme/README.md` → `README.md` and replaces `@project.version@` with the current project version
- This PR contains only the regenerated `README.md` with the correct `1.3.0-SNAPSHOT` version

**Related Issue**

- N/A — follow-up to version bump commit `7ca1feb`

**Type of Change**

- [x] Bug fix

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed