### PR TITLE
#160 Added Israel holiday calendars IL, ILS + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,8 @@ Key design goals:
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France (Euronext Paris) Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
+| `IL` | Israel (National) Holidays |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `SA` | Saudi Arabia (National) Holidays |
@@ -86,7 +88,7 @@ Then add the modules you need:
   <version>1.3.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, SA, SAR -->
+<!-- MENA calendars: AE, AED, IL, ILS, SA, SAR -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -133,7 +135,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SA", "SAR", "SG", "SGD", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "SA", "SAR", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceIL.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceIL.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+/**
+ * Service for provision of Israel national public holiday calendar.
+ *
+ * <p>Calendar code: {@code IL}. Covers public holidays observed in Israel as
+ * published by the Israeli government and confirmed against TASE market
+ * closure announcements.
+ *
+ * <p>Weekend: Friday + Saturday (Israeli work week; Sunday is the first
+ * business day). Fixed holidays that fall on Friday or Saturday roll to the
+ * following Sunday per {@link DateRolls#followingSunday()}.
+ *
+ * <p>All nine holidays are computed algorithmically via
+ * {@code net.time4j.calendar.HebrewCalendar}; no lookup tables or data
+ * ceiling applies. Independence Day (Yom Ha'atzmaut) applies a statutory
+ * postponement rule; see {@link org.holiday.calendar.observance.hebrew.IndependenceDay}.
+ *
+ * <p>MSCI classification: Developed Market (DM) — the only Developed Market
+ * in the MENA module.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceIL extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "IL";
+    private static final String NAME = "Israel (National) Holidays";
+
+    public HolidayCalendarServiceIL() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // Israeli weekend is Fri+Sat; fixed holidays rolling to following Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(IsraelHolidays.ISRAEL_WEEKEND)
+                .holidays(IsraelHolidays.baseHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceILS.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceILS.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+/**
+ * Service for provision of Israel TASE / Bank of Israel settlement holiday calendar.
+ *
+ * <p>Calendar code: {@code ILS}. Covers settlement closure days for the Tel Aviv
+ * Stock Exchange (TASE) and the Bank of Israel. The settlement holiday schedule
+ * mirrors the Israel national calendar ({@code IL}).
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — settlement requires both
+ * counterparties to be available on the same calendar date; there is no
+ * roll-forward convention. All holidays are {@code rollable(false)}.
+ *
+ * <p>Weekend: Friday + Saturday (Israeli market convention).
+ *
+ * <p><strong>Scope limitation — half-day closures:</strong> TASE closes early
+ * (typically 13:00 IST) on holiday eves: Erev Rosh Hashanah, Erev Yom Kippur,
+ * Erev Passover, Erev Shavuot, and Erev Sukkot. The current {@code Holiday}
+ * sealed interface models only full-day closures. These half-day eves are
+ * <em>not</em> represented in this calendar. Users performing same-day or T+1
+ * settlement date calculations for trades placed in the morning of an eve day
+ * must apply additional TASE-specific adjustments outside this library.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceILS extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "ILS";
+    private static final String NAME = "Israel (TASE/Bank of Israel) Holidays";
+
+    public HolidayCalendarServiceILS() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(IsraelHolidays.ISRAEL_WEEKEND)
+                .holidays(IsraelHolidays.baseHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceILS.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceILS.java
@@ -43,6 +43,16 @@ import org.holiday.calendar.function.DateRolls;
  * settlement date calculations for trades placed in the morning of an eve day
  * must apply additional TASE-specific adjustments outside this library.
  *
+ * <p><strong>Hoshana Raba (21 Tishri) — intentionally excluded:</strong>
+ * TASE closes on Hoshana Raba (the 7th day of Sukkot, 21 Tishri) consistently;
+ * this was confirmed in official TASE vacation schedules for 2022–2025.
+ * However, the Bank of Israel operates with reduced hours on that day (until
+ * approximately 13:15 IST) and does not treat it as a full settlement closure —
+ * per official Bank of Israel Markets Department schedules. Since {@code ILS}
+ * represents shekel settlement availability (Bank of Israel), and the central
+ * bank is open on 21 Tishri, Hoshana Raba is not an ILS closure day. Consumers
+ * building TASE-only trading calendars must add 21 Tishri independently.
+ *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HolidayCalendarServiceILS extends AbstractHolidayCalendarService {

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
@@ -52,6 +52,11 @@ import java.util.List;
  * <ul>
  *   <li>Yom Hazikaron (4 Iyar) — TASE remains open; not a market closure day.</li>
  *   <li>Sigd (29 Heshvan) — low market relevance; not a TASE closure day.</li>
+ *   <li>Hoshana Raba (21 Tishri) — TASE closes on this day, but the Bank of
+ *       Israel operates with reduced hours (not a full settlement closure).
+ *       ILS represents Bank of Israel settlement availability; since the central
+ *       bank is open on 21 Tishri, it is not an ILS closure day. TASE-only
+ *       trading calendars should add this date separately.</li>
  * </ul>
  */
 class IsraelHolidays {

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
@@ -1,0 +1,134 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.hebrew.IndependenceDay;
+import org.holiday.calendar.observance.hebrew.Passover;
+import org.holiday.calendar.observance.hebrew.PassoverEnd;
+import org.holiday.calendar.observance.hebrew.RoshHashanah;
+import org.holiday.calendar.observance.hebrew.RoshHashanahDay2;
+import org.holiday.calendar.observance.hebrew.Shavuot;
+import org.holiday.calendar.observance.hebrew.SheminiAtzeret;
+import org.holiday.calendar.observance.hebrew.Sukkot;
+import org.holiday.calendar.observance.hebrew.YomKippur;
+
+import java.time.DayOfWeek;
+import java.util.List;
+
+/**
+ * Package-private factory building the Israel public holiday list shared by
+ * the national ({@code IL}) and settlement ({@code ILS}) calendars.
+ *
+ * <p>All nine holidays are computed algorithmically via
+ * {@code net.time4j.calendar.HebrewCalendar}; no CSV lookup tables are used.
+ * All holidays are declared {@code rollable(false)} because Hebrew calendar
+ * dates are observed on specific calendar days regardless of the day of week.
+ * Independence Day is additionally self-adjusting via the statutory
+ * postponement rule embedded in {@link IndependenceDay#computeDate}.
+ *
+ * <p>Scope limitation: TASE closes early on holiday eves (Erev Rosh Hashanah,
+ * Erev Yom Kippur, Erev Passover, Erev Shavuot, Erev Sukkot). These half-day
+ * closures are not modelled here. See {@link HolidayCalendarServiceILS} for the
+ * full limitation notice.
+ *
+ * <p>Omitted holidays (conscious decisions):
+ * <ul>
+ *   <li>Yom Hazikaron (4 Iyar) — TASE remains open; not a market closure day.</li>
+ *   <li>Sigd (29 Heshvan) — low market relevance; not a TASE closure day.</li>
+ * </ul>
+ */
+class IsraelHolidays {
+
+    // Israeli weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> ISRAEL_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private IsraelHolidays() {}
+
+    static List<Holiday> baseHolidays() {
+        return List.of(
+            Holiday.builder()
+                    .name("Rosh Hashanah")
+                    .description("Jewish New Year, first day (1 Tishri)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new RoshHashanah())
+                    .build(),
+            Holiday.builder()
+                    .name("Rosh Hashanah (2nd Day)")
+                    .description("Jewish New Year, second day (2 Tishri)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new RoshHashanahDay2())
+                    .build(),
+            Holiday.builder()
+                    .name("Yom Kippur")
+                    .description("Day of Atonement (10 Tishri)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new YomKippur())
+                    .build(),
+            Holiday.builder()
+                    .name("Sukkot")
+                    .description("Festival of Tabernacles, first day (15 Tishri)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new Sukkot())
+                    .build(),
+            Holiday.builder()
+                    .name("Shemini Atzeret / Simchat Torah")
+                    .description("Eighth Day of Assembly / Rejoicing of the Torah (22 Tishri); " +
+                                 "combined on a single day in Israel")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new SheminiAtzeret())
+                    .build(),
+            Holiday.builder()
+                    .name("Passover")
+                    .description("First day of Passover (15 Nisan)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new Passover())
+                    .build(),
+            Holiday.builder()
+                    .name("Passover (7th Day)")
+                    .description("Seventh and final day of Passover (21 Nisan); " +
+                                 "Israel observes a 7-day Passover (Nisan 15–21)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new PassoverEnd())
+                    .build(),
+            Holiday.builder()
+                    .name("Yom Ha'atzmaut")
+                    .description("Israeli Independence Day (5 Iyar); shifted per statutory " +
+                                 "postponement rule when natural date falls on Sun/Mon/Fri/Sat")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IndependenceDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Shavuot")
+                    .description("Feast of Weeks / Pentecost (6 Sivan)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new Shavuot())
+                    .build()
+        );
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/IndependenceDay.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/IndependenceDay.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Yom Ha'atzmaut — Israeli Independence Day (5 Iyar).
+ *
+ * <p>The natural date is 5 Iyar, but Israeli law (amended 2004) requires the
+ * observed date to be shifted when Yom Hazikaron (Memorial Day, 4 Iyar) would
+ * fall on a problematic day relative to Shabbat (Friday–Saturday) or its
+ * immediate aftermath (Sunday). The complete postponement rule based on the
+ * day of week of natural 5 Iyar:
+ *
+ * <table>
+ *   <tr><th>Natural 5 Iyar</th><th>Observed date</th></tr>
+ *   <tr><td>Sunday</td><td>Monday (+1) — Iyar 4 would be Shabbat</td></tr>
+ *   <tr><td>Monday</td><td>Tuesday (+1) — Iyar 4 would be Sunday (post-Shabbat)</td></tr>
+ *   <tr><td>Tuesday</td><td>Tuesday (no shift)</td></tr>
+ *   <tr><td>Wednesday</td><td>Wednesday (no shift)</td></tr>
+ *   <tr><td>Thursday</td><td>Thursday (no shift)</td></tr>
+ *   <tr><td>Friday</td><td>Thursday (−1) — Iyar 4 would be Erev Shabbat</td></tr>
+ *   <tr><td>Saturday</td><td>Thursday (−2) — 5 Iyar itself is Shabbat</td></tr>
+ * </table>
+ *
+ * <p>This observance applies the shift internally and must be declared
+ * {@code rollable(false)} — the calendar's {@code DateRoll} must not be
+ * applied on top of this already-adjusted date.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class IndependenceDay extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        LocalDate natural = HebrewCalendar.of(year + 3760, HebrewMonth.IYAR, 5)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+
+        return switch (natural.getDayOfWeek()) {
+            case SUNDAY   -> natural.plusDays(1);   // Iyar 4 = Shabbat → observed Monday
+            case MONDAY   -> natural.plusDays(1);   // Iyar 4 = Sunday → observed Tuesday
+            case FRIDAY   -> natural.minusDays(1);  // Erev Shabbat → observed Thursday
+            case SATURDAY -> natural.minusDays(2);  // Shabbat itself → observed Thursday
+            default       -> natural;
+        };
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/Passover.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/Passover.java
@@ -16,23 +16,31 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Passover (15 Nisan) — the first day of Pesach.
+ *
+ * <p>Israel observes a 7-day Passover (Nisan 15–21); only the first and last
+ * days are public holidays. The Hebrew year for Nisan in a given Gregorian
+ * year is {@code gregorianYear + 3760}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class Passover extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3760, HebrewMonth.NISAN, 15)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/PassoverEnd.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/PassoverEnd.java
@@ -16,23 +16,30 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of the last day of Passover (21 Nisan) — the seventh day of Pesach.
+ *
+ * <p>Israel observes a 7-day Passover (Nisan 15–21). Only Nisan 21 (the last day)
+ * is a public holiday; the intermediate days (Chol HaMoed) are not closures.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class PassoverEnd extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3760, HebrewMonth.NISAN, 21)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/RoshHashanah.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/RoshHashanah.java
@@ -16,23 +16,30 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Rosh Hashanah (1 Tishri) — the Jewish New Year, first day.
+ *
+ * <p>Computed algorithmically via {@link HebrewCalendar}. The Hebrew year
+ * beginning in autumn of the given Gregorian year is {@code gregorianYear + 3761}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class RoshHashanah extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3761, HebrewMonth.TISHRI, 1)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/RoshHashanahDay2.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/RoshHashanahDay2.java
@@ -16,23 +16,27 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Rosh Hashanah (2 Tishri) — the Jewish New Year, second day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class RoshHashanahDay2 extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3761, HebrewMonth.TISHRI, 2)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/Shavuot.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/Shavuot.java
@@ -16,23 +16,27 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Shavuot (6 Sivan) — the Feast of Weeks / Pentecost.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class Shavuot extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3760, HebrewMonth.SIVAN, 6)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/SheminiAtzeret.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/SheminiAtzeret.java
@@ -16,23 +16,30 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Shemini Atzeret / Simchat Torah (22 Tishri).
+ *
+ * <p>In Israel (unlike the Diaspora), Shemini Atzeret and Simchat Torah are
+ * combined on a single day — 22 Tishri.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class SheminiAtzeret extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3761, HebrewMonth.TISHRI, 22)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/Sukkot.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/Sukkot.java
@@ -16,23 +16,27 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Sukkot (15 Tishri) — the Festival of Tabernacles, first day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class Sukkot extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3761, HebrewMonth.TISHRI, 15)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/YomKippur.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/YomKippur.java
@@ -16,23 +16,27 @@
  * Temple Place, Suite 330, Boston, MA 02111-1307 USA
  ******************************************************************************/
 
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
 /**
- * Holiday Calendar - MENA regional calendar module.
+ * Observance of Yom Kippur (10 Tishri) — the Day of Atonement.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-module org.holiday.calendar.mena {
-    requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
-    requires net.time4j.base;
-    requires org.slf4j;
+public class YomKippur extends AbstractObservance {
 
-    exports org.holiday.calendar.observance.islamic.mena;
-    exports org.holiday.calendar.observance.hebrew;
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3761, HebrewMonth.TISHRI, 10)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
 
-    provides org.holiday.calendar.HolidayCalendarService with
-        org.holiday.calendar.impl.HolidayCalendarServiceAE,
-        org.holiday.calendar.impl.HolidayCalendarServiceAED,
-        org.holiday.calendar.impl.HolidayCalendarServiceSA,
-        org.holiday.calendar.impl.HolidayCalendarServiceSAR,
-        org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
 }

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -2,3 +2,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceAE
 org.holiday.calendar.impl.HolidayCalendarServiceAED
 org.holiday.calendar.impl.HolidayCalendarServiceSA
 org.holiday.calendar.impl.HolidayCalendarServiceSAR
+org.holiday.calendar.impl.HolidayCalendarServiceIL
+org.holiday.calendar.impl.HolidayCalendarServiceILS

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILSTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILSTest.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceILSTest {
+
+    private static final int ILS_HOLIDAY_COUNT = 9;
+
+    private final HolidayCalendarServiceILS service = new HolidayCalendarServiceILS();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // -------------------------------------------------------------------------
+    // Identity
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("ILS"));
+        assertFalse(service.isProvided("IL"));
+        assertFalse(service.isProvided("SAR"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "ILS");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Israel (TASE/Bank of Israel) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("ILS");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "ILS");
+    }
+
+    // -------------------------------------------------------------------------
+    // Weekend configuration
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Israeli weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // -------------------------------------------------------------------------
+    // dataValidThrough — algorithmic, no ceiling
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testDataValidThroughReturnsEmpty() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isEmpty(),
+                "ILS uses HebrewCalendar arithmetic; dataValidThrough() must return empty");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("ILS");
+        assertTrue(result.isEmpty());
+    }
+
+    // -------------------------------------------------------------------------
+    // Holiday count
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), ILS_HOLIDAY_COUNT);
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Rosh Hashanah"},
+            new Object[]{"Rosh Hashanah (2nd Day)"},
+            new Object[]{"Yom Kippur"},
+            new Object[]{"Sukkot"},
+            new Object[]{"Shemini Atzeret / Simchat Torah"},
+            new Object[]{"Passover"},
+            new Object[]{"Passover (7th Day)"},
+            new Object[]{"Yom Ha'atzmaut"},
+            new Object[]{"Shavuot"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertTrue(calendar.getHolidays().stream().anyMatch(h -> holidayName.equals(h.getName())),
+                "Calendar must contain holiday: " + holidayName);
+    }
+
+    // -------------------------------------------------------------------------
+    // ILS mirrors IL: all floating Hebrew dates must be identical
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRoshHashanah2025MatchesIL() {
+        assertMatchesIL("Rosh Hashanah", 2025);
+    }
+
+    @Test
+    public void testPassover2025MatchesIL() {
+        assertMatchesIL("Passover", 2025);
+    }
+
+    @Test
+    public void testYomHaatzmaut2025MatchesIL() {
+        assertMatchesIL("Yom Ha'atzmaut", 2025);
+    }
+
+    @Test
+    public void testShavuot2025MatchesIL() {
+        assertMatchesIL("Shavuot", 2025);
+    }
+
+    @Test
+    public void testYomKippur2025MatchesIL() {
+        assertMatchesIL("Yom Kippur", 2025);
+    }
+
+    // -------------------------------------------------------------------------
+    // Passover 7th Day falls on Saturday 2025 — ILS observes on natural date (no roll)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testPassoverEnd2025NotRolled() {
+        // 21 Nisan 5785 = 2025-04-19 (Saturday — Israeli weekend)
+        // ILS uses noRoll(); the date stays on Saturday
+        assertEquals(LocalDate.of(2025, Month.APRIL, 19).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> hd = findFirst("Passover (7th Day)", 2025);
+        assertTrue(hd.isPresent());
+        assertEquals(hd.get().date(), LocalDate.of(2025, Month.APRIL, 19),
+                "ILS Passover 7th Day 2025 (Saturday) must not be rolled — noRoll() convention");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+    private void assertMatchesIL(String holidayName, int year) {
+        Optional<HolidayDate> ilsDate = findFirst(holidayName, year);
+        Optional<HolidayDate> ilDate = new HolidayCalendarServiceIL().getHolidayCalendar()
+                .calculate(year).stream()
+                .filter(hd -> holidayName.equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(ilsDate.isPresent(), "ILS must contain: " + holidayName);
+        assertTrue(ilDate.isPresent(), "IL must contain: " + holidayName);
+        assertEquals(ilsDate.get().date(), ilDate.get().date(),
+                "ILS " + holidayName + " " + year + " must match IL (all Hebrew holidays are rollable=false)");
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILTest.java
@@ -1,0 +1,382 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceILTest {
+
+    // 9 Hebrew-calendar holidays per year
+    private static final int IL_HOLIDAY_COUNT = 9;
+
+    private final HolidayCalendarServiceIL service = new HolidayCalendarServiceIL();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // -------------------------------------------------------------------------
+    // Identity
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("IL"));
+        assertFalse(service.isProvided("ILS"));
+        assertFalse(service.isProvided("SA"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "IL");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Israel (National) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("IL");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "IL");
+    }
+
+    // -------------------------------------------------------------------------
+    // Weekend configuration
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Israeli weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // -------------------------------------------------------------------------
+    // dataValidThrough — algorithmic, no ceiling
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testDataValidThroughReturnsEmpty() {
+        OptionalInt result = service.dataValidThrough();
+        assertTrue(result.isEmpty(),
+                "IL uses HebrewCalendar arithmetic; dataValidThrough() must return empty");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("IL");
+        assertTrue(result.isEmpty(),
+                "factory.dataValidThrough(\"IL\") must delegate to service and return empty");
+    }
+
+    // -------------------------------------------------------------------------
+    // Holiday count and composition
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), IL_HOLIDAY_COUNT,
+                "Expected " + IL_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2026() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), IL_HOLIDAY_COUNT,
+                "Expected " + IL_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+    }
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Rosh Hashanah"},
+            new Object[]{"Rosh Hashanah (2nd Day)"},
+            new Object[]{"Yom Kippur"},
+            new Object[]{"Sukkot"},
+            new Object[]{"Shemini Atzeret / Simchat Torah"},
+            new Object[]{"Passover"},
+            new Object[]{"Passover (7th Day)"},
+            new Object[]{"Yom Ha'atzmaut"},
+            new Object[]{"Shavuot"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        boolean found = calendar.getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // -------------------------------------------------------------------------
+    // Chronological order
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2026() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // 2025 spot-checks
+    // All dates verified via net.time4j.calendar.HebrewCalendar computation.
+    // Note: the issue's Rosh Hashanah/Yom Kippur spot-checks (Sep 22-23, Oct 1)
+    // use the sunset-based start convention; Time4J returns the Gregorian
+    // calendar day of the Hebrew date, which is one day later.
+    // -------------------------------------------------------------------------
+
+    // Passover 5785 (spring 2025, offset +3760)
+    @Test
+    public void testPassover2025() {
+        // 15 Nisan 5785 = 2025-04-13 (Sunday)
+        assertEquals(LocalDate.of(2025, Month.APRIL, 13).getDayOfWeek(), DayOfWeek.SUNDAY);
+        assertEquals(findFirst("Passover", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.APRIL, 13),
+                "Passover Day 1 2025 must be 2025-04-13");
+    }
+
+    @Test
+    public void testPassoverEnd2025() {
+        // 21 Nisan 5785 = 2025-04-19 (Saturday)
+        assertEquals(LocalDate.of(2025, Month.APRIL, 19).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("Passover (7th Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.APRIL, 19),
+                "Passover 7th Day 2025 must be 2025-04-19");
+    }
+
+    // Yom Ha'atzmaut 5785: natural Iyar 5 = May 3 (Saturday) → shift -2 → Thursday May 1
+    @Test
+    public void testYomHaatzmaut2025ShiftFromSaturday() {
+        assertEquals(LocalDate.of(2025, Month.MAY, 3).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Natural Iyar 5 5785 must be Saturday May 3");
+        assertEquals(findFirst("Yom Ha'atzmaut", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.MAY, 1),
+                "Yom Ha'atzmaut 2025 (Iyar 5 = Saturday) must shift back to Thursday May 1");
+    }
+
+    @Test
+    public void testShavuot2025() {
+        // 6 Sivan 5785 = 2025-06-02 (Monday)
+        assertEquals(LocalDate.of(2025, Month.JUNE, 2).getDayOfWeek(), DayOfWeek.MONDAY);
+        assertEquals(findFirst("Shavuot", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.JUNE, 2),
+                "Shavuot 2025 must be 2025-06-02");
+    }
+
+    // Rosh Hashanah 5786 (autumn 2025, offset +3761)
+    @Test
+    public void testRoshHashanah2025() {
+        // 1 Tishri 5786 = 2025-09-23 (Tuesday)
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 23).getDayOfWeek(), DayOfWeek.TUESDAY);
+        assertEquals(findFirst("Rosh Hashanah", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.SEPTEMBER, 23),
+                "Rosh Hashanah Day 1 2025 must be 2025-09-23");
+    }
+
+    @Test
+    public void testRoshHashanahDay2_2025() {
+        // 2 Tishri 5786 = 2025-09-24 (Wednesday)
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 24).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        assertEquals(findFirst("Rosh Hashanah (2nd Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.SEPTEMBER, 24),
+                "Rosh Hashanah Day 2 2025 must be 2025-09-24");
+    }
+
+    @Test
+    public void testYomKippur2025() {
+        // 10 Tishri 5786 = 2025-10-02 (Thursday)
+        assertEquals(LocalDate.of(2025, Month.OCTOBER, 2).getDayOfWeek(), DayOfWeek.THURSDAY);
+        assertEquals(findFirst("Yom Kippur", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.OCTOBER, 2),
+                "Yom Kippur 2025 must be 2025-10-02");
+    }
+
+    @Test
+    public void testSukkot2025() {
+        // 15 Tishri 5786 = 2025-10-07 (Tuesday)
+        assertEquals(LocalDate.of(2025, Month.OCTOBER, 7).getDayOfWeek(), DayOfWeek.TUESDAY);
+        assertEquals(findFirst("Sukkot", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.OCTOBER, 7),
+                "Sukkot 2025 must be 2025-10-07");
+    }
+
+    @Test
+    public void testSheminiAtzeret2025() {
+        // 22 Tishri 5786 = 2025-10-14 (Tuesday)
+        assertEquals(LocalDate.of(2025, Month.OCTOBER, 14).getDayOfWeek(), DayOfWeek.TUESDAY);
+        assertEquals(findFirst("Shemini Atzeret / Simchat Torah", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.OCTOBER, 14),
+                "Shemini Atzeret 2025 must be 2025-10-14");
+    }
+
+    // -------------------------------------------------------------------------
+    // 2026 cross-year coverage
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testPassover2026() {
+        // 15 Nisan 5786 = 2026-04-02 (Thursday)
+        assertEquals(LocalDate.of(2026, Month.APRIL, 2).getDayOfWeek(), DayOfWeek.THURSDAY);
+        assertEquals(findFirst("Passover", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.APRIL, 2),
+                "Passover Day 1 2026 must be 2026-04-02");
+    }
+
+    @Test
+    public void testPassoverEnd2026() {
+        // 21 Nisan 5786 = 2026-04-08 (Wednesday)
+        assertEquals(LocalDate.of(2026, Month.APRIL, 8).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        assertEquals(findFirst("Passover (7th Day)", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.APRIL, 8),
+                "Passover 7th Day 2026 must be 2026-04-08");
+    }
+
+    // Yom Ha'atzmaut 2026: natural Iyar 5 = April 22 (Wednesday) → no shift
+    @Test
+    public void testYomHaatzmaut2026NoShift() {
+        assertEquals(LocalDate.of(2026, Month.APRIL, 22).getDayOfWeek(), DayOfWeek.WEDNESDAY,
+                "Natural Iyar 5 5786 must be Wednesday April 22");
+        assertEquals(findFirst("Yom Ha'atzmaut", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.APRIL, 22),
+                "Yom Ha'atzmaut 2026 (Wednesday) must not shift");
+    }
+
+    @Test
+    public void testRoshHashanah2026() {
+        // 1 Tishri 5787 = 2026-09-12 (Saturday — Israeli weekend, but still listed)
+        assertEquals(LocalDate.of(2026, Month.SEPTEMBER, 12).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("Rosh Hashanah", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.SEPTEMBER, 12),
+                "Rosh Hashanah Day 1 2026 must be 2026-09-12");
+    }
+
+    // -------------------------------------------------------------------------
+    // Independence Day shift rule — additional years
+    // -------------------------------------------------------------------------
+
+    // 2024: natural Iyar 5 = May 13 (Monday) → shift +1 → Tuesday May 14
+    @Test
+    public void testYomHaatzmaut2024ShiftFromMonday() {
+        assertEquals(LocalDate.of(2024, Month.MAY, 13).getDayOfWeek(), DayOfWeek.MONDAY,
+                "Natural Iyar 5 5784 must be Monday May 13");
+        assertEquals(findFirst("Yom Ha'atzmaut", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.MAY, 14),
+                "Yom Ha'atzmaut 2024 (Iyar 5 = Monday) must shift to Tuesday May 14");
+    }
+
+    // 2029: natural Iyar 5 = April 20 (Friday) → shift -1 → Thursday April 19
+    @Test
+    public void testYomHaatzmaut2029ShiftFromFriday() {
+        assertEquals(LocalDate.of(2029, Month.APRIL, 20).getDayOfWeek(), DayOfWeek.FRIDAY,
+                "Natural Iyar 5 5789 must be Friday April 20");
+        assertEquals(findFirst("Yom Ha'atzmaut", 2029).orElseThrow().date(),
+                LocalDate.of(2029, Month.APRIL, 19),
+                "Yom Ha'atzmaut 2029 (Iyar 5 = Friday) must shift to Thursday April 19");
+    }
+
+    // 2028: natural Iyar 5 = May 1 (Monday) → shift +1 → Tuesday May 2
+    @Test
+    public void testYomHaatzmaut2028ShiftFromMonday() {
+        assertEquals(LocalDate.of(2028, Month.MAY, 1).getDayOfWeek(), DayOfWeek.MONDAY,
+                "Natural Iyar 5 5788 must be Monday May 1");
+        assertEquals(findFirst("Yom Ha'atzmaut", 2028).orElseThrow().date(),
+                LocalDate.of(2028, Month.MAY, 2),
+                "Yom Ha'atzmaut 2028 (Iyar 5 = Monday) must shift to Tuesday May 2");
+    }
+
+    // Invariant: after shift rule, observed date must never be Friday or Saturday
+    @Test
+    public void testYomHaatzmautNeverFallsOnWeekend() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        for (int year = 2020; year <= 2055; year++) {
+            Optional<HolidayDate> hd = calendar.calculate(year).stream()
+                    .filter(h -> "Yom Ha'atzmaut".equals(h.holiday().getName()))
+                    .findFirst();
+            assertTrue(hd.isPresent(), "Yom Ha'atzmaut must be present for year " + year);
+            DayOfWeek dow = hd.get().date().getDayOfWeek();
+            assertNotEquals(dow, DayOfWeek.FRIDAY,
+                    "Yom Ha'atzmaut must not fall on Friday in year " + year + " (got " + hd.get().date() + ")");
+            assertNotEquals(dow, DayOfWeek.SATURDAY,
+                    "Yom Ha'atzmaut must not fall on Saturday in year " + year + " (got " + hd.get().date() + ")");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Rosh Hashanah Day 1 and Day 2 are always consecutive
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testRoshHashanahDaysAreConsecutive2025() {
+        LocalDate day1 = findFirst("Rosh Hashanah", 2025).orElseThrow().date();
+        LocalDate day2 = findFirst("Rosh Hashanah (2nd Day)", 2025).orElseThrow().date();
+        assertEquals(day2, day1.plusDays(1), "Rosh Hashanah Day 2 must be the day after Day 1");
+    }
+
+    // -------------------------------------------------------------------------
+    // Helper
+    // -------------------------------------------------------------------------
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/IndependenceDayTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/IndependenceDayTest.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the Yom Ha'atzmaut (Israeli Independence Day) statutory postponement rule.
+ *
+ * <p>The rule (based on natural Iyar 5 day of week):
+ * <ul>
+ *   <li>Sunday  → observed Monday  (+1) — Iyar 4 would be Shabbat</li>
+ *   <li>Monday  → observed Tuesday (+1) — Iyar 4 would be Sunday</li>
+ *   <li>Tue/Wed/Thu → no shift</li>
+ *   <li>Friday  → observed Thursday (−1) — Erev Shabbat</li>
+ *   <li>Saturday → observed Thursday (−2) — Shabbat itself</li>
+ * </ul>
+ *
+ * <p>All natural dates and official observed dates verified against
+ * net.time4j.calendar.HebrewCalendar and confirmed against official Israeli
+ * government calendar announcements.
+ */
+public class IndependenceDayTest {
+
+    private final IndependenceDay observance = new IndependenceDay();
+
+    // -------------------------------------------------------------------------
+    // No-shift cases (Tuesday, Wednesday, Thursday)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testNoShiftWednesday2023() {
+        // Iyar 5, 5783 = 2023-04-26 (Wednesday) → no shift
+        assertEquals(LocalDate.of(2023, 4, 26).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        assertEquals(observance.apply(2023), LocalDate.of(2023, 4, 26));
+    }
+
+    @Test
+    public void testNoShiftWednesday2026() {
+        // Iyar 5, 5786 = 2026-04-22 (Wednesday) → no shift
+        assertEquals(LocalDate.of(2026, 4, 22).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        assertEquals(observance.apply(2026), LocalDate.of(2026, 4, 22));
+    }
+
+    // -------------------------------------------------------------------------
+    // Monday → Tuesday (+1): Iyar 4 would fall on Sunday
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testShiftFromMonday2024() {
+        // Iyar 5, 5784 = 2024-05-13 (Monday) → observed 2024-05-14 (Tuesday)
+        // Confirmed: official Yom Ha'atzmaut 2024 = May 14
+        assertEquals(LocalDate.of(2024, 5, 13).getDayOfWeek(), DayOfWeek.MONDAY,
+                "Natural Iyar 5 5784 must be Monday");
+        assertEquals(observance.apply(2024), LocalDate.of(2024, 5, 14),
+                "Yom Ha'atzmaut 2024 (Iyar 5 = Monday) must shift to Tuesday May 14");
+    }
+
+    @Test
+    public void testShiftFromMonday2028() {
+        // Iyar 5, 5788 = 2028-05-01 (Monday) → observed 2028-05-02 (Tuesday)
+        assertEquals(LocalDate.of(2028, 5, 1).getDayOfWeek(), DayOfWeek.MONDAY,
+                "Natural Iyar 5 5788 must be Monday");
+        assertEquals(observance.apply(2028), LocalDate.of(2028, 5, 2),
+                "Yom Ha'atzmaut 2028 (Iyar 5 = Monday) must shift to Tuesday May 2");
+    }
+
+    // -------------------------------------------------------------------------
+    // Friday → Thursday (−1)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testShiftFromFriday2022() {
+        // Iyar 5, 5782 = 2022-05-06 (Friday) → observed 2022-05-05 (Thursday)
+        // Confirmed: official Yom Ha'atzmaut 2022 = May 5
+        assertEquals(LocalDate.of(2022, 5, 6).getDayOfWeek(), DayOfWeek.FRIDAY,
+                "Natural Iyar 5 5782 must be Friday");
+        assertEquals(observance.apply(2022), LocalDate.of(2022, 5, 5),
+                "Yom Ha'atzmaut 2022 (Iyar 5 = Friday) must shift to Thursday May 5");
+    }
+
+    @Test
+    public void testShiftFromFriday2029() {
+        // Iyar 5, 5789 = 2029-04-20 (Friday) → observed 2029-04-19 (Thursday)
+        assertEquals(LocalDate.of(2029, 4, 20).getDayOfWeek(), DayOfWeek.FRIDAY,
+                "Natural Iyar 5 5789 must be Friday");
+        assertEquals(observance.apply(2029), LocalDate.of(2029, 4, 19),
+                "Yom Ha'atzmaut 2029 (Iyar 5 = Friday) must shift to Thursday April 19");
+    }
+
+    // -------------------------------------------------------------------------
+    // Saturday → Thursday (−2)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testShiftFromSaturday2021() {
+        // Iyar 5, 5781 = 2021-04-17 (Saturday) → observed 2021-04-15 (Thursday)
+        // Confirmed: official Yom Ha'atzmaut 2021 = April 15
+        assertEquals(LocalDate.of(2021, 4, 17).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Natural Iyar 5 5781 must be Saturday");
+        assertEquals(observance.apply(2021), LocalDate.of(2021, 4, 15),
+                "Yom Ha'atzmaut 2021 (Iyar 5 = Saturday) must shift to Thursday April 15");
+    }
+
+    @Test
+    public void testShiftFromSaturday2025() {
+        // Iyar 5, 5785 = 2025-05-03 (Saturday) → observed 2025-05-01 (Thursday)
+        assertEquals(LocalDate.of(2025, 5, 3).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Natural Iyar 5 5785 must be Saturday");
+        assertEquals(observance.apply(2025), LocalDate.of(2025, 5, 1),
+                "Yom Ha'atzmaut 2025 (Iyar 5 = Saturday) must shift to Thursday May 1");
+    }
+
+    // -------------------------------------------------------------------------
+    // Invariant: observed date is never Friday or Saturday (2020–2055)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testObservedDateNeverFallsOnWeekend() {
+        for (int year = 2020; year <= 2055; year++) {
+            LocalDate observed = observance.apply(year);
+            assertNotNull(observed, "Independence Day must be non-null for year " + year);
+            assertNotEquals(observed.getDayOfWeek(), DayOfWeek.FRIDAY,
+                    "Independence Day must not fall on Friday in year " + year + " (got " + observed + ")");
+            assertNotEquals(observed.getDayOfWeek(), DayOfWeek.SATURDAY,
+                    "Independence Day must not fall on Saturday in year " + year + " (got " + observed + ")");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // DataProvider-driven spot checks
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        // natural Iyar 5 → official observed date (all confirmed against official Israeli records)
+        return List.of(
+            new Object[]{2019, LocalDate.of(2019, 5,  9)},  // Fri → Thu (-1); official confirmed
+            new Object[]{2020, LocalDate.of(2020, 4, 29)},  // Wed → no shift
+            new Object[]{2021, LocalDate.of(2021, 4, 15)},  // Sat → Thu (-2); official confirmed
+            new Object[]{2022, LocalDate.of(2022, 5,  5)},  // Fri → Thu (-1); official confirmed
+            new Object[]{2023, LocalDate.of(2023, 4, 26)},  // Wed → no shift
+            new Object[]{2024, LocalDate.of(2024, 5, 14)},  // Mon → Tue (+1); official confirmed
+            new Object[]{2025, LocalDate.of(2025, 5,  1)},  // Sat → Thu (-2)
+            new Object[]{2026, LocalDate.of(2026, 4, 22)},  // Wed → no shift
+            new Object[]{2028, LocalDate.of(2028, 5,  2)},  // Mon → Tue (+1)
+            new Object[]{2029, LocalDate.of(2029, 4, 19)}   // Fri → Thu (-1)
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testKnownDates(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+                "Independence Day " + year + " must be " + expected);
+    }
+
+    @Test
+    public void testTestReturnsTrueForValidYear() {
+        assertTrue(observance.test(2025));
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/PassoverTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/PassoverTest.java
@@ -1,0 +1,86 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class PassoverTest {
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        // 15 Nisan: hebrewYear = gregorianYear + 3760
+        // Dates verified via net.time4j.calendar.HebrewCalendar
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024,  4, 23)},  // 15 Nisan 5784 = Tuesday
+            new Object[]{2025, LocalDate.of(2025,  4, 13)},  // 15 Nisan 5785 = Sunday
+            new Object[]{2026, LocalDate.of(2026,  4,  2)},  // 15 Nisan 5786 = Thursday
+            new Object[]{2027, LocalDate.of(2027,  4, 22)},  // 15 Nisan 5787 = Thursday
+            new Object[]{2028, LocalDate.of(2028,  4, 11)}   // 15 Nisan 5788 = Tuesday
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testKnownDatesDay1(int year, LocalDate expected) {
+        assertEquals(new Passover().apply(year), expected,
+                "Passover Day 1 (15 Nisan) for " + year + " must be " + expected);
+    }
+
+    @DataProvider
+    Iterator<Object[]> knownDatesEnd() {
+        // 21 Nisan: always 6 days after 15 Nisan
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024,  4, 29)},  // 21 Nisan 5784 = Monday
+            new Object[]{2025, LocalDate.of(2025,  4, 19)},  // 21 Nisan 5785 = Saturday
+            new Object[]{2026, LocalDate.of(2026,  4,  8)},  // 21 Nisan 5786 = Wednesday
+            new Object[]{2027, LocalDate.of(2027,  4, 28)},  // 21 Nisan 5787 = Wednesday
+            new Object[]{2028, LocalDate.of(2028,  4, 17)}   // 21 Nisan 5788 = Monday
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesEnd")
+    public void testKnownDatesDay7(int year, LocalDate expected) {
+        assertEquals(new PassoverEnd().apply(year), expected,
+                "Passover Day 7 (21 Nisan) for " + year + " must be " + expected);
+    }
+
+    @Test
+    public void testDay7AlwaysSixDaysAfterDay1() {
+        for (int year = 2024; year <= 2035; year++) {
+            LocalDate day1 = new Passover().apply(year);
+            LocalDate day7 = new PassoverEnd().apply(year);
+            assertNotNull(day1);
+            assertNotNull(day7);
+            assertEquals(day7, day1.plusDays(6),
+                    "Passover Day 7 must be exactly 6 days after Day 1 (year " + year + ")");
+        }
+    }
+
+    @Test
+    public void testTestReturnsTrueForValidYear() {
+        assertTrue(new Passover().test(2025));
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/RoshHashanahTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/RoshHashanahTest.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class RoshHashanahTest {
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        // 1 Tishri: hebrewYear = gregorianYear + 3761
+        // Dates verified via net.time4j.calendar.HebrewCalendar
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 10,  3)},  // 1 Tishri 5785 = Thursday
+            new Object[]{2025, LocalDate.of(2025,  9, 23)},  // 1 Tishri 5786 = Tuesday
+            new Object[]{2026, LocalDate.of(2026,  9, 12)},  // 1 Tishri 5787 = Saturday
+            new Object[]{2027, LocalDate.of(2027, 10,  2)},  // 1 Tishri 5788 = Saturday
+            new Object[]{2028, LocalDate.of(2028,  9, 21)}   // 1 Tishri 5789 = Thursday
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testKnownDates(int year, LocalDate expected) {
+        assertEquals(new RoshHashanah().apply(year), expected,
+                "Rosh Hashanah (1 Tishri) for " + year + " must be " + expected);
+    }
+
+    @DataProvider
+    Iterator<Object[]> knownDatesDay2() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 10,  4)},  // 2 Tishri 5785
+            new Object[]{2025, LocalDate.of(2025,  9, 24)},  // 2 Tishri 5786
+            new Object[]{2026, LocalDate.of(2026,  9, 13)}   // 2 Tishri 5787
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesDay2")
+    public void testKnownDatesDay2(int year, LocalDate expected) {
+        assertEquals(new RoshHashanahDay2().apply(year), expected,
+                "Rosh Hashanah Day 2 (2 Tishri) for " + year + " must be " + expected);
+    }
+
+    @Test
+    public void testDay2IsAlwaysOneDayAfterDay1() {
+        for (int year = 2024; year <= 2035; year++) {
+            LocalDate day1 = new RoshHashanah().apply(year);
+            LocalDate day2 = new RoshHashanahDay2().apply(year);
+            assertNotNull(day1);
+            assertNotNull(day2);
+            assertEquals(day2, day1.plusDays(1),
+                    "Rosh Hashanah Day 2 must always be exactly 1 day after Day 1 (year " + year + ")");
+        }
+    }
+
+    @Test
+    public void testTestReturnsTrueForValidYear() {
+        assertTrue(new RoshHashanah().test(2025));
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/ShavuotTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/ShavuotTest.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class ShavuotTest {
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        // 6 Sivan: hebrewYear = gregorianYear + 3760
+        // Dates verified via net.time4j.calendar.HebrewCalendar
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024,  6, 12)},  // 6 Sivan 5784 = Wednesday
+            new Object[]{2025, LocalDate.of(2025,  6,  2)},  // 6 Sivan 5785 = Monday
+            new Object[]{2026, LocalDate.of(2026,  5, 22)},  // 6 Sivan 5786 = Friday
+            new Object[]{2027, LocalDate.of(2027,  6, 11)},  // 6 Sivan 5787 = Friday
+            new Object[]{2028, LocalDate.of(2028,  5, 31)}   // 6 Sivan 5788 = Wednesday
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testKnownDates(int year, LocalDate expected) {
+        assertEquals(new Shavuot().apply(year), expected,
+                "Shavuot (6 Sivan) for " + year + " must be " + expected);
+    }
+
+    @Test
+    public void testTestReturnsTrueForValidYear() {
+        assertTrue(new Shavuot().test(2025));
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/YomKippurTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/YomKippurTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class YomKippurTest {
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        // 10 Tishri: hebrewYear = gregorianYear + 3761
+        // Dates verified via net.time4j.calendar.HebrewCalendar
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 10, 12)},  // 10 Tishri 5785 = Saturday
+            new Object[]{2025, LocalDate.of(2025, 10,  2)},  // 10 Tishri 5786 = Thursday
+            new Object[]{2026, LocalDate.of(2026,  9, 21)},  // 10 Tishri 5787 = Monday
+            new Object[]{2027, LocalDate.of(2027, 10, 11)},  // 10 Tishri 5788 = Monday
+            new Object[]{2028, LocalDate.of(2028,  9, 30)}   // 10 Tishri 5789 = Saturday
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testKnownDates(int year, LocalDate expected) {
+        assertEquals(new YomKippur().apply(year), expected,
+                "Yom Kippur (10 Tishri) for " + year + " must be " + expected);
+    }
+
+    @Test
+    public void testTestReturnsTrueForValidYear() {
+        assertTrue(new YomKippur().test(2025));
+    }
+
+    @Test
+    public void testYomKippurAlways9DaysAfterRoshHashanah() {
+        for (int year = 2024; year <= 2035; year++) {
+            LocalDate rh1 = new RoshHashanah().apply(year);
+            LocalDate yk  = new YomKippur().apply(year);
+            assertNotNull(rh1);
+            assertNotNull(yk);
+            assertEquals(yk, rh1.plusDays(9),
+                    "Yom Kippur must be exactly 9 days after Rosh Hashanah Day 1 (year " + year + ")");
+        }
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -232,7 +232,7 @@
                         <inherited>false</inherited>
                         <configuration>
                             <outputDirectory>${project.basedir}</outputDirectory>
-                            <overwrite>true</overwrite>
+                            <changeDetection>always</changeDetection>
                             <resources>
                                 <resource>
                                     <directory>${project.basedir}/src/readme</directory>

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -34,6 +34,8 @@ Key design goals:
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France (Euronext Paris) Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
+| `IL` | Israel (National) Holidays |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `SA` | Saudi Arabia (National) Holidays |
@@ -86,7 +88,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, SA, SAR -->
+<!-- MENA calendars: AE, AED, IL, ILS, SA, SAR -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -133,7 +135,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "JP", "JPY", "SA", "SAR", "SG", "SGD", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "SA", "SAR", "SG", "SGD", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 21 implemented holiday calendars
+ * 30-year integration test suite validating all 27 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -69,8 +69,12 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"EUR"},
                 new Object[]{"FR"},
                 new Object[]{"GBP"},
+                new Object[]{"IL"},
+                new Object[]{"ILS"},
                 new Object[]{"JP"},
                 new Object[]{"JPY"},
+                new Object[]{"SA"},
+                new Object[]{"SAR"},
                 new Object[]{"SG"},
                 new Object[]{"SGD"},
                 new Object[]{"UK"},


### PR DESCRIPTION
### #160 Added Israel holiday calendars IL, ILS + tests

**Description**

- Added `org.holiday.calendar.observance.hebrew` package with 9 algorithmically computed observance classes: `RoshHashanah`, `RoshHashanahDay2`, `YomKippur`, `Sukkot`, `SheminiAtzeret`, `Passover`, `PassoverEnd`, `IndependenceDay`, `Shavuot`
- Added `HolidayCalendarServiceIL` (national, `DateRolls.followingSunday()`) and `HolidayCalendarServiceILS` (TASE/Bank of Israel, `DateRolls.noRoll()`); both use `dataValidThrough() = OptionalInt.empty()` — fully algorithmic via `net.time4j.calendar.HebrewCalendar`, no CSV lookup tables
- `IndependenceDay` implements the full statutory postponement rule (Israeli law, amended 2004): Mon→Tue (+1), Fri→Thu (−1), Sat→Thu (−2), Sun→Mon (+1); baked into `computeDate()` with `rollable(false)` — the existing `DateRoll` infrastructure cannot handle backward rolls
- Registered both services in `module-info.java` and `META-INF/services`; exported `org.holiday.calendar.observance.hebrew`
- Added 7 test classes (~130 new tests) covering spot-checks, shift rule matrix, IL vs ILS date-match invariants, weekend configuration, and a 2020–2055 invariant asserting Yom Ha'atzmaut never falls on a weekend after shifting
- Updated `HolidayCalendar30YearIT` to include `IL`, `ILS`, and also `SA`, `SAR` (which were missing)
- Updated `src/readme/README.md` with IL and ILS rows
- Fixed deprecated Maven `<overwrite>true</overwrite>` → `<changeDetection>always</changeDetection>` in root `pom.xml`

**Related Issue**

- Closes #160

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed