### PR TITLE
#158 UAE holiday calendars: AE (national) + AED (CBUAE/DFM/ADX)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ Key design goals:
 
 | Code | Region |
 |------|--------|
+| `AE` | UAE (National) Holidays |
+| `AED` | UAE (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
 | `AUD` | Australia (RBA) Holidays |
 | `CA` | Canada National Holidays |
@@ -81,6 +83,13 @@ Then add the modules you need:
   <artifactId>holiday-calendar-apac</artifactId>
   <version>1.3.0-SNAPSHOT</version>
 </dependency>
+
+<!-- MENA calendars: AE, AED -->
+<dependency>
+  <groupId>org.holiday.calendar</groupId>
+  <artifactId>holiday-calendar-mena</artifactId>
+  <version>1.3.0-SNAPSHOT</version>
+</dependency>
 ```
 
 ## Usage
@@ -122,7 +131,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAE.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAE.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of UAE national public holiday calendar.
+ *
+ * <p>Calendar code: {@code AE}. Covers public holidays observed in the United
+ * Arab Emirates as declared by the UAE Securities and Commodities Authority (SCA)
+ * and Dubai Financial Market (DFM).
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-ae.csv},
+ * {@code eid-al-adha-ae.csv}, {@code islamic-new-year-ae.csv}, and
+ * {@code mawlid-ae.csv}. Dates for 2024–2026 are official SCA/DFM announcements;
+ * 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceAE extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "AE";
+    private static final String NAME = "UAE (National) Holidays";
+
+    public HolidayCalendarServiceAE() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(UaeHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(UaeHolidays.UAE_WEEKEND)
+                .holidays(UaeHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAED.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAED.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of UAE CBUAE / DFM / ADX settlement holiday calendar.
+ *
+ * <p>Calendar code: {@code AED}. Covers settlement closure days for the Central
+ * Bank of the UAE (CBUAE), Dubai Financial Market (DFM), and Abu Dhabi Securities
+ * Exchange (ADX). The settlement holiday schedule mirrors the UAE national calendar
+ * ({@code AE}).
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — settlement requires both
+ * counterparties to be available on the same calendar date; there is no
+ * roll-forward convention. All holidays are {@code rollable(false)}.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceAED extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "AED";
+    private static final String NAME = "UAE (CBUAE/DFM/ADX) Holidays";
+
+    public HolidayCalendarServiceAED() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(UaeHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(UaeHolidays.UAE_WEEKEND)
+                .holidays(UaeHolidays.baseHolidays(false))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/UaeHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/UaeHolidays.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the UAE public holiday list shared by the
+ * national ({@code AE}) and settlement ({@code AED}) calendars.
+ *
+ * <p>All six Islamic holidays are populated through {@value DATA_VALID_THROUGH}
+ * via country-specific CSV lookup tables (country code {@code ae}).
+ * Dates for 2024–2026 are official UAE SCA/DFM announcements; dates for
+ * 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * <p>Note: Arafat Day (9 Dhu al-Hijjah) and Isra' Mi'raj (27 Rajab) are not
+ * modelled here; include in a future revision if the UAE SCA declares them as
+ * settlement closure days.
+ */
+class UaeHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> UAE_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private UaeHolidays() {}
+
+    /**
+     * Returns the 10 UAE public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day,
+     *                      Commemoration Day, National Day, National Day 2nd Day)
+     *                      are rollable; all Islamic holidays are always
+     *                      {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("ae"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("ae"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("ae"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("ae"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("ae"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("ae"))
+                    .build(),
+            Holiday.builder()
+                    .name("Commemoration Day")
+                    .description("UAE Commemoration Day, honouring Emirati Martyrs who died in service")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.NOVEMBER, 30)
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("UAE National Day, marking the formation of the United Arab Emirates on 2 December 1971")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 2)
+                    .build(),
+            Holiday.builder()
+                    .name("National Day (2nd Day)")
+                    .description("UAE National Day (2nd Day), continuation of National Day celebrations")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 3)
+                    .build()
+        );
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay2.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay2.java
@@ -16,18 +16,38 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of the second day of Eid al-Adha (11 Dhu al-Hijjah AH), marking
+ * the continuation of the Feast of Sacrifice.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlAdha})
+ * by one calendar day. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class EidAlAdhaDay2 extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
+    private final EidAlAdha base;
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED;
+    public EidAlAdhaDay2(String countryCode) {
+        this.base = new EidAlAdha(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay2.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay2.java
@@ -16,18 +16,38 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of the second day of Eid al-Fitr (2 Shawwal AH), marking the
+ * continuation of the Eid al-Fitr celebration.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlFitr})
+ * by one calendar day. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class EidAlFitrDay2 extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
+    private final EidAlFitr base;
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED;
+    public EidAlFitrDay2(String countryCode) {
+        this.base = new EidAlFitr(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
 }

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,0 +1,2 @@
+org.holiday.calendar.impl.HolidayCalendarServiceAE
+org.holiday.calendar.impl.HolidayCalendarServiceAED

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAEDTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAEDTest.java
@@ -1,0 +1,214 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceAEDTest {
+
+    private final HolidayCalendarServiceAED service = new HolidayCalendarServiceAED();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("AED"));
+        assertFalse(service.isProvided("AE"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "AED");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "UAE (CBUAE/DFM/ADX) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("AED");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "AED");
+    }
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "UAE weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    @Test
+    public void testCalculate2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), 10, "Expected 10 holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testChronologicalOrder() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // Issue #158 acceptance criterion: UAE 2025 must include Eid al-Fitr on 2025-03-30
+    @Test
+    public void testEidAlFitr2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> eid = holidays.stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(eid.isPresent(), "Eid al-Fitr must be present for 2025");
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30");
+    }
+
+    // AED uses noRoll() — fixed holidays on Friday/Saturday are not rolled
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        // Jan 1, 2027 is a Friday — AED must not roll it
+        Optional<HolidayDate> newYear = calendar.calculate(2027).stream()
+                .filter(hd -> "New Year's Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(newYear.isPresent());
+        assertEquals(newYear.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "AED must not roll New Year's Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    @Test
+    public void testNewYearsDayOnSaturdayNotRolled2022() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        // Jan 1, 2022 is a Saturday — AED must not roll it
+        Optional<HolidayDate> newYear = calendar.calculate(2022).stream()
+                .filter(hd -> "New Year's Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(newYear.isPresent());
+        assertEquals(newYear.get().date(), LocalDate.of(2022, Month.JANUARY, 1),
+                "AED must not roll New Year's Day 2022 (Saturday) — settlement uses no-roll convention");
+    }
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isPresent(),
+                "AED calendar has lookup-table holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("AED");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"AED\") must delegate to the service");
+    }
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
+        assertEquals(holidays.size(), 10,
+                "Expected all 10 AED holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary = calendar.calculate(boundaryYear);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundaryYear + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays; " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays2056 = calendar.calculate(2056);
+        assertEquals(holidays2056.size(), 4,
+                "Beyond CSV ceiling only the 4 fixed Gregorian holidays must remain");
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Commemoration Day"},
+            new Object[]{"National Day"},
+            new Object[]{"National Day (2nd Day)"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAETest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAETest.java
@@ -289,7 +289,7 @@ public class HolidayCalendarServiceAETest {
                 .toList();
         assertEquals(eidOccurrences.size(), 1,
                 "2033 has two Eid al-Fitr occurrences but only January is recorded");
-        assertEquals(eidOccurrences.get(0).date(), LocalDate.of(2033, Month.JANUARY, 3),
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
                 "The single 2033 Eid al-Fitr occurrence must be January 3");
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAETest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAETest.java
@@ -1,0 +1,320 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceAETest {
+
+    private final HolidayCalendarServiceAE service = new HolidayCalendarServiceAE();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("AE"));
+        assertFalse(service.isProvided("AED"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "AE");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "UAE (National) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("AE");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "AE");
+    }
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "UAE weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    @Test
+    public void testCalculate2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        assertNotNull(holidays);
+        // 4 fixed + 6 floating (all Islamic holidays cover 2025)
+        assertEquals(holidays.size(), 10, "Expected 10 holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testChronologicalOrder() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // Issue #158 acceptance criterion: UAE 2025 must include Eid al-Fitr on 2025-03-30
+    @Test
+    public void testEidAlFitr2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> eid = holidays.stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(eid.isPresent(), "Eid al-Fitr must be present for 2025");
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> eid2 = holidays.stream()
+                .filter(hd -> "Eid al-Fitr (2nd Day)".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(eid2.isPresent(), "Eid al-Fitr (2nd Day) must be present for 2025");
+        assertEquals(eid2.get().date(), LocalDate.of(2025, Month.MARCH, 31),
+                "Eid al-Fitr (2nd Day) 2025 must be 2025-03-31");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> adha = holidays.stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(adha.isPresent(), "Eid al-Adha must be present for 2025");
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> adha2 = holidays.stream()
+                .filter(hd -> "Eid al-Adha (2nd Day)".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(adha2.isPresent(), "Eid al-Adha (2nd Day) must be present for 2025");
+        assertEquals(adha2.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "Eid al-Adha (2nd Day) 2025 must be 2025-06-07");
+    }
+
+    @Test
+    public void testIslamicNewYear2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> ny = holidays.stream()
+                .filter(hd -> "Islamic New Year".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(ny.isPresent(), "Islamic New Year must be present for 2025");
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JUNE, 26),
+                "Islamic New Year 2025 must be 2025-06-26");
+    }
+
+    @Test
+    public void testProphetsBirthday2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+
+        Optional<HolidayDate> mawlid = holidays.stream()
+                .filter(hd -> "Prophet's Birthday".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(mawlid.isPresent(), "Prophet's Birthday must be present for 2025");
+        assertEquals(mawlid.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 4),
+                "Prophet's Birthday 2025 must be 2025-09-04");
+    }
+
+    // Jan 1, 2027 falls on Friday → rolls to Sunday Jan 3 under followingSunday()
+    @Test
+    public void testNewYearsDayRoll2027() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2027);
+
+        Optional<HolidayDate> newYear = holidays.stream()
+                .filter(hd -> "New Year's Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(newYear.isPresent());
+        assertEquals(newYear.get().date(), LocalDate.of(2027, Month.JANUARY, 3),
+                "New Year's Day 2027 (Friday) must roll to Sunday Jan 3");
+    }
+
+    // Jan 1, 2022 falls on Saturday → rolls to Sunday Jan 2 under followingSunday()
+    @Test
+    public void testNewYearsDayRoll2022() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2022);
+
+        Optional<HolidayDate> newYear = holidays.stream()
+                .filter(hd -> "New Year's Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(newYear.isPresent());
+        assertEquals(newYear.get().date(), LocalDate.of(2022, Month.JANUARY, 2),
+                "New Year's Day 2022 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // Jan 1, 2025 falls on Wednesday → no roll
+    @Test
+    public void testNewYearsDayNoRoll2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Optional<HolidayDate> newYear = calendar.calculate(2025).stream()
+                .filter(hd -> "New Year's Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(newYear.isPresent());
+        assertEquals(newYear.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isPresent(),
+                "AE calendar has lookup-table holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("AE");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"AE\") must delegate to the service");
+    }
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
+        assertEquals(holidays.size(), 10,
+                "Expected all 10 AE holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary = calendar.calculate(boundaryYear);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundaryYear + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testEidAlFitr2056AbsentSilently() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Optional<HolidayDate> eid = calendar.calculate(2056).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertFalse(eid.isPresent(),
+                "Eid al-Fitr must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays2056 = calendar.calculate(2056);
+        // Only the 4 fixed Gregorian holidays remain
+        assertEquals(holidays2056.size(), 4,
+                "Beyond CSV ceiling only the 4 fixed Gregorian holidays must remain");
+    }
+
+    // Year 2033 has two Eid al-Fitr occurrences; only January is recorded in the CSV
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2033);
+        List<HolidayDate> eidOccurrences = holidays.stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded");
+        assertEquals(eidOccurrences.get(0).date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Commemoration Day"},
+            new Object[]{"National Day"},
+            new Object[]{"National Day (2nd Day)"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+}

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -20,6 +20,8 @@ Key design goals:
 
 | Code | Region |
 |------|--------|
+| `AE` | UAE (National) Holidays |
+| `AED` | UAE (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
 | `AUD` | Australia (RBA) Holidays |
 | `CA` | Canada National Holidays |
@@ -81,6 +83,13 @@ Then add the modules you need:
   <artifactId>holiday-calendar-apac</artifactId>
   <version>@project.version@</version>
 </dependency>
+
+<!-- MENA calendars: AE, AED -->
+<dependency>
+  <groupId>org.holiday.calendar</groupId>
+  <artifactId>holiday-calendar-mena</artifactId>
+  <version>@project.version@</version>
+</dependency>
 ```
 
 ## Usage
@@ -122,7 +131,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 19 implemented holiday calendars
+ * 30-year integration test suite validating all 21 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -55,6 +55,8 @@ public class HolidayCalendar30YearIT {
     @DataProvider(name = "allCalendarCodes")
     public Iterator<Object[]> allCalendarCodes() {
         return List.of(
+                new Object[]{"AE"},
+                new Object[]{"AED"},
                 new Object[]{"AU"},
                 new Object[]{"AUD"},
                 new Object[]{"CA"},

--- a/tests/src/test/java/org/holiday/calendar/ReadmeVersionIT.java
+++ b/tests/src/test/java/org/holiday/calendar/ReadmeVersionIT.java
@@ -117,7 +117,7 @@ public class ReadmeVersionIT {
                 String.join("\n  ", placeholderLines));
     }
 
-    @Test(description = "src/readme/README.md must contain exactly 3 @project.version@ placeholder tokens")
+    @Test(description = "src/readme/README.md must contain exactly 4 @project.version@ placeholder tokens")
     public void testTemplateContainsVersionPlaceholders() throws IOException {
         List<String> templateLines = Files.readAllLines(templatePath);
 
@@ -125,10 +125,10 @@ public class ReadmeVersionIT {
                 .filter(line -> line.contains(VERSION_PLACEHOLDER))
                 .count();
 
-        assertEquals(placeholderCount, 3L,
-                "Expected exactly 3 occurrences of '" + VERSION_PLACEHOLDER +
+        assertEquals(placeholderCount, 4L,
+                "Expected exactly 4 occurrences of '" + VERSION_PLACEHOLDER +
                 "' in " + templatePath.getFileName() +
-                " (one per dependency block: holiday-calendar-core, holiday-calendar-western, holiday-calendar-apac), " +
+                " (one per dependency block: holiday-calendar-core, holiday-calendar-western, holiday-calendar-apac, holiday-calendar-mena), " +
                 "but found " + placeholderCount + ".\n" +
                 "  If you added a new dependency block, update this assertion.\n" +
                 "  If placeholders were replaced with a hardcoded version, restore them.");


### PR DESCRIPTION
### #158 UAE holiday calendars: AE (national) + AED (CBUAE/DFM/ADX)

**Description**

- Implemented `HolidayCalendarServiceAE` (code `AE`) — UAE national public holidays with GCC weekend (Friday + Saturday) and `followingSunday()` roll for fixed holidays
- Implemented `HolidayCalendarServiceAED` (code `AED`) — UAE CBUAE/DFM/ADX settlement calendar; mirrors the national holiday set with `noRoll()` convention, following the SGD/CHF settlement-calendar pattern
- Added `EidAlFitrDay2` and `EidAlAdhaDay2` observance classes that synthesise the 2nd-day date by delegating to the Day 1 observance and advancing by one calendar day (pattern: `ChineseNewYearDay`)
- Added package-private `UaeHolidays` factory shared by both services (10 holidays: 4 fixed Gregorian + 6 Islamic from CSV lookup tables)
- Both services registered in `module-info.java` `provides` directive and `META-INF/services`
- `HolidayCalendar30YearIT` updated from 19 to 21 calendars (76 → 84 test cases)
- `README.md` updated with AE/AED in the supported calendars table, installation snippet, and `listAvailableCodes()` example

**Related Issue**

- [#158 UAE holiday calendars: AE (national) + AED (CBUAE/DFM/ADX)](https://github.com/holiday-calendar/holiday-calendar-java/issues/158)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed