### PR TITLE
#161 Added Turkey holiday calendars TR, TRY + tests

### DIFF
--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -34,5 +34,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceSA,
         org.holiday.calendar.impl.HolidayCalendarServiceSAR,
         org.holiday.calendar.impl.HolidayCalendarServiceIL,
-        org.holiday.calendar.impl.HolidayCalendarServiceILS;
+        org.holiday.calendar.impl.HolidayCalendarServiceILS,
+        org.holiday.calendar.impl.HolidayCalendarServiceTR,
+        org.holiday.calendar.impl.HolidayCalendarServiceTRY;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Turkey national public holiday calendar.
+ *
+ * <p>Calendar code: {@code TR}. Covers public holidays observed in the Republic
+ * of Turkey as declared by Borsa Istanbul (BIST) and the Central Bank of the
+ * Republic of Turkey (TCMB).
+ *
+ * <p>Weekend: Saturday + Sunday (standard Western weekend). Fixed holidays that
+ * fall on Saturday or Sunday are observed on the following Monday per
+ * {@link DateRolls#followingMonday()}.
+ *
+ * <p>Islamic holidays (Ramazan Bayramı / Eid al-Fitr × 3 days; Kurban Bayramı /
+ * Eid al-Adha × 4 days) are sourced from Diyanet (Presidency of Religious Affairs)
+ * ilmi takvim (scientific calendar) via {@code eid-al-fitr-tr.csv} and
+ * {@code eid-al-adha-tr.csv}. Dates for 2024–2026 are official Diyanet / BIST
+ * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Diyanet uses ilmi takvim, which may differ from the Umm al-Qura
+ * calendar by ±1 day — verify projected dates against official announcements as
+ * each year is published. Corrections require a new JAR release.
+ *
+ * <p><strong>Half-day closure not modelled:</strong>
+ * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
+ * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
+ * settlement from midday. This calendar does not include 28 October as a holiday.
+ * Callers relying on afternoon liquidity or same-day settlement on this date must
+ * apply their own adjustment.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceTR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "TR";
+    private static final String NAME = "Turkey (National) Holidays";
+
+    public HolidayCalendarServiceTR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(TurkeyHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.followingMonday())
+                .weekendDays(TurkeyHolidays.STANDARD_WEEKEND)
+                .holidays(TurkeyHolidays.baseHolidays(true, List.of()))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTRY.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTRY.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.List;
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Turkey BIST / TCMB settlement holiday calendar.
+ *
+ * <p>Calendar code: {@code TRY}. Covers settlement closure days for Borsa Istanbul
+ * (BIST) and the Central Bank of the Republic of Turkey (TCMB). The settlement
+ * holiday schedule mirrors the Turkey national calendar ({@code TR}).
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — settlement requires both
+ * counterparties to be available on the same calendar date; there is no
+ * roll-forward convention. All holidays are {@code rollable(false)}.
+ *
+ * <p>Weekend: Saturday + Sunday (standard Western weekend).
+ *
+ * <p><strong>Half-day closure not modelled:</strong>
+ * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
+ * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
+ * settlement from midday. This calendar does not include 28 October as a holiday.
+ * Callers relying on afternoon liquidity or same-day settlement on this date must
+ * apply their own adjustment.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceTRY extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "TRY";
+    private static final String NAME = "Turkey (BIST/TCMB) Holidays";
+
+    public HolidayCalendarServiceTRY() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(TurkeyHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(TurkeyHolidays.STANDARD_WEEKEND)
+                .holidays(TurkeyHolidays.baseHolidays(false, List.of()))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -1,0 +1,185 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay4;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Package-private factory building the Turkey public holiday list shared by
+ * the national ({@code TR}) and settlement ({@code TRY}) calendars.
+ *
+ * <p>All seven Islamic holidays are populated through {@value DATA_VALID_THROUGH}
+ * via Diyanet-sourced CSV lookup tables (country code {@code tr}).
+ * Dates for 2024–2026 are official Diyanet (Presidency of Religious Affairs) /
+ * BIST market calendar announcements; dates for 2027–2055 are projected from
+ * the Umm al-Qura tabular Islamic calendar. Diyanet uses ilmi takvim (scientific
+ * method), which may differ from the Umm al-Qura calendar by ±1 day — verify
+ * projected dates against Diyanet announcements as each year is published.
+ * Corrections require a new JAR release; no runtime update mechanism exists.
+ *
+ * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days
+ * of Eid al-Adha (Kurban Bayramı), consistent with BIST market closure announcements.
+ *
+ * <p><strong>Half-day closure not modelled:</strong>
+ * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
+ * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
+ * settlement from midday. This calendar does not include 28 October as a holiday.
+ * Callers relying on afternoon liquidity or same-day settlement on this date must
+ * apply their own adjustment.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ * Similarly, 2039 contains two Eid al-Adha occurrences; only January is recorded.
+ */
+class TurkeyHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    static final List<DayOfWeek> STANDARD_WEEKEND = List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+
+    private TurkeyHolidays() {}
+
+    /**
+     * Returns the 15 Turkey public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays are rollable; all Islamic
+     *                      holidays are always {@code rollable(false)}
+     * @param additional    additional holidays to append (e.g. future BIST-specific
+     *                      closures); pass {@link List#of()} when not needed
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed, List<Holiday> additional) {
+        List<Holiday> holidays = new ArrayList<>(15 + additional.size());
+        holidays.add(Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of the new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 1)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("National Sovereignty and Children's Day")
+                .description("Commemorates the opening of the Grand National Assembly on 23 April 1920")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.APRIL, 23)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Labour and Solidarity Day")
+                .description("International Workers' Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.MAY, 1)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Commemoration of Atatürk, Youth and Sports Day")
+                .description("Commemorates Mustafa Kemal Atatürk's arrival in Samsun on 19 May 1919, "
+                        + "marking the start of the Turkish War of Independence")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.MAY, 19)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr")
+                .description("First day of Ramazan Bayramı (Eid al-Fitr), marking the end of Ramadan "
+                        + "(1 Shawwal AH) per Diyanet ilmi takvim")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitr("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr (2nd Day)")
+                .description("Second day of Ramazan Bayramı (2 Shawwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitrDay2("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr (3rd Day)")
+                .description("Third day of Ramazan Bayramı (3 Shawwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitrDay3("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Democracy and National Unity Day")
+                .description("Commemorates the failed coup attempt of 15 July 2016")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JULY, 15)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha")
+                .description("First day of Kurban Bayramı (Eid al-Adha), the Feast of Sacrifice "
+                        + "(10 Dhu al-Hijjah AH) per Diyanet ilmi takvim")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdha("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha (2nd Day)")
+                .description("Second day of Kurban Bayramı (11 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdhaDay2("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha (3rd Day)")
+                .description("Third day of Kurban Bayramı (12 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdhaDay3("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha (4th Day)")
+                .description("Fourth day of Kurban Bayramı (13 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdhaDay4("tr"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Victory Day")
+                .description("Commemorates the decisive Turkish victory at the Battle of Dumlupınar "
+                        + "on 30 August 1922")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 30)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Republic Day")
+                .description("Commemorates the proclamation of the Republic of Turkey on 29 October 1923")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.OCTOBER, 29)
+                .build());
+        holidays.addAll(additional);
+        return List.copyOf(holidays);
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of the fourth day of Eid al-Adha (13 Dhu al-Hijjah AH), marking
+ * the final day of the Feast of Sacrifice.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlAdha})
+ * by three calendar days. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * <p>Turkey observes four days of Eid al-Adha, one more than the three days
+ * observed by GCC states (Saudi Arabia, UAE).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class EidAlAdhaDay4 extends AbstractObservance {
+
+    private final EidAlAdha base;
+
+    public EidAlAdhaDay4(String countryCode) {
+        this.base = new EidAlAdha(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(3);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -4,3 +4,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceSA
 org.holiday.calendar.impl.HolidayCalendarServiceSAR
 org.holiday.calendar.impl.HolidayCalendarServiceIL
 org.holiday.calendar.impl.HolidayCalendarServiceILS
+org.holiday.calendar.impl.HolidayCalendarServiceTR
+org.holiday.calendar.impl.HolidayCalendarServiceTRY

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
@@ -1,0 +1,60 @@
+# Kurban Bayramı (Eid al-Adha, 10 Dhu al-Hijjah) — Turkey public holiday dates
+# The Feast of Sacrifice.
+#
+# SOURCE TIERS:
+#   2024–2026: Diyanet (Presidency of Religious Affairs) official announcements,
+#              confirmed against BIST market calendar publications.
+#   2027–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
+#              Küçük 30-year cycle), used as a best-available approximation because Diyanet
+#              does not publish ilmi takvim (scientific calendar) projections beyond 1–2 years
+#              in advance. Actual Diyanet dates may differ by ±1 day from these Umm al-Qura
+#              values — the 2025 divergence below is the canonical confirmed example.
+#              Replace with ilmi takvim calculations when available (see GitHub issue #180).
+#              Verify against Diyanet and BIST official announcements as each year is published.
+#              Corrections require a new JAR release — no runtime update mechanism exists.
+#
+# KNOWN DIVERGENCE — 2025: Diyanet declared 10 Dhu al-Hijjah 1446 as 5 June 2025,
+# one day earlier than the Saudi/UAE Umm al-Qura date of 6 June 2025. This is the
+# canonical confirmed example of ilmi takvim vs. Umm al-Qura divergence.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,Diyanet official
+# 2025: Diyanet = June 5 (1446 AH); differs from Saudi/UAE Umm al-Qura date of June 6
+2025,2025-06-05,Diyanet official
+2026,2026-05-26,Diyanet official
+# 2027–2055: Umm al-Qura tabular projection; verify against Diyanet announcements (±1 day risk)
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
@@ -1,0 +1,54 @@
+# Ramazan Bayramı (Eid al-Fitr, 1 Shawwal) — Turkey public holiday dates
+# Marks the end of Ramadan.
+#
+# SOURCE TIERS:
+#   2024–2026: Diyanet (Presidency of Religious Affairs) official announcements,
+#              confirmed against BIST market calendar publications.
+#   2027–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
+#              used as a best-available approximation because Diyanet does not publish
+#              ilmi takvim (scientific calendar) projections beyond 1–2 years in advance.
+#              Actual Diyanet dates may differ by ±1 day from these Umm al-Qura values.
+#              Replace with ilmi takvim calculations when available (see GitHub issue #180).
+#              Verify against Diyanet and BIST official announcements as each year is published.
+#              Corrections require a new JAR release — no runtime update mechanism exists.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,Diyanet official
+2025,2025-03-30,Diyanet official
+2026,2026-03-19,Diyanet official
+# 2027–2055: Umm al-Qura tabular projection; verify against Diyanet announcements (±1 day risk)
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -99,55 +99,39 @@ public class HolidayCalendarServiceTRTest {
     // Holiday count
     // =========================================================================
 
-    @Test
-    public void testCalculate2024() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
-        assertNotNull(holidays);
-        assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
-                "Expected " + TR_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    @DataProvider
+    Iterator<Object[]> calculateYears() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
     }
 
-    @Test
-    public void testCalculate2025() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+    @Test(dataProvider = "calculateYears")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
         assertNotNull(holidays);
         assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
-                "Expected " + TR_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
-    }
-
-    @Test
-    public void testCalculate2026() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
-        assertNotNull(holidays);
-        assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
-                "Expected " + TR_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+                "Expected " + TR_HOLIDAY_COUNT + " holidays for " + year + ", got: " + holidays.size());
     }
 
     // =========================================================================
     // Chronological order
     // =========================================================================
 
-    @Test
-    public void testChronologicalOrder2024() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
-        for (int i = 1; i < holidays.size(); i++) {
-            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
-                    "Holidays must be in chronological order");
-        }
+    @DataProvider
+    Iterator<Object[]> chronologicalOrderYears() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
     }
 
-    @Test
-    public void testChronologicalOrder2025() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
-        for (int i = 1; i < holidays.size(); i++) {
-            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
-                    "Holidays must be in chronological order");
-        }
-    }
-
-    @Test
-    public void testChronologicalOrder2026() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+    @Test(dataProvider = "chronologicalOrderYears")
+    public void testChronologicalOrder(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
         for (int i = 1; i < holidays.size(); i++) {
             assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
                     "Holidays must be in chronological order");

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -1,0 +1,599 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceTRTest {
+
+    // 7 fixed + 3 Eid al-Fitr + 4 Eid al-Adha = 14 (Republic Day Eve omitted; half-day not modelled)
+    private static final int TR_HOLIDAY_COUNT = 14;
+
+    private final HolidayCalendarServiceTR service = new HolidayCalendarServiceTR();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // =========================================================================
+    // Identity — SPI discovery
+    // =========================================================================
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("TR"));
+        assertFalse(service.isProvided("TRY"));
+        assertFalse(service.isProvided("SA"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "TR");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Turkey (National) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("TR");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "TR");
+    }
+
+    // =========================================================================
+    // Weekend configuration — Saturday + Sunday
+    // =========================================================================
+
+    @Test
+    public void testWeekendDaysSaturdayAndSunday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Turkish weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must not be a weekend day");
+    }
+
+    // =========================================================================
+    // Holiday count
+    // =========================================================================
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
+                "Expected " + TR_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
+                "Expected " + TR_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2026() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
+                "Expected " + TR_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+    }
+
+    // =========================================================================
+    // Chronological order
+    // =========================================================================
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2026() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // =========================================================================
+    // Holiday name membership
+    // =========================================================================
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"National Sovereignty and Children's Day"},
+            new Object[]{"Labour and Solidarity Day"},
+            new Object[]{"Commemoration of Atatürk, Youth and Sports Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Democracy and National Unity Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Eid al-Adha (4th Day)"},
+            new Object[]{"Victory Day"},
+            new Object[]{"Republic Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        assertTrue(service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName())),
+                "Calendar must contain holiday: " + holidayName);
+    }
+
+    // =========================================================================
+    // Fixed holiday spot-checks — no roll (weekday years)
+    // =========================================================================
+
+    @Test
+    public void testNewYearsDayNoRoll2025() {
+        // Jan 1, 2025 = Wednesday; no roll
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        assertEquals(findFirst("New Year's Day", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    @Test
+    public void testRepublicDayNoRoll2025() {
+        // Oct 29, 2025 = Wednesday; no roll
+        assertEquals(LocalDate.of(2025, Month.OCTOBER, 29).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        assertEquals(findFirst("Republic Day", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.OCTOBER, 29),
+                "Republic Day 2025 (Wednesday) must not roll");
+    }
+
+    // =========================================================================
+    // Fixed holiday spot-checks — roll cases
+    // =========================================================================
+
+    @Test
+    public void testAtaturkDayRollFromSunday2024() {
+        // May 19, 2024 = Sunday; rolls to Monday May 20
+        assertEquals(LocalDate.of(2024, Month.MAY, 19).getDayOfWeek(), DayOfWeek.SUNDAY);
+        assertEquals(findFirst("Commemoration of Atatürk, Youth and Sports Day", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.MAY, 20),
+                "Atatürk Day 2024 (Sunday) must roll to Monday May 20");
+    }
+
+    @Test
+    public void testVictoryDayRollFromSaturday2025() {
+        // Aug 30, 2025 = Saturday; rolls to Monday Sep 1
+        assertEquals(LocalDate.of(2025, Month.AUGUST, 30).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("Victory Day", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.SEPTEMBER, 1),
+                "Victory Day 2025 (Saturday) must roll to Monday Sep 1");
+    }
+
+    @Test
+    public void testNewYearsDayNoRollOnFriday2027() {
+        // Jan 1, 2027 = Friday (a workday); followingMonday() only rolls Sat/Sun, not Fri
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        assertEquals(findFirst("New Year's Day", 2027).orElseThrow().date(),
+                LocalDate.of(2027, Month.JANUARY, 1),
+                "New Year's Day 2027 (Friday) must not roll — Friday is a workday");
+    }
+
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        // Jan 1, 2028 = Saturday; rolls to Monday Jan 3
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("New Year's Day", 2028).orElseThrow().date(),
+                LocalDate.of(2028, Month.JANUARY, 3),
+                "New Year's Day 2028 (Saturday) must roll to Monday Jan 3");
+    }
+
+    @Test
+    public void testLabourDayRollFromSaturday2027() {
+        // May 1, 2027 = Saturday; rolls to Monday May 3
+        assertEquals(LocalDate.of(2027, Month.MAY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("Labour and Solidarity Day", 2027).orElseThrow().date(),
+                LocalDate.of(2027, Month.MAY, 3),
+                "Labour Day 2027 (Saturday) must roll to Monday May 3");
+    }
+
+    @Test
+    public void testRepublicDayNoRollOnFriday2027() {
+        // Oct 29, 2027 = Friday (a workday); followingMonday() only rolls Sat/Sun, not Fri
+        assertEquals(LocalDate.of(2027, Month.OCTOBER, 29).getDayOfWeek(), DayOfWeek.FRIDAY);
+        assertEquals(findFirst("Republic Day", 2027).orElseThrow().date(),
+                LocalDate.of(2027, Month.OCTOBER, 29),
+                "Republic Day 2027 (Friday) must not roll — Friday is a workday");
+    }
+
+    @Test
+    public void testNationalSovereigntyDayRollFromSunday2028() {
+        // Apr 23, 2028 = Sunday; rolls to Monday Apr 24
+        assertEquals(LocalDate.of(2028, Month.APRIL, 23).getDayOfWeek(), DayOfWeek.SUNDAY);
+        assertEquals(findFirst("National Sovereignty and Children's Day", 2028).orElseThrow().date(),
+                LocalDate.of(2028, Month.APRIL, 24),
+                "National Sovereignty Day 2028 (Sunday) must roll to Monday Apr 24");
+    }
+
+    @Test
+    public void testDemocracyDayRollFromSaturday2028() {
+        // Jul 15, 2028 = Saturday; rolls to Monday Jul 17
+        assertEquals(LocalDate.of(2028, Month.JULY, 15).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("Democracy and National Unity Day", 2028).orElseThrow().date(),
+                LocalDate.of(2028, Month.JULY, 17),
+                "Democracy Day 2028 (Saturday) must roll to Monday Jul 17");
+    }
+
+    // =========================================================================
+    // Islamic spot-checks — Eid al-Fitr (Diyanet, rollable=false)
+    // =========================================================================
+
+    @Test
+    public void testEidAlFitr2024() {
+        assertEquals(findFirst("Eid al-Fitr", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per Diyanet");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        assertEquals(findFirst("Eid al-Fitr (2nd Day)", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        assertEquals(findFirst("Eid al-Fitr (3rd Day)", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        // Mar 30, 2025 = Sunday — must not roll (rollable=false)
+        assertEquals(LocalDate.of(2025, Month.MARCH, 30).getDayOfWeek(), DayOfWeek.SUNDAY);
+        assertEquals(findFirst("Eid al-Fitr", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 (Sunday) must not be rolled — rollable(false)");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2025() {
+        assertEquals(findFirst("Eid al-Fitr (2nd Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.MARCH, 31));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2025() {
+        assertEquals(findFirst("Eid al-Fitr (3rd Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.APRIL, 1));
+    }
+
+    @Test
+    public void testEidAlFitr2026() {
+        assertEquals(findFirst("Eid al-Fitr", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MARCH, 19),
+                "Eid al-Fitr 2026 must be 2026-03-19 per Diyanet");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2026() {
+        assertEquals(findFirst("Eid al-Fitr (2nd Day)", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MARCH, 20));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2026() {
+        assertEquals(findFirst("Eid al-Fitr (3rd Day)", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MARCH, 21));
+    }
+
+    // =========================================================================
+    // Islamic spot-checks — Eid al-Adha (Diyanet, 4 days, rollable=false)
+    // =========================================================================
+
+    @Test
+    public void testEidAlAdha2024() {
+        assertEquals(findFirst("Eid al-Adha", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per Diyanet");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        assertEquals(findFirst("Eid al-Adha (2nd Day)", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        assertEquals(findFirst("Eid al-Adha (3rd Day)", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlAdhaDay4_2024() {
+        assertEquals(findFirst("Eid al-Adha (4th Day)", 2024).orElseThrow().date(),
+                LocalDate.of(2024, Month.JUNE, 19));
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        // Turkey Diyanet = June 5; one day earlier than Saudi/UAE (June 6)
+        assertEquals(findFirst("Eid al-Adha", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.JUNE, 5),
+                "Eid al-Adha 2025 must be 2025-06-05 per Diyanet (one day earlier than Saudi/UAE)");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2025() {
+        assertEquals(findFirst("Eid al-Adha (2nd Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.JUNE, 6));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2025() {
+        assertEquals(findFirst("Eid al-Adha (3rd Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.JUNE, 7));
+    }
+
+    @Test
+    public void testEidAlAdhaDay4_2025() {
+        assertEquals(findFirst("Eid al-Adha (4th Day)", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.JUNE, 8));
+    }
+
+    @Test
+    public void testEidAlAdha2026() {
+        assertEquals(findFirst("Eid al-Adha", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MAY, 26),
+                "Eid al-Adha 2026 must be 2026-05-26 per Diyanet");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2026() {
+        assertEquals(findFirst("Eid al-Adha (2nd Day)", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MAY, 27));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2026() {
+        assertEquals(findFirst("Eid al-Adha (3rd Day)", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MAY, 28));
+    }
+
+    @Test
+    public void testEidAlAdhaDay4_2026() {
+        assertEquals(findFirst("Eid al-Adha (4th Day)", 2026).orElseThrow().date(),
+                LocalDate.of(2026, Month.MAY, 29));
+    }
+
+    // =========================================================================
+    // Consecutiveness invariants
+    // =========================================================================
+
+    @Test
+    public void testEidAlFitrDaysAreConsecutive2025() {
+        LocalDate day1 = findFirst("Eid al-Fitr", 2025).orElseThrow().date();
+        LocalDate day2 = findFirst("Eid al-Fitr (2nd Day)", 2025).orElseThrow().date();
+        LocalDate day3 = findFirst("Eid al-Fitr (3rd Day)", 2025).orElseThrow().date();
+        assertEquals(day2, day1.plusDays(1), "Eid al-Fitr Day 2 must be the day after Day 1");
+        assertEquals(day3, day1.plusDays(2), "Eid al-Fitr Day 3 must be two days after Day 1");
+    }
+
+    @Test
+    public void testEidAlAdhaDaysAreConsecutive2025() {
+        LocalDate day1 = findFirst("Eid al-Adha", 2025).orElseThrow().date();
+        LocalDate day2 = findFirst("Eid al-Adha (2nd Day)", 2025).orElseThrow().date();
+        LocalDate day3 = findFirst("Eid al-Adha (3rd Day)", 2025).orElseThrow().date();
+        LocalDate day4 = findFirst("Eid al-Adha (4th Day)", 2025).orElseThrow().date();
+        assertEquals(day2, day1.plusDays(1), "Eid al-Adha Day 2 must be the day after Day 1");
+        assertEquals(day3, day1.plusDays(2), "Eid al-Adha Day 3 must be two days after Day 1");
+        assertEquals(day4, day1.plusDays(3), "Eid al-Adha Day 4 must be three days after Day 1");
+    }
+
+    // =========================================================================
+    // dataValidThrough
+    // =========================================================================
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "TR calendar has lookup-table Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("TR");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), 2055,
+                "factory.dataValidThrough(\"TR\") must return 2055");
+    }
+
+    // =========================================================================
+    // Boundary: 2024 (first valid year)
+    // =========================================================================
+
+    @Test
+    public void testCalculate2024ContainsEidAlFitr() {
+        assertTrue(findFirst("Eid al-Fitr", 2024).isPresent(),
+                "Eid al-Fitr must be present for boundary year 2024");
+    }
+
+    @Test
+    public void testCalculate2024ContainsEidAlAdha() {
+        assertTrue(findFirst("Eid al-Adha", 2024).isPresent(),
+                "Eid al-Adha must be present for boundary year 2024");
+    }
+
+    // =========================================================================
+    // Boundary: 2055 (last valid year)
+    // =========================================================================
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundaryYear + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), TR_HOLIDAY_COUNT,
+                "Expected " + TR_HOLIDAY_COUNT + " holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testEidAlFitr2055Present() {
+        assertTrue(findFirst("Eid al-Fitr", 2055).isPresent(),
+                "Eid al-Fitr must be present at the data ceiling year 2055");
+    }
+
+    @Test
+    public void testEidAlAdha2055Present() {
+        assertTrue(findFirst("Eid al-Adha", 2055).isPresent(),
+                "Eid al-Adha must be present at the data ceiling year 2055");
+    }
+
+    // =========================================================================
+    // Beyond ceiling: 2056 — Islamic holidays silently absent
+    // =========================================================================
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> atBoundary = service.getHolidayCalendar().calculate(boundaryYear);
+        List<HolidayDate> beyondBoundary = service.getHolidayCalendar().calculate(boundaryYear + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); "
+                + "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testEidAlFitr2056AbsentSilently() {
+        assertFalse(findFirst("Eid al-Fitr", 2056).isPresent(),
+                "Eid al-Fitr must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testEidAlAdha2056AbsentSilently() {
+        assertFalse(findFirst("Eid al-Adha", 2056).isPresent(),
+                "Eid al-Adha must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), 7,
+                "Beyond CSV ceiling only the 7 fixed Gregorian holidays must remain");
+    }
+
+    // =========================================================================
+    // Before floor: 2023 — Islamic holidays absent
+    // =========================================================================
+
+    @Test
+    public void testEidAlFitr2023AbsentSilently() {
+        assertFalse(findFirst("Eid al-Fitr", 2023).isPresent(),
+                "Eid al-Fitr must be silently absent for 2023 — before the table floor");
+    }
+
+    // =========================================================================
+    // Double Eid al-Fitr in 2033 — only January occurrence recorded
+    // =========================================================================
+
+    @Test
+    public void testEidAlFitr2033OnlyOneOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only the first is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // =========================================================================
+    // Republic Day Eve (Oct 28) — confirmed absent; half-day not modelled
+    // =========================================================================
+
+    @Test
+    public void testRepublicDayEveAbsent2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        boolean oct28Present = holidays.stream()
+                .anyMatch(hd -> hd.date().equals(LocalDate.of(2025, Month.OCTOBER, 28)));
+        assertFalse(oct28Present,
+                "Oct 28 (Republic Day Eve) must not be present — half-day closures are not modelled");
+    }
+
+    // =========================================================================
+    // Helper
+    // =========================================================================
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRYTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRYTest.java
@@ -1,0 +1,299 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceTRYTest {
+
+    // 7 fixed + 3 Eid al-Fitr + 4 Eid al-Adha = 14 (Republic Day Eve omitted; half-day not modelled)
+    private static final int TRY_HOLIDAY_COUNT = 14;
+
+    private final HolidayCalendarServiceTRY service = new HolidayCalendarServiceTRY();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // =========================================================================
+    // Identity — SPI discovery
+    // =========================================================================
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("TRY"));
+        assertFalse(service.isProvided("TR"));
+        assertFalse(service.isProvided("SAR"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "TRY");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Turkey (BIST/TCMB) Holidays");
+    }
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("TRY");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "TRY");
+    }
+
+    // =========================================================================
+    // Weekend configuration — Saturday + Sunday
+    // =========================================================================
+
+    @Test
+    public void testWeekendDaysSaturdayAndSunday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2);
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY));
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY));
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY));
+    }
+
+    // =========================================================================
+    // Holiday count
+    // =========================================================================
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), TRY_HOLIDAY_COUNT,
+                "Expected " + TRY_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // =========================================================================
+    // Chronological order
+    // =========================================================================
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // =========================================================================
+    // Holiday name membership
+    // =========================================================================
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"National Sovereignty and Children's Day"},
+            new Object[]{"Labour and Solidarity Day"},
+            new Object[]{"Commemoration of Atatürk, Youth and Sports Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Democracy and National Unity Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Eid al-Adha (4th Day)"},
+            new Object[]{"Victory Day"},
+            new Object[]{"Republic Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        assertTrue(service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName())),
+                "Calendar must contain holiday: " + holidayName);
+    }
+
+    // =========================================================================
+    // No-roll behavior — fixed holidays stay on natural date
+    // =========================================================================
+
+    @Test
+    public void testVictoryDay2025NotRolled() {
+        // Aug 30, 2025 = Saturday; TR rolls to Sep 1 but TRY stays on Aug 30
+        assertEquals(LocalDate.of(2025, Month.AUGUST, 30).getDayOfWeek(), DayOfWeek.SATURDAY);
+        HolidayCalendar trCalendar = new HolidayCalendarServiceTR().getHolidayCalendar();
+        assertEquals(findFirst("Victory Day", 2025).orElseThrow().date(),
+                LocalDate.of(2025, Month.AUGUST, 30),
+                "TRY must not roll Victory Day 2025 (Saturday) — noRoll() convention");
+        assertEquals(trCalendar.calculate(2025).stream()
+                .filter(hd -> "Victory Day".equals(hd.holiday().getName()))
+                .findFirst().orElseThrow().date(),
+                LocalDate.of(2025, Month.SEPTEMBER, 1),
+                "TR must roll Victory Day 2025 (Saturday) to Sep 1");
+    }
+
+    @Test
+    public void testNewYearsDay2028NotRolled() {
+        // Jan 1, 2028 = Saturday; TR rolls to Jan 3 (Monday) but TRY stays on Jan 1
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        assertEquals(findFirst("New Year's Day", 2028).orElseThrow().date(),
+                LocalDate.of(2028, Month.JANUARY, 1),
+                "TRY must not roll New Year's Day 2028 (Saturday) — noRoll() convention");
+    }
+
+    // =========================================================================
+    // TRY mirrors TR — identical dates for any given year
+    // =========================================================================
+
+    @Test
+    public void testTRYSameHolidayCountAsTR2025() {
+        HolidayCalendar trCalendar = new HolidayCalendarServiceTR().getHolidayCalendar();
+        assertEquals(service.getHolidayCalendar().calculate(2025).size(),
+                trCalendar.calculate(2025).size(),
+                "TRY and TR must produce the same number of holidays for 2025");
+    }
+
+    @Test
+    public void testTRYSameHolidayCountAsTR2026() {
+        HolidayCalendar trCalendar = new HolidayCalendarServiceTR().getHolidayCalendar();
+        assertEquals(service.getHolidayCalendar().calculate(2026).size(),
+                trCalendar.calculate(2026).size(),
+                "TRY and TR must produce the same number of holidays for 2026");
+    }
+
+    @Test
+    public void testEidAlFitr2025MatchesTR() {
+        assertMatchesTR("Eid al-Fitr", 2025);
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesTR() {
+        assertMatchesTR("Eid al-Adha", 2025);
+    }
+
+    @Test
+    public void testEidAlFitr2026MatchesTR() {
+        assertMatchesTR("Eid al-Fitr", 2026);
+    }
+
+    @Test
+    public void testEidAlAdha2026MatchesTR() {
+        assertMatchesTR("Eid al-Adha", 2026);
+    }
+
+    // =========================================================================
+    // dataValidThrough
+    // =========================================================================
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "TRY calendar has lookup-table Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("TRY");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), 2055,
+                "factory.dataValidThrough(\"TRY\") must return 2055");
+    }
+
+    // =========================================================================
+    // Boundary: 2055 / beyond ceiling: 2056
+    // =========================================================================
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundaryYear);
+        assertFalse(holidays.isEmpty(),
+                "calculate(2055) must return holidays — within the covered range");
+        assertEquals(holidays.size(), TRY_HOLIDAY_COUNT,
+                "Expected " + TRY_HOLIDAY_COUNT + " holidays for boundary year " + boundaryYear);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundaryYear = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> atBoundary = service.getHolidayCalendar().calculate(boundaryYear);
+        List<HolidayDate> beyondBoundary = service.getHolidayCalendar().calculate(boundaryYear + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays; "
+                + "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    // =========================================================================
+    // Republic Day Eve (Oct 28) — confirmed absent
+    // =========================================================================
+
+    @Test
+    public void testRepublicDayEveAbsent2025() {
+        boolean oct28Present = service.getHolidayCalendar().calculate(2025).stream()
+                .anyMatch(hd -> hd.date().equals(LocalDate.of(2025, Month.OCTOBER, 28)));
+        assertFalse(oct28Present,
+                "Oct 28 (Republic Day Eve) must not be present — half-day closures are not modelled");
+    }
+
+    // =========================================================================
+    // Helper
+    // =========================================================================
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+    private void assertMatchesTR(String holidayName, int year) {
+        Optional<HolidayDate> tryDate = findFirst(holidayName, year);
+        Optional<HolidayDate> trDate = new HolidayCalendarServiceTR().getHolidayCalendar()
+                .calculate(year).stream()
+                .filter(hd -> holidayName.equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(tryDate.isPresent(), "TRY must contain: " + holidayName);
+        assertTrue(trDate.isPresent(), "TR must contain: " + holidayName);
+        assertEquals(tryDate.get().date(), trDate.get().date(),
+                "TRY " + holidayName + " " + year + " must match TR");
+    }
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class EidAlAdhaDay4Test {
+
+    @DataProvider
+    Iterator<Object[]> knownDatesTR() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 6, 19)},
+            new Object[]{2025, LocalDate.of(2025, 6, 8)},
+            new Object[]{2026, LocalDate.of(2026, 5, 29)},
+            new Object[]{2055, LocalDate.of(2055, 7, 6)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesTR")
+    public void testKnownDatesTR(int year, LocalDate expected) {
+        assertEquals(new EidAlAdhaDay4("TR").apply(year), expected,
+                "Eid al-Adha (4th Day) " + year + " must be Day 1 + 3 days");
+    }
+
+    @Test
+    public void testDay4IsThreeDaysAfterDay1() {
+        LocalDate day1 = new EidAlAdha("TR").apply(2025);
+        LocalDate day4 = new EidAlAdhaDay4("TR").apply(2025);
+        assertEquals(day4, day1.plusDays(3),
+                "Eid al-Adha Day 4 must be exactly 3 days after Day 1");
+    }
+
+    @Test
+    public void testCeilingYearReturnsDate() {
+        assertNotNull(new EidAlAdhaDay4("TR").apply(EidAlAdha.DATA_VALID_THROUGH),
+                "EidAlAdhaDay4 must return a date for the ceiling year 2055");
+    }
+
+    @Test
+    public void testBeyondCeilingReturnsNull() {
+        assertNull(new EidAlAdhaDay4("TR").apply(EidAlAdha.DATA_VALID_THROUGH + 1),
+                "EidAlAdhaDay4 must return null for year beyond ceiling");
+    }
+
+    @Test
+    public void testBelowFloorReturnsNull() {
+        assertNull(new EidAlAdhaDay4("TR").apply(EidAlAdha.DATA_VALID_FROM - 1),
+                "EidAlAdhaDay4 must return null for year below floor");
+    }
+
+    @Test
+    public void testIsValidYearFalseForBeyondCeiling() {
+        assertFalse(new EidAlAdhaDay4("TR").test(EidAlAdha.DATA_VALID_THROUGH + 1));
+    }
+
+    @Test
+    public void testCaseInsensitiveCountryCode() {
+        assertEquals(new EidAlAdhaDay4("tr").apply(2025), new EidAlAdhaDay4("TR").apply(2025));
+    }
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -94,4 +94,38 @@ public class EidAlAdhaTest {
     public void testCaseInsensitiveCountryCode() {
         assertEquals(new EidAlAdha("ae").apply(2025), new EidAlAdha("AE").apply(2025));
     }
+
+    // -------------------------------------------------------------------------
+    // Known dates — TR (Diyanet ilmi takvim)
+    // 2025 divergence: Diyanet = June 5; Saudi/UAE Umm al-Qura = June 6
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDatesTR() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 6, 16)},
+            new Object[]{2025, LocalDate.of(2025, 6, 5)},   // one day earlier than AE/SA
+            new Object[]{2026, LocalDate.of(2026, 5, 26)},
+            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesTR")
+    public void testKnownDatesTR(int year, LocalDate expected) {
+        assertEquals(new EidAlAdha("TR").apply(year), expected,
+                "Eid al-Adha " + year + " per Diyanet must be " + expected);
+    }
+
+    // Canonical Diyanet vs. Umm al-Qura divergence: 2025 Eid al-Adha
+    @Test
+    public void testTR2025DiffersFromAE() {
+        LocalDate trDate = new EidAlAdha("TR").apply(2025);
+        LocalDate aeDate = new EidAlAdha("AE").apply(2025);
+        assertEquals(trDate, LocalDate.of(2025, 6, 5),
+                "Diyanet Eid al-Adha 2025 must be June 5");
+        assertEquals(aeDate, LocalDate.of(2025, 6, 6),
+                "UAE SCA Eid al-Adha 2025 must be June 6");
+        assertNotEquals(trDate, aeDate,
+                "Diyanet and Umm al-Qura Eid al-Adha 2025 must differ by one day");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -148,4 +148,31 @@ public class EidAlFitrTest {
     public void testTestReturnsFalseForBeyondCeiling() {
         assertFalse(new EidAlFitr("AE").test(EidAlFitr.DATA_VALID_THROUGH + 1));
     }
+
+    // -------------------------------------------------------------------------
+    // Known dates — TR (Diyanet ilmi takvim)
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDatesTR() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 4, 10)},
+            new Object[]{2025, LocalDate.of(2025, 3, 30)},
+            new Object[]{2026, LocalDate.of(2026, 3, 19)},
+            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesTR")
+    public void testKnownDatesTR(int year, LocalDate expected) {
+        assertEquals(new EidAlFitr("TR").apply(year), expected,
+                "Eid al-Fitr " + year + " per Diyanet must be " + expected);
+    }
+
+    // TR 2025 matches AE: both Diyanet and UAE SCA agree on March 30 for 1446 AH
+    @Test
+    public void testTR2025MatchesAE() {
+        assertEquals(new EidAlFitr("TR").apply(2025), new EidAlFitr("AE").apply(2025),
+                "Eid al-Fitr 2025: Diyanet (TR) and UAE SCA (AE) must agree on March 30");
+    }
 }


### PR DESCRIPTION
### #161 Added Turkey holiday calendars TR (National) + TRY (BIST/TCMB)

**Description**

- Implemented `HolidayCalendarServiceTR` (Turkey National Holidays) and `HolidayCalendarServiceTRY` (Turkey BIST/TCMB Holidays)
- Shared `TurkeyHolidays` package-private factory with `baseHolidays(rollableFixed, additional)` extensibility seam
- 7 Gregorian fixed holidays; `TR` uses `followingMonday()` date roll, `TRY` uses `noRoll()`
- Eid al-Fitr (Ramazan Bayramı) × 3 days + Eid al-Adha (Kurban Bayramı) × 4 days via Diyanet-sourced CSV lookup tables covering 2024–2055; `dataValidThrough()` returns 2055
- New `EidAlAdhaDay4` observance class (Turkey observes 4 Eid al-Adha days vs. 3 for GCC states)
- CSV projection rows (2027–2055) use Umm al-Qura tabular calendar as best-available approximation; Diyanet ilmi takvim replacement tracked in #180
- Republic Day Eve (28 October, half-day closure) explicitly omitted with Javadoc warning; half-day model support tracked in #176
- Both services registered in `module-info.java` and `META-INF/services`
- 109 new test methods across 4 test classes; all 2,302 tests pass

**Related Issue**

- [#161 Turkey holiday calendars: TR (national) + TRY (BIST/TCMB)](https://github.com/holiday-calendar/holiday-calendar-java/issues/161)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed