### PR TITLE
#159 Added SA, SAR holiday calendars for Saudi Arabia

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
+| `SA` | Saudi Arabia (National) Holidays |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
 | `SG` | Singapore (SGX) Holidays |
 | `SGD` | Singapore (MAS/MEPS+) Holidays |
 | `UK` | United Kingdom National Holidays |
@@ -84,7 +86,7 @@ Then add the modules you need:
   <version>1.3.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED -->
+<!-- MENA calendars: AE, AED, SA, SAR -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -131,7 +133,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SA", "SAR", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSA.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSA.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Saudi Arabia national public holiday calendar.
+ *
+ * <p>Calendar code: {@code SA}. Covers public holidays observed in the Kingdom of
+ * Saudi Arabia as declared by the Saudi Exchange (Tadawul) and the Saudi Central
+ * Bank (SAMA).
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-sa.csv},
+ * {@code eid-al-adha-sa.csv}, {@code islamic-new-year-sa.csv}, and
+ * {@code mawlid-sa.csv}. Dates for 2024–2026 are official Tadawul/SAMA
+ * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Saudi Arabia uses the Umm al-Qura calendar as its official state
+ * calendar; note that moon sighting determinations may still differ from UAE
+ * announcements by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceSA extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "SA";
+    private static final String NAME = "Saudi Arabia (National) Holidays";
+
+    public HolidayCalendarServiceSA() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(SaudiHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(SaudiHolidays.SAUDI_WEEKEND)
+                .holidays(SaudiHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSAR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSAR.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Saudi Arabia SAMA / Tadawul settlement holiday calendar.
+ *
+ * <p>Calendar code: {@code SAR}. Covers settlement closure days for the Saudi Central
+ * Bank (SAMA) and the Saudi Exchange (Tadawul / TASI). The settlement holiday schedule
+ * mirrors the Saudi Arabia national calendar ({@code SA}).
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — settlement requires both
+ * counterparties to be available on the same calendar date; there is no
+ * roll-forward convention. All holidays are {@code rollable(false)}.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceSAR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "SAR";
+    private static final String NAME = "Saudi Arabia (Tadawul/SAMA) Holidays";
+
+    public HolidayCalendarServiceSAR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(SaudiHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(SaudiHolidays.SAUDI_WEEKEND)
+                .holidays(SaudiHolidays.baseHolidays(false))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/SaudiHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/SaudiHolidays.java
@@ -1,0 +1,140 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Saudi Arabia public holiday list shared by
+ * the national ({@code SA}) and settlement ({@code SAR}) calendars.
+ *
+ * <p>All eight Islamic holidays are populated through {@value DATA_VALID_THROUGH}
+ * via country-specific CSV lookup tables (country code {@code sa}).
+ * Dates for 2024–2026 are official Saudi Exchange (Tadawul) / SAMA announcements;
+ * dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * <p>Saudi Arabia observes three days each for Eid al-Fitr and Eid al-Adha,
+ * consistent with official Tadawul market closure announcements.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class SaudiHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> SAUDI_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private SaudiHolidays() {}
+
+    /**
+     * Returns the 10 Saudi Arabia public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (Saudi Founding Day,
+     *                      Saudi National Day) are rollable; all Islamic holidays
+     *                      are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("Saudi Founding Day")
+                    .description("Founding Day of the Kingdom of Saudi Arabia, established 22 February 1727")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.FEBRUARY, 22)
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("sa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Saudi National Day")
+                    .description("Saudi National Day, marking the unification of the Kingdom on 23 September 1932")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.SEPTEMBER, 23)
+                    .build()
+        );
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay3.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay3.java
@@ -16,20 +16,38 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of the third day of Eid al-Adha (12 Dhu al-Hijjah AH), marking
+ * the continuation of the Feast of Sacrifice.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlAdha})
+ * by two calendar days. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class EidAlAdhaDay3 extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
+    private final EidAlAdha base;
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR;
+    public EidAlAdhaDay3(String countryCode) {
+        this.base = new EidAlAdha(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(2);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay3.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay3.java
@@ -16,20 +16,38 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of the third day of Eid al-Fitr (3 Shawwal AH), marking the
+ * continuation of the Eid al-Fitr celebration.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlFitr})
+ * by two calendar days. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class EidAlFitrDay3 extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
+    private final EidAlFitr base;
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR;
+    public EidAlFitrDay3(String countryCode) {
+        this.base = new EidAlFitr(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(2);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
 }

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,2 +1,4 @@
 org.holiday.calendar.impl.HolidayCalendarServiceAE
 org.holiday.calendar.impl.HolidayCalendarServiceAED
+org.holiday.calendar.impl.HolidayCalendarServiceSA
+org.holiday.calendar.impl.HolidayCalendarServiceSAR

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSARTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSARTest.java
@@ -1,0 +1,258 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceSARTest {
+
+    // 2 fixed + 3 Eid al-Fitr + 3 Eid al-Adha + Islamic New Year + Mawlid = 10
+    private static final int SA_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceSAR service = new HolidayCalendarServiceSAR();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("SAR"));
+        assertFalse(service.isProvided("SA"));
+        assertFalse(service.isProvided("AED"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "SAR");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Saudi Arabia (Tadawul/SAMA) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("SAR");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "SAR");
+    }
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Saudi weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    @Test
+    public void testCalculate2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), SA_HOLIDAY_COUNT,
+                "Expected " + SA_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testChronologicalOrder() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // SAR uses noRoll() — fixed holidays on Friday/Saturday are not rolled
+
+    // Feb 22, 2025 is Saturday — SAR must not roll it
+    @Test
+    public void testFoundingDayOnSaturdayNotRolled2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2025, Month.FEBRUARY, 22).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> foundingDay = calendar.calculate(2025).stream()
+                .filter(hd -> "Saudi Founding Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(foundingDay.isPresent());
+        assertEquals(foundingDay.get().date(), LocalDate.of(2025, Month.FEBRUARY, 22),
+                "SAR must not roll Saudi Founding Day 2025 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Feb 22, 2030 is Friday — SAR must not roll it
+    @Test
+    public void testFoundingDayOnFridayNotRolled2030() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2030, Month.FEBRUARY, 22).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> foundingDay = calendar.calculate(2030).stream()
+                .filter(hd -> "Saudi Founding Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(foundingDay.isPresent());
+        assertEquals(foundingDay.get().date(), LocalDate.of(2030, Month.FEBRUARY, 22),
+                "SAR must not roll Saudi Founding Day 2030 (Friday)");
+    }
+
+    // Sep 23, 2028 is Saturday — SAR must not roll it
+    @Test
+    public void testNationalDayOnSaturdayNotRolled2028() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2028, Month.SEPTEMBER, 23).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nationalDay = calendar.calculate(2028).stream()
+                .filter(hd -> "Saudi National Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(nationalDay.isPresent());
+        assertEquals(nationalDay.get().date(), LocalDate.of(2028, Month.SEPTEMBER, 23),
+                "SAR must not roll Saudi National Day 2028 (Saturday)");
+    }
+
+    // SAR mirrors SA: Islamic floating dates must be identical
+    @Test
+    public void testEidAlFitr2025MatchesSA() {
+        HolidayCalendar sarCalendar = service.getHolidayCalendar();
+        HolidayCalendar saCalendar = new HolidayCalendarServiceSA().getHolidayCalendar();
+
+        Optional<HolidayDate> sarEid = sarCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        Optional<HolidayDate> saEid = saCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+
+        assertTrue(sarEid.isPresent());
+        assertTrue(saEid.isPresent());
+        assertEquals(sarEid.get().date(), saEid.get().date(),
+                "SAR Eid al-Fitr date must match SA");
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesSA() {
+        HolidayCalendar sarCalendar = service.getHolidayCalendar();
+        HolidayCalendar saCalendar = new HolidayCalendarServiceSA().getHolidayCalendar();
+
+        Optional<HolidayDate> sarAdha = sarCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        Optional<HolidayDate> saAdha = saCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+
+        assertTrue(sarAdha.isPresent());
+        assertTrue(saAdha.isPresent());
+        assertEquals(sarAdha.get().date(), saAdha.get().date(),
+                "SAR Eid al-Adha date must match SA");
+    }
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isPresent(),
+                "SAR calendar has lookup-table holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("SAR");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"SAR\") must delegate to the service");
+    }
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
+        assertEquals(holidays.size(), SA_HOLIDAY_COUNT,
+                "Expected all " + SA_HOLIDAY_COUNT + " SAR holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary = calendar.calculate(boundaryYear);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundaryYear + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays; " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays2056 = calendar.calculate(2056);
+        assertEquals(holidays2056.size(), 2,
+                "Beyond CSV ceiling only the 2 fixed Saudi holidays must remain");
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Saudi Founding Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Saudi National Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSATest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSATest.java
@@ -1,0 +1,392 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceSATest {
+
+    // 2 fixed + 3 Eid al-Fitr + 3 Eid al-Adha + Islamic New Year + Mawlid = 10
+    private static final int SA_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceSA service = new HolidayCalendarServiceSA();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("SA"));
+        assertFalse(service.isProvided("SAR"));
+        assertFalse(service.isProvided("AE"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "SA");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Saudi Arabia (National) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("SA");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "SA");
+    }
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Saudi weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    @Test
+    public void testCalculate2024() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), SA_HOLIDAY_COUNT,
+                "Expected " + SA_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), SA_HOLIDAY_COUNT,
+                "Expected " + SA_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testChronologicalOrder2024() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // Feb 22, 2025 is Saturday → rolls to Sunday Feb 23
+    @Test
+    public void testFoundingDayRoll2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2025, Month.FEBRUARY, 22).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> foundingDay = calendar.calculate(2025).stream()
+                .filter(hd -> "Saudi Founding Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(foundingDay.isPresent());
+        assertEquals(foundingDay.get().date(), LocalDate.of(2025, Month.FEBRUARY, 23),
+                "Saudi Founding Day 2025 (Saturday) must roll to Sunday Feb 23");
+    }
+
+    // Sep 23, 2025 is Tuesday → no roll
+    @Test
+    public void testNationalDay2025() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 23).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> nationalDay = calendar.calculate(2025).stream()
+                .filter(hd -> "Saudi National Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(nationalDay.isPresent());
+        assertEquals(nationalDay.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 23),
+                "Saudi National Day 2025 (Tuesday) must not roll");
+    }
+
+    // Feb 22, 2030 is Friday → rolls to Sunday Feb 24
+    @Test
+    public void testFoundingDayRollFromFriday2030() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2030, Month.FEBRUARY, 22).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> foundingDay = calendar.calculate(2030).stream()
+                .filter(hd -> "Saudi Founding Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(foundingDay.isPresent());
+        assertEquals(foundingDay.get().date(), LocalDate.of(2030, Month.FEBRUARY, 24),
+                "Saudi Founding Day 2030 (Friday) must roll to Sunday Feb 24");
+    }
+
+    // Sep 23, 2028 is Saturday → rolls to Sunday Sep 24
+    @Test
+    public void testNationalDayRollFromSaturday2028() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(LocalDate.of(2028, Month.SEPTEMBER, 23).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nationalDay = calendar.calculate(2028).stream()
+                .filter(hd -> "Saudi National Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(nationalDay.isPresent());
+        assertEquals(nationalDay.get().date(), LocalDate.of(2028, Month.SEPTEMBER, 24),
+                "Saudi National Day 2028 (Saturday) must roll to Sunday Sep 24");
+    }
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11),
+                "Eid al-Fitr (2nd Day) 2024 must be 2024-04-11");
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12),
+                "Eid al-Fitr (3rd Day) 2024 must be 2024-04-12");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17),
+                "Eid al-Adha (2nd Day) 2024 must be 2024-06-17");
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18),
+                "Eid al-Adha (3rd Day) 2024 must be 2024-06-18");
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> ny = findFirst("Islamic New Year", 2024);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> mawlid = findFirst("Prophet's Birthday", 2024);
+        assertTrue(mawlid.isPresent());
+        assertEquals(mawlid.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15");
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2025() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2025);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2025, Month.MARCH, 31),
+                "Eid al-Fitr (2nd Day) 2025 must be 2025-03-31");
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2025() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2025);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2025, Month.APRIL, 1),
+                "Eid al-Fitr (3rd Day) 2025 must be 2025-04-01");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per Tadawul official announcement");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2025() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2025);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "Eid al-Adha (2nd Day) 2025 must be 2025-06-07");
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2025() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2025);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2025, Month.JUNE, 8),
+                "Eid al-Adha (3rd Day) 2025 must be 2025-06-08");
+    }
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isPresent(),
+                "SA calendar has lookup-table holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("SA");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"SA\") must delegate to the service");
+    }
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays = calendar.calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
+        assertEquals(holidays.size(), SA_HOLIDAY_COUNT,
+                "Expected all " + SA_HOLIDAY_COUNT + " SA holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary = calendar.calculate(boundaryYear);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundaryYear + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testEidAlFitr2056AbsentSilently() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Optional<HolidayDate> eid = calendar.calculate(2056).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertFalse(eid.isPresent(),
+                "Eid al-Fitr must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> holidays2056 = calendar.calculate(2056);
+        assertEquals(holidays2056.size(), 2,
+                "Beyond CSV ceiling only the 2 fixed Saudi holidays must remain");
+    }
+
+    // Year 2033 has two Eid al-Fitr occurrences; only January is recorded in the CSV
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> eidOccurrences = calendar.calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Saudi Founding Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Saudi National Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -36,6 +36,8 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
+| `SA` | Saudi Arabia (National) Holidays |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
 | `SG` | Singapore (SGX) Holidays |
 | `SGD` | Singapore (MAS/MEPS+) Holidays |
 | `UK` | United Kingdom National Holidays |
@@ -84,7 +86,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED -->
+<!-- MENA calendars: AE, AED, SA, SAR -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -131,7 +133,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SG", "SGD", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SA", "SAR", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar


### PR DESCRIPTION
### #159 Added SA, SAR holiday calendars for Saudi Arabia

**Description**

- Added `HolidayCalendarServiceSA` (code `SA`) — Saudi Arabia national public holiday calendar with `followingSunday()` date-roll and Friday + Saturday weekend
- Added `HolidayCalendarServiceSAR` (code `SAR`) — Saudi Arabia SAMA / Tadawul settlement calendar with `noRoll()`, mirroring the national schedule
- Added `SaudiHolidays` package-private factory shared by both services
- Added `EidAlFitrDay3` and `EidAlAdhaDay3` observances (Saudi Arabia observes 3 days for each Eid, vs. 2 days for UAE)
- Islamic holidays loaded from existing per-country CSVs (`eid-al-fitr-sa.csv`, `eid-al-adha-sa.csv`, `islamic-new-year-sa.csv`, `mawlid-sa.csv`); data valid through 2055
- Registered both services in `module-info.java` and `META-INF/services`
- Updated README to include `SA` and `SAR` in the supported calendars table

**Related Issue**

- [#159 Saudi Arabia holiday calendars: SA (national) + SAR (Tadawul/SAMA)](https://github.com/holiday-calendar/holiday-calendar-java/issues/159)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed