### PR TITLE
#177 Add Yom Hazikaron to IL holiday calendar

### DIFF
--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceIL.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceIL.java
@@ -25,18 +25,21 @@ import org.holiday.calendar.function.DateRolls;
 /**
  * Service for provision of Israel national public holiday calendar.
  *
- * <p>Calendar code: {@code IL}. Covers public holidays observed in Israel as
- * published by the Israeli government and confirmed against TASE market
- * closure announcements.
+ * <p>Calendar code: {@code IL}. Covers statutory national public holidays
+ * recognized by the Israeli government, including days of mourning and
+ * remembrance where government offices and schools close. For TASE and
+ * Bank of Israel settlement closures only, see {@code ILS}.
  *
  * <p>Weekend: Friday + Saturday (Israeli work week; Sunday is the first
  * business day). Fixed holidays that fall on Friday or Saturday roll to the
  * following Sunday per {@link DateRolls#followingSunday()}.
  *
- * <p>All nine holidays are computed algorithmically via
+ * <p>All ten holidays are computed algorithmically via
  * {@code net.time4j.calendar.HebrewCalendar}; no lookup tables or data
  * ceiling applies. Independence Day (Yom Ha'atzmaut) applies a statutory
  * postponement rule; see {@link org.holiday.calendar.observance.hebrew.IndependenceDay}.
+ * Yom Hazikaron (Memorial Day) is coupled to Independence Day and always
+ * observed one day before it.
  *
  * <p>MSCI classification: Developed Market (DM) — the only Developed Market
  * in the MENA module.
@@ -60,7 +63,7 @@ public class HolidayCalendarServiceIL extends AbstractHolidayCalendarService {
                 // Israeli weekend is Fri+Sat; fixed holidays rolling to following Sunday
                 .dateRoll(DateRolls.followingSunday())
                 .weekendDays(IsraelHolidays.ISRAEL_WEEKEND)
-                .holidays(IsraelHolidays.baseHolidays())
+                .holidays(IsraelHolidays.ilHolidays())
                 .build();
     }
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
@@ -21,6 +21,7 @@ package org.holiday.calendar.impl;
 import org.holiday.calendar.Holiday;
 import org.holiday.calendar.observance.hebrew.IndependenceDay;
 import org.holiday.calendar.observance.hebrew.Passover;
+import org.holiday.calendar.observance.hebrew.YomHazikaron;
 import org.holiday.calendar.observance.hebrew.PassoverEnd;
 import org.holiday.calendar.observance.hebrew.RoshHashanah;
 import org.holiday.calendar.observance.hebrew.RoshHashanahDay2;
@@ -30,13 +31,18 @@ import org.holiday.calendar.observance.hebrew.Sukkot;
 import org.holiday.calendar.observance.hebrew.YomKippur;
 
 import java.time.DayOfWeek;
+import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Package-private factory building the Israel public holiday list shared by
- * the national ({@code IL}) and settlement ({@code ILS}) calendars.
+ * Package-private factory building the Israel public holiday lists for the
+ * national ({@code IL}) and settlement ({@code ILS}) calendars.
  *
- * <p>All nine holidays are computed algorithmically via
+ * <p>{@link #baseHolidays()} returns the nine holidays shared by both calendars.
+ * {@link #ilHolidays()} returns ten holidays for the {@code IL} national calendar,
+ * adding Yom Hazikaron (Israeli Memorial Day, 4 Iyar).
+ *
+ * <p>All holidays are computed algorithmically via
  * {@code net.time4j.calendar.HebrewCalendar}; no CSV lookup tables are used.
  * All holidays are declared {@code rollable(false)} because Hebrew calendar
  * dates are observed on specific calendar days regardless of the day of week.
@@ -50,7 +56,9 @@ import java.util.List;
  *
  * <p>Omitted holidays (conscious decisions):
  * <ul>
- *   <li>Yom Hazikaron (4 Iyar) — TASE remains open; not a market closure day.</li>
+ *   <li>Yom HaShoah (27 Nisan) — Holocaust Remembrance Day is a national
+ *       commemoration day, but it is not a statutory public rest holiday under
+ *       the Work and Rest Hours Law. TASE also remains open.</li>
  *   <li>Sigd (29 Heshvan) — low market relevance; not a TASE closure day.</li>
  *   <li>Hoshana Raba (21 Tishri) — TASE closes on this day, but the Bank of
  *       Israel operates with reduced hours (not a full settlement closure).
@@ -65,6 +73,28 @@ class IsraelHolidays {
     static final List<DayOfWeek> ISRAEL_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
 
     private IsraelHolidays() {}
+
+    /**
+     * Returns the ten holidays for the {@code IL} national calendar.
+     * Includes all nine holidays from {@link #baseHolidays()} plus Yom Hazikaron
+     * (Israeli Memorial Day, 4 Iyar), which is a statutory national day where
+     * government offices and schools close. TASE remains open on Yom Hazikaron,
+     * so it is not included in the {@code ILS} settlement calendar.
+     */
+    static List<Holiday> ilHolidays() {
+        List<Holiday> holidays = new ArrayList<>(baseHolidays());
+        holidays.add(7,
+            Holiday.builder()
+                    .name("Yom Hazikaron")
+                    .description("Israeli Memorial Day (4 Iyar); observed date is always the " +
+                                 "day before Yom Ha'atzmaut per the 1963 statutory shift rule")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new YomHazikaron())
+                    .build()
+        );
+        return List.copyOf(holidays);
+    }
 
     static List<Holiday> baseHolidays() {
         return List.of(

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/YomHazikaron.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/YomHazikaron.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Yom Hazikaron — Israeli Memorial Day (4 Iyar).
+ *
+ * <p>Yom Hazikaron always falls on the day immediately before the observed
+ * Yom Ha'atzmaut. The two days are coupled by the Memorial Day and Independence
+ * Day Law (1963): when Independence Day shifts to avoid Shabbat, Memorial Day
+ * shifts with it by exactly one day. This observance derives the date from
+ * {@link IndependenceDay} rather than replicating the shift logic.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class YomHazikaron extends AbstractObservance {
+
+    private final IndependenceDay independenceDay = new IndependenceDay();
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return independenceDay.apply(year).minusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILTest.java
@@ -38,8 +38,8 @@ import static org.testng.Assert.*;
 
 public class HolidayCalendarServiceILTest {
 
-    // 9 Hebrew-calendar holidays per year
-    private static final int IL_HOLIDAY_COUNT = 9;
+    // 10 Hebrew-calendar holidays per year (9 shared with ILS + Yom Hazikaron)
+    private static final int IL_HOLIDAY_COUNT = 10;
 
     private final HolidayCalendarServiceIL service = new HolidayCalendarServiceIL();
     private HolidayCalendarFactory factory;
@@ -139,6 +139,7 @@ public class HolidayCalendarServiceILTest {
             new Object[]{"Shemini Atzeret / Simchat Torah"},
             new Object[]{"Passover"},
             new Object[]{"Passover (7th Day)"},
+            new Object[]{"Yom Hazikaron"},
             new Object[]{"Yom Ha'atzmaut"},
             new Object[]{"Shavuot"}
         ).iterator();
@@ -339,6 +340,55 @@ public class HolidayCalendarServiceILTest {
         assertEquals(findFirst("Yom Ha'atzmaut", 2028).orElseThrow().date(),
                 LocalDate.of(2028, Month.MAY, 2),
                 "Yom Ha'atzmaut 2028 (Iyar 5 = Monday) must shift to Tuesday May 2");
+    }
+
+    // -------------------------------------------------------------------------
+    // Yom Hazikaron — always one day before observed Yom Ha'atzmaut
+    // -------------------------------------------------------------------------
+
+    // 2025: Yom Ha'atzmaut = May 1 (Thu, shifted from Sat) → Yom Hazikaron = Apr 30 (Wed)
+    @Test
+    public void testYomHazikaron2025() {
+        assertEquals(findFirst("Yom Hazikaron", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.APRIL, 30),
+                "Yom Hazikaron 2025 must be 2025-04-30");
+    }
+
+    // 2026: Yom Ha'atzmaut = Apr 22 (Wed, no shift) → Yom Hazikaron = Apr 21 (Tue)
+    @Test
+    public void testYomHazikaron2026() {
+        assertEquals(findFirst("Yom Hazikaron", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.APRIL, 21),
+                "Yom Hazikaron 2026 must be 2026-04-21");
+    }
+
+    // 2024: Yom Ha'atzmaut = May 14 (Tue, shifted from Mon) → Yom Hazikaron = May 13 (Mon)
+    @Test
+    public void testYomHazikaron2024() {
+        assertEquals(findFirst("Yom Hazikaron", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.MAY, 13),
+                "Yom Hazikaron 2024 must be 2024-05-13");
+    }
+
+    // Invariant: Yom Hazikaron must always be exactly one day before Yom Ha'atzmaut
+    @Test
+    public void testYomHazikaron_AlwaysOneDayBeforeIndependenceDay() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        for (int year = 2020; year <= 2055; year++) {
+            final int y = year;
+            LocalDate memorial = calendar.calculate(year).stream()
+                    .filter(h -> "Yom Hazikaron".equals(h.holiday().getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Yom Hazikaron missing for year " + y))
+                    .date();
+            LocalDate independence = calendar.calculate(year).stream()
+                    .filter(h -> "Yom Ha'atzmaut".equals(h.holiday().getName()))
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("Yom Ha'atzmaut missing for year " + y))
+                    .date();
+            assertEquals(memorial, independence.minusDays(1),
+                    "Yom Hazikaron must be exactly one day before Yom Ha'atzmaut in year " + year);
+        }
     }
 
     // Invariant: after shift rule, observed date must never be Friday or Saturday


### PR DESCRIPTION
### #177 Add Yom Hazikaron (4 Iyar) to IL national calendar

**Description**

- Resolves the open question in #177: `IL` models statutory national public holidays, not just market closure days (that is `ILS`'s role)
- Adds `YomHazikaron` observance class; derives its date as one day before observed Yom Ha'atzmaut, encoding the statutory coupling from the Memorial Day and Independence Day Law (1963) without duplicating the shift logic
- Adds `ilHolidays()` factory method to `IsraelHolidays`; `ILS` continues to use `baseHolidays()` (9 holidays, TASE/Bank of Israel closures only)
- Updates `HolidayCalendarServiceIL` Javadoc to clearly state "statutory national public holidays" and point to `ILS` for settlement closures
- Updates omissions Javadoc: Yom HaShoah (27 Nisan) documented as excluded because it is not a public rest holiday under the Work and Rest Hours Law
- `IL` now returns 10 holidays per year; `ILS` unchanged at 9

**Related Issue**

- [#177 IL: evaluate adding Yom Hazikaron (4 Iyar) to Israel national calendar](https://github.com/holiday-calendar/holiday-calendar-java/issues/177)

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed