### PR TITLE
#171 Define aggregate.report.dir property in root POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,9 +71,11 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.sourceEncoding>UTF-8</project.reporting.sourceEncoding>
 
+        <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
+
         <sonar.organization>holiday-calendar</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
-        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+        <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 
         <repo.domain>github.com</repo.domain>
         <repo.user>holiday-calendar</repo.user>


### PR DESCRIPTION
## Summary

- Define `aggregate.report.dir` property in root `pom.xml` so child module `sonar.coverage.jacoco.xmlReportPaths` expressions resolve correctly
- Update root POM's own `sonar.coverage.jacoco.xmlReportPaths` to use the new property for consistency

## Problem

Each child module sets:

```xml
<sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
```

`aggregate.report.dir` was never defined in the reactor, so Maven left it as a literal unexpanded string. SonarCloud received an invalid path and could not load coverage data for any child module.

## Fix

Added to root `pom.xml` properties:

```xml
<aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
```

Child module paths now resolve to e.g. `<basedir>/../tests/target/site/jacoco-aggregate/jacoco.xml` — the correct absolute path to the aggregate report.

The root POM's own `sonar.coverage.jacoco.xmlReportPaths` now also uses the property (was hardcoded), keeping both in sync.

## Test plan

- [x] `mvn clean verify` passes with no regressions
- [x] `tests/target/site/jacoco-aggregate/jacoco.xml` generated as before
- Resolves #171