### PR TITLE
#162 Qatar holiday calendars: QA (national) + QAR (QSE/QCB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,28 +73,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, IL, ILS, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Key design goals:
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
+| `QA` | Qatar (National) Holidays |
+| `QAR` | Qatar (QSE/QCB) Holidays |
 | `SA` | Saudi Arabia (National) Holidays |
 | `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
 | `SG` | Singapore (SGX) Holidays |
@@ -90,7 +92,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -137,7 +139,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/function/DateRolls.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/function/DateRolls.java
@@ -75,9 +75,10 @@ public final class DateRolls {
     /**
      * Friday and Saturday both roll forward to Sunday.
      *
-     * <p>Implements the GCC market rule (Saudi Arabia, UAE, Kuwait, Qatar, Bahrain, Oman):
+     * <p>Implements the GCC market rule (Saudi Arabia, UAE, Kuwait, Bahrain, Oman):
      * the weekend is Friday + Saturday; Sunday is the first business day of the week.
      *
+     * @see #previousThursdayOrFollowingSunday() for Qatar's asymmetric substitute rule
      * @see #followingMonday() for the analogous Sat/Sun → Mon rule used by Western markets
      */
     public static DateRoll followingSunday() {
@@ -85,6 +86,28 @@ public final class DateRolls {
             if (date.getDayOfWeek() == DayOfWeek.FRIDAY)   return date.plusDays(2);
             if (date.getDayOfWeek() == DayOfWeek.SATURDAY) return date.plusDays(1);
             return date;
+        };
+    }
+
+    /**
+     * Friday rolls back to Thursday; Saturday rolls forward to Sunday.
+     *
+     * <p>Implements the Qatar national holiday substitute rule as announced by the
+     * Amiri Diwan: when a public holiday falls on Friday (the first weekend day),
+     * it is observed on the preceding Thursday; when it falls on Saturday (the
+     * second weekend day), it is observed on the following Sunday.
+     *
+     * <p>Confirmed precedents: Qatar National Day 2020 (18 Dec = Friday → 17 Dec
+     * Thursday official); Qatar National Day 2021 (18 Dec = Saturday → 19 Dec
+     * Sunday official).
+     *
+     * @see #followingSunday() for the always-forward GCC convention used by Saudi Arabia and UAE
+     */
+    public static DateRoll previousThursdayOrFollowingSunday() {
+        return date -> switch (date.getDayOfWeek()) {
+            case FRIDAY   -> date.minusDays(1);
+            case SATURDAY -> date.plusDays(1);
+            default       -> date;
         };
     }
 

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/function/DateRollsTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/function/DateRollsTest.java
@@ -126,4 +126,39 @@ public class DateRollsTest {
     public void testFollowingSunday_Workday_NoRoll(LocalDate workday) {
         assertEquals(DateRolls.followingSunday().rollToObservedDate(workday), workday);
     }
+
+    // ── previousThursdayOrFollowingSunday ─────────────────────────────────────
+    // Qatar Amiri Diwan rule: Friday → preceding Thursday; Saturday → following Sunday
+
+    @Test
+    public void testPreviousThursdayOrFollowingSunday_Friday_RollsToThursday() {
+        // Dec 18, 2020 is Friday → Dec 17, 2020 (Thursday); confirmed Amiri Diwan
+        LocalDate fri = LocalDate.of(2020, 12, 18);
+        assertEquals(DateRolls.previousThursdayOrFollowingSunday().rollToObservedDate(fri),
+                LocalDate.of(2020, 12, 17));
+    }
+
+    @Test
+    public void testPreviousThursdayOrFollowingSunday_Saturday_RollsToSunday() {
+        // Dec 18, 2021 is Saturday → Dec 19, 2021 (Sunday); confirmed Amiri Diwan
+        LocalDate sat = LocalDate.of(2021, 12, 18);
+        assertEquals(DateRolls.previousThursdayOrFollowingSunday().rollToObservedDate(sat),
+                LocalDate.of(2021, 12, 19));
+    }
+
+    @DataProvider(name = "qatarWorkdays")
+    public Object[][] qatarWorkdays() {
+        return new Object[][] {
+            { LocalDate.of(2025, 1, 5)  },  // Sunday
+            { LocalDate.of(2025, 1, 6)  },  // Monday
+            { LocalDate.of(2025, 1, 7)  },  // Tuesday
+            { LocalDate.of(2025, 1, 8)  },  // Wednesday
+            { LocalDate.of(2025, 1, 9)  },  // Thursday
+        };
+    }
+
+    @Test(dataProvider = "qatarWorkdays")
+    public void testPreviousThursdayOrFollowingSunday_Workday_NoRoll(LocalDate workday) {
+        assertEquals(DateRolls.previousThursdayOrFollowingSunday().rollToObservedDate(workday), workday);
+    }
 }

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module org.holiday.calendar.mena {
 
     exports org.holiday.calendar.observance.islamic.mena;
     exports org.holiday.calendar.observance.hebrew;
+    exports org.holiday.calendar.observance.qa;
 
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceAE,
@@ -36,5 +37,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceIL,
         org.holiday.calendar.impl.HolidayCalendarServiceILS,
         org.holiday.calendar.impl.HolidayCalendarServiceTR,
-        org.holiday.calendar.impl.HolidayCalendarServiceTRY;
+        org.holiday.calendar.impl.HolidayCalendarServiceTRY,
+        org.holiday.calendar.impl.HolidayCalendarServiceQA,
+        org.holiday.calendar.impl.HolidayCalendarServiceQAR;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQA.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQA.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Qatar national public holiday calendar.
+ *
+ * <p>Calendar code: {@code QA}. Covers public holidays observed in the State of
+ * Qatar as declared by the Amiri Diwan and the Qatar Central Bank (QCB).
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday are observed on the preceding Thursday; holidays that fall on Saturday
+ * are observed on the following Sunday, per {@link DateRolls#previousThursdayOrFollowingSunday()}
+ * and confirmed Amiri Diwan precedents (National Day 2020 and 2021).
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-qa.csv} and
+ * {@code eid-al-adha-qa.csv}. Dates for 2024–2026 are official QCB announcements;
+ * 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * <p>Islamic New Year and Prophet's Birthday are not gazetted public holidays in
+ * Qatar and are not included.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceQA extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "QA";
+    private static final String NAME = "Qatar (National) Holidays";
+
+    public HolidayCalendarServiceQA() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(QatarHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // Friday → preceding Thursday; Saturday → following Sunday (Amiri Diwan rule)
+                .dateRoll(DateRolls.previousThursdayOrFollowingSunday())
+                .weekendDays(QatarHolidays.QATAR_WEEKEND)
+                .holidays(QatarHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQAR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQAR.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Qatar exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code QAR}. Covers market closure days for the Qatar Stock
+ * Exchange (QSE) and Qatar Central Bank (QCB) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED and SAR convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-qa.csv} and
+ * {@code eid-al-adha-qa.csv}. Dates for 2024–2026 are official QCB announcements;
+ * 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * <p>In addition to the 9 national holidays shared with {@code QA}, this calendar
+ * includes the Qatar Banks Holiday (first Sunday of March), mandated by Cabinet
+ * Decision No. (33) of 2009 for all QCB-supervised financial institutions.
+ *
+ * <p>Islamic New Year and Prophet's Birthday are not gazetted public holidays in
+ * Qatar and are not included.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceQAR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "QAR";
+    private static final String NAME = "Qatar (QSE/QCB) Holidays";
+
+    public HolidayCalendarServiceQAR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(QatarHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(QatarHolidays.QATAR_WEEKEND)
+                .holidays(QatarHolidays.qarHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/QatarHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/QatarHolidays.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.qa.QatarBanksHoliday;
+import org.holiday.calendar.observance.qa.QatarNationalSportsDay;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Package-private factory building the Qatar public holiday lists for the
+ * national ({@code QA}) and settlement ({@code QAR}) calendars.
+ *
+ * <p>The national calendar ({@code QA}) observes 9 public holidays: New Year's Day,
+ * Qatar National Sports Day, three days of Eid al-Fitr, three days of Eid al-Adha,
+ * and National Day.
+ *
+ * <p>The settlement calendar ({@code QAR}) adds one QCB-specific closure:
+ * the Qatar Banks Holiday (first Sunday of March, Cabinet Decision No. (33) of 2009),
+ * for a total of 10 holidays.
+ *
+ * <p>Islamic New Year and Prophet's Birthday are not gazetted public holidays in
+ * Qatar and are not included (cf. UAE and Saudi Arabia which observe both).
+ *
+ * <p>Eid al-Fitr and Eid al-Adha dates are populated through
+ * {@value DATA_VALID_THROUGH} via country-specific CSV lookup tables
+ * (country code {@code qa}). Dates for 2024–2026 are official Qatar Central Bank
+ * (QCB) announcements; dates for 2027–2055 are projected from the Umm al-Qura
+ * tabular Islamic calendar. Verify against official QCB/QSE announcements as
+ * each year is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class QatarHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> QATAR_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private QatarHolidays() {}
+
+    /**
+     * Returns the 9 Qatar public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, National Day)
+     *                      are rollable; the floating Sports Day and all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Qatar National Sports Day")
+                    .description("Qatar National Sports Day — second Tuesday of February (Emiri Decree No. 80 of 2011)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new QatarNationalSportsDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("Qatar National Day, marking independence from Britain on 18 December 1971")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 18)
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 10 Qatar QSE/QCB holidays: the 9 base holidays (with
+     * {@code rollableFixed=false}) plus the Qatar Banks Holiday.
+     */
+    static List<Holiday> qarHolidays() {
+        List<Holiday> holidays = new ArrayList<>(baseHolidays(false));
+        holidays.add(
+            Holiday.builder()
+                    .name("Qatar Banks Holiday")
+                    .description("Annual bank holiday for all QCB-supervised financial institutions — first Sunday of March (Cabinet Decision No. (33) of 2009)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new QatarBanksHoliday())
+                    .build()
+        );
+        return Collections.unmodifiableList(holidays);
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarBanksHoliday.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarBanksHoliday.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Observance of the Qatar Banks Holiday — the first Sunday of March.
+ *
+ * <p>Mandated by Cabinet Decision No. (33) of 2009 for all banks, money exchange
+ * outlets, investment and financial companies, insurance firms, and insurance
+ * broker companies operating in the State of Qatar. Sunday is a working day in
+ * Qatar (Friday + Saturday weekend), so this closure falls on the first business
+ * day of March in most years.
+ *
+ * <p>This holiday applies to the {@code QAR} (QSE/QCB) settlement calendar only;
+ * it is not a gazetted national public holiday and is not included in {@code QA}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class QatarBanksHoliday extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.MARCH, 1)
+                        .with(TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.SUNDAY));
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return year >= 2009;
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarNationalSportsDay.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarNationalSportsDay.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Observance of Qatar National Sports Day — the second Tuesday of February.
+ *
+ * <p>Established by Emiri Decree No. 80 of 2011; first observed on
+ * 14 February 2012. Falls on a Tuesday by definition and never requires a
+ * substitute holiday.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class QatarNationalSportsDay extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.FEBRUARY, 1)
+                        .with(TemporalAdjusters.dayOfWeekInMonth(2, DayOfWeek.TUESDAY));
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return year >= 2012;
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -6,3 +6,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceIL
 org.holiday.calendar.impl.HolidayCalendarServiceILS
 org.holiday.calendar.impl.HolidayCalendarServiceTR
 org.holiday.calendar.impl.HolidayCalendarServiceTRY
+org.holiday.calendar.impl.HolidayCalendarServiceQA
+org.holiday.calendar.impl.HolidayCalendarServiceQAR

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-qa.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-qa.csv
@@ -1,0 +1,51 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Qatar public holiday dates
+# The Feast of Sacrifice. The observed date follows the Qatar Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# 2024–2026: Qatar Central Bank (QCB) official holiday announcements for financial
+#            institutions; consistent with Umm al-Qura calendar in confirmed years.
+#            Source: The Peninsula Qatar / QCB circulars.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH, Küçük 30-year cycle).
+#            Verify against official QCB/QSE announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,QCB official
+2025,2025-06-06,QCB official
+2026,2026-05-26,QCB official
+# 2027–2055: Umm al-Qura tabular projection; verify against official QCB/QSE announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-qa.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-qa.csv
@@ -1,0 +1,50 @@
+# Eid al-Fitr (1 Shawwal) — Qatar public holiday dates
+# Marks the end of Ramadan. The observed date follows the Qatar Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# 2024–2026: Qatar Central Bank (QCB) official holiday announcements for financial
+#            institutions; consistent with Umm al-Qura calendar in confirmed years.
+#            Source: The Peninsula Qatar / QCB circulars.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official QCB/QSE announcements as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,QCB official
+2025,2025-03-30,QCB official
+2026,2026-03-19,QCB official
+# 2027–2055: Umm al-Qura tabular projection; verify against official QCB/QSE announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQARTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQARTest.java
@@ -1,0 +1,287 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceQARTest {
+
+    // 9 national holidays shared with QA + Qatar Banks Holiday (first Sunday of March) = 10
+    private static final int QAR_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceQAR service = new HolidayCalendarServiceQAR();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("QAR"));
+        assertFalse(service.isProvided("QA"));
+        assertFalse(service.isProvided("SAR"));
+        assertFalse(service.isProvided("USD"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "QAR");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Qatar (QSE/QCB) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("QAR");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "QAR");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Qatar weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QAR_HOLIDAY_COUNT,
+                "Expected " + QAR_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QAR_HOLIDAY_COUNT,
+                "Expected " + QAR_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── no-roll: National Day stays on natural date ───────────────────────────
+
+    // Dec 18, 2026 is Friday — QAR must NOT roll (noRoll convention)
+    @Test
+    public void testNationalDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2026);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2026, Month.DECEMBER, 18),
+                "QAR must not roll National Day 2026 (Friday) — settlement uses no-roll convention");
+    }
+
+    // Dec 18, 2027 is Saturday — QAR must NOT roll
+    @Test
+    public void testNationalDayOnSaturdayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2027);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2027, Month.DECEMBER, 18),
+                "QAR must not roll National Day 2027 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // ── no-roll: New Year's Day stays on natural date ─────────────────────────
+
+    // Jan 1, 2027 is Friday — QAR must NOT roll
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "QAR must not roll New Year's Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── Qatar Banks Holiday (first Sunday of March, QAR-only) ────────────────
+
+    // Mar 3, 2024 is the first Sunday of March — confirmed QCB announcement
+    @Test
+    public void testQatarBanksHoliday2024() {
+        assertEquals(LocalDate.of(2024, Month.MARCH, 3).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> bh = findFirst("Qatar Banks Holiday", 2024);
+        assertTrue(bh.isPresent());
+        assertEquals(bh.get().date(), LocalDate.of(2024, Month.MARCH, 3),
+                "Qatar Banks Holiday 2024 must be 2024-03-03 per QCB announcement");
+    }
+
+    @Test
+    public void testQatarBanksHoliday2025() {
+        assertEquals(LocalDate.of(2025, Month.MARCH, 2).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> bh = findFirst("Qatar Banks Holiday", 2025);
+        assertTrue(bh.isPresent());
+        assertEquals(bh.get().date(), LocalDate.of(2025, Month.MARCH, 2),
+                "Qatar Banks Holiday 2025 must be 2025-03-02");
+    }
+
+    @Test
+    public void testQatarBanksHolidayNotInQA() {
+        boolean inQA = new HolidayCalendarServiceQA().getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Qatar Banks Holiday".equals(h.getName()));
+        assertFalse(inQA, "Qatar Banks Holiday is QAR-only — not a national public holiday");
+    }
+
+    // ── Islamic dates match QA (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testEidAlFitr2025MatchesQA() {
+        HolidayCalendar qaCalendar  = new HolidayCalendarServiceQA().getHolidayCalendar();
+        Optional<HolidayDate> qarEid = findFirst("Eid al-Fitr", 2025);
+        Optional<HolidayDate> qaEid  = qaCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(qarEid.isPresent());
+        assertTrue(qaEid.isPresent());
+        assertEquals(qarEid.get().date(), qaEid.get().date(),
+                "QAR Eid al-Fitr 2025 must match QA (same CSV source)");
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesQA() {
+        HolidayCalendar qaCalendar  = new HolidayCalendarServiceQA().getHolidayCalendar();
+        Optional<HolidayDate> qarAdha = findFirst("Eid al-Adha", 2025);
+        Optional<HolidayDate> qaAdha  = qaCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(qarAdha.isPresent());
+        assertTrue(qaAdha.isPresent());
+        assertEquals(qarAdha.get().date(), qaAdha.get().date(),
+                "QAR Eid al-Adha 2025 must match QA (same CSV source)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "QAR calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("QAR");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"QAR\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), QAR_HOLIDAY_COUNT,
+                "Expected all " + QAR_HOLIDAY_COUNT + " QAR holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        // New Year's Day, Sports Day, National Day, and Qatar Banks Holiday are all
+        // algorithmic/fixed — they remain after the Eid CSV data is exhausted
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), 4,
+                "Beyond CSV ceiling the 4 fixed/computed QAR holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Qatar National Sports Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"National Day"},
+            new Object[]{"Qatar Banks Holiday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQATest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQATest.java
@@ -1,0 +1,394 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceQATest {
+
+    // 2 fixed (New Year's, National Day) + 1 floating Gregorian (Sports Day)
+    // + 3 Eid al-Fitr + 3 Eid al-Adha = 9
+    private static final int QA_HOLIDAY_COUNT = 9;
+
+    private final HolidayCalendarServiceQA service = new HolidayCalendarServiceQA();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("QA"));
+        assertFalse(service.isProvided("QAR"));
+        assertFalse(service.isProvided("SA"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "QA");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Qatar (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("QA");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "QA");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Qatar weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QA_HOLIDAY_COUNT,
+                "Expected " + QA_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QA_HOLIDAY_COUNT,
+                "Expected " + QA_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── Sports Day (second Tuesday of February) ───────────────────────────────
+
+    @Test
+    public void testSportsDay2024() {
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 13).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> sd = findFirst("Qatar National Sports Day", 2024);
+        assertTrue(sd.isPresent());
+        assertEquals(sd.get().date(), LocalDate.of(2024, Month.FEBRUARY, 13),
+                "Sports Day 2024 must be 2024-02-13");
+    }
+
+    @Test
+    public void testSportsDay2025() {
+        assertEquals(LocalDate.of(2025, Month.FEBRUARY, 11).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> sd = findFirst("Qatar National Sports Day", 2025);
+        assertTrue(sd.isPresent());
+        assertEquals(sd.get().date(), LocalDate.of(2025, Month.FEBRUARY, 11),
+                "Sports Day 2025 must be 2025-02-11");
+    }
+
+    // ── National Day (Dec 18) — no roll when weekday ──────────────────────────
+
+    // Dec 18, 2024 is Wednesday — must not roll
+    @Test
+    public void testNationalDay2024NoRoll() {
+        assertEquals(LocalDate.of(2024, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2024);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2024, Month.DECEMBER, 18),
+                "National Day 2024 (Wednesday) must not roll");
+    }
+
+    // ── National Day — Friday rolls to preceding Thursday ─────────────────────
+
+    // Dec 18, 2026 is Friday → rolls to Thursday Dec 17 (Amiri Diwan rule; confirmed 2020)
+    @Test
+    public void testNationalDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2026);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2026, Month.DECEMBER, 17),
+                "National Day 2026 (Friday) must roll to Thursday Dec 17");
+    }
+
+    // ── National Day — Saturday rolls to following Sunday ─────────────────────
+
+    // Dec 18, 2027 is Saturday → rolls to Sunday Dec 19 (Amiri Diwan rule; confirmed 2021)
+    @Test
+    public void testNationalDayRollFromSaturday2027() {
+        assertEquals(LocalDate.of(2027, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2027);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2027, Month.DECEMBER, 19),
+                "National Day 2027 (Saturday) must roll to Sunday Dec 19");
+    }
+
+    // ── New Year's Day rolls ──────────────────────────────────────────────────
+
+    // Jan 1, 2027 is Friday → rolls to Thursday Dec 31, 2026
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2026, Month.DECEMBER, 31),
+                "New Year's Day 2027 (Friday) must roll to Thursday Dec 31, 2026");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per QCB official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per QCB official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per QCB official");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per QCB official");
+    }
+
+    // ── Islamic holidays not included ─────────────────────────────────────────
+
+    @Test
+    public void testIslamicNewYearNotIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Islamic New Year".equals(h.getName()));
+        assertFalse(found, "Islamic New Year is not a gazetted Qatar public holiday");
+    }
+
+    @Test
+    public void testProphetsBirthdayNotIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Prophet's Birthday".equals(h.getName()));
+        assertFalse(found, "Prophet's Birthday is not a gazetted Qatar public holiday");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "QA calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("QA");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"QA\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), QA_HOLIDAY_COUNT,
+                "Expected all " + QA_HOLIDAY_COUNT + " QA holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testEidAlFitr2056AbsentSilently() {
+        Optional<HolidayDate> eid = service.getHolidayCalendar().calculate(2056).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertFalse(eid.isPresent(),
+                "Eid al-Fitr must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        // New Year's Day, Sports Day, and National Day remain after CSV data is exhausted
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), 3,
+                "Beyond CSV ceiling only the 3 fixed/computed Qatar holidays must remain");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Qatar National Sports Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"National Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -128,4 +128,30 @@ public class EidAlAdhaTest {
         assertNotEquals(trDate, aeDate,
                 "Diyanet and Umm al-Qura Eid al-Adha 2025 must differ by one day");
     }
+
+    // -------------------------------------------------------------------------
+    // Known dates — QA (Qatar Central Bank official)
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDatesQA() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 6, 16)},
+            new Object[]{2025, LocalDate.of(2025, 6, 6)},
+            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesQA")
+    public void testKnownDatesQA(int year, LocalDate expected) {
+        assertEquals(new EidAlAdha("QA").apply(year), expected,
+                "Eid al-Adha " + year + " per QCB must be " + expected);
+    }
+
+    // QA 2025 matches AE: Qatar and UAE both use Umm al-Qura; Jun 6 confirmed QCB official
+    @Test
+    public void testQA2025MatchesAE() {
+        assertEquals(new EidAlAdha("QA").apply(2025), new EidAlAdha("AE").apply(2025),
+                "Eid al-Adha 2025: Qatar (QCB) and UAE (SCA) must agree on June 6");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -175,4 +175,30 @@ public class EidAlFitrTest {
         assertEquals(new EidAlFitr("TR").apply(2025), new EidAlFitr("AE").apply(2025),
                 "Eid al-Fitr 2025: Diyanet (TR) and UAE SCA (AE) must agree on March 30");
     }
+
+    // -------------------------------------------------------------------------
+    // Known dates — QA (Qatar Central Bank official)
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDatesQA() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 4, 10)},
+            new Object[]{2025, LocalDate.of(2025, 3, 30)},
+            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesQA")
+    public void testKnownDatesQA(int year, LocalDate expected) {
+        assertEquals(new EidAlFitr("QA").apply(year), expected,
+                "Eid al-Fitr " + year + " per QCB must be " + expected);
+    }
+
+    // QA 2025 matches AE: both Qatar and UAE arrive at same date via Umm al-Qura
+    @Test
+    public void testQA2025MatchesAE() {
+        assertEquals(new EidAlFitr("QA").apply(2025), new EidAlFitr("AE").apply(2025),
+                "Eid al-Fitr 2025: Qatar (QCB) and UAE (SCA) must agree on March 30");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarBanksHolidayTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarBanksHolidayTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class QatarBanksHolidayTest {
+
+    private final QatarBanksHoliday banksHoliday = new QatarBanksHoliday();
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        return List.of(
+            // 2024-03-03 confirmed via QCB official announcement (Gulf Times)
+            new Object[]{2024, LocalDate.of(2024, Month.MARCH, 3)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 2)},
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 1)},
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 7)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testFirstSundayOfMarch(int year, LocalDate expected) {
+        assertEquals(banksHoliday.apply(year), expected,
+                "Qatar Banks Holiday " + year + " must be " + expected);
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testAlwaysFallsOnSunday(int year, LocalDate expected) {
+        assertEquals(banksHoliday.apply(year).getDayOfWeek(), DayOfWeek.SUNDAY,
+                "Qatar Banks Holiday must always fall on Sunday");
+    }
+
+    @Test
+    public void testValidFrom2009() {
+        assertNotNull(banksHoliday.apply(2009),
+                "Qatar Banks Holiday must be computable from 2009 (Cabinet Decision No. (33) of 2009)");
+        assertEquals(banksHoliday.apply(2009).getDayOfWeek(), DayOfWeek.SUNDAY);
+    }
+
+    @Test
+    public void testInvalidBefore2009ReturnsNull() {
+        assertNull(banksHoliday.apply(2008),
+                "Qatar Banks Holiday before 2009 must return null — Cabinet Decision not yet in force");
+    }
+
+    @Test
+    public void testTestReturnsFalseBeforeInception() {
+        assertFalse(banksHoliday.test(2008));
+    }
+
+    @Test
+    public void testTestReturnsTrueFrom2009() {
+        assertTrue(banksHoliday.test(2024));
+    }
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarNationalSportsDayTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarNationalSportsDayTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class QatarNationalSportsDayTest {
+
+    private final QatarNationalSportsDay sportsDay = new QatarNationalSportsDay();
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        return List.of(
+            // Amiri Diwan confirmed dates
+            new Object[]{2023, LocalDate.of(2023, Month.FEBRUARY, 14)},
+            new Object[]{2024, LocalDate.of(2024, Month.FEBRUARY, 13)},
+            new Object[]{2025, LocalDate.of(2025, Month.FEBRUARY, 11)},
+            new Object[]{2026, LocalDate.of(2026, Month.FEBRUARY, 10)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testSecondTuesdayOfFebruary(int year, LocalDate expected) {
+        assertEquals(sportsDay.apply(year), expected,
+                "Qatar National Sports Day " + year + " must be " + expected);
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testAlwaysFallsOnTuesday(int year, LocalDate expected) {
+        assertEquals(sportsDay.apply(year).getDayOfWeek(), DayOfWeek.TUESDAY,
+                "Qatar National Sports Day must always fall on Tuesday");
+    }
+
+    @Test
+    public void testValidFrom2012() {
+        assertNotNull(sportsDay.apply(2012),
+                "First Sports Day (2012) must be computable");
+        assertEquals(sportsDay.apply(2012).getDayOfWeek(), DayOfWeek.TUESDAY);
+    }
+
+    @Test
+    public void testInvalidBefore2012ReturnsNull() {
+        assertNull(sportsDay.apply(2011),
+                "Sports Day before 2012 must return null — Decree enacted 2011, first observed 2012");
+    }
+
+    @Test
+    public void testTestReturnsFalseBeforeInception() {
+        assertFalse(sportsDay.test(2011));
+    }
+
+    @Test
+    public void testTestReturnsTrueFrom2012() {
+        assertTrue(sportsDay.test(2025));
+    }
+}

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.1</version>
+    <version>1.4.0-SNAPSHOT</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -31,7 +31,7 @@
       {@link org.holiday.calendar.HolidayCalendarService}.</p>
 
   <h1>Modules</h1>
-  <p>This API is divided into three modules to enable client software to depend
+  <p>This API is divided into four modules to enable client software to depend
       only on the regions it requires.</p>
   <dl>
     <dt><strong>holiday-calendar-core</strong></dt>
@@ -55,6 +55,14 @@
         Tokyo Stock Exchange (JP), Bank of Japan (JPY), and
         People's Bank of China (CNY). Uses Time4J for accurate
         non-Gregorian date calculations such as Chinese New Year.</dd>
+    <dt><strong>holiday-calendar-mena</strong></dt>
+    <dd>Holiday calendars for Middle East and North Africa markets:
+        UAE national (AE), UAE DFM / CBUAE (AED),
+        Saudi Arabia national (SA), Saudi Exchange / SAMA (SAR),
+        Israel national (IL), Tel Aviv Stock Exchange / Bank of Israel (ILS),
+        Turkey national (TR), Borsa İstanbul / TCMB (TRY),
+        Qatar national (QA), and Qatar Stock Exchange / QCB (QAR).
+        Uses CSV lookup tables for Islamic lunar holidays.</dd>
   </dl>
 </body>
 </html>

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -38,6 +38,8 @@ Key design goals:
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
+| `QA` | Qatar (National) Holidays |
+| `QAR` | Qatar (QSE/QCB) Holidays |
 | `SA` | Saudi Arabia (National) Holidays |
 | `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
 | `SG` | Singapore (SGX) Holidays |
@@ -90,7 +92,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -137,7 +139,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 27 implemented holiday calendars
+ * 30-year integration test suite validating all 29 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -73,6 +73,8 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"ILS"},
                 new Object[]{"JP"},
                 new Object[]{"JPY"},
+                new Object[]{"QA"},
+                new Object[]{"QAR"},
                 new Object[]{"SA"},
                 new Object[]{"SAR"},
                 new Object[]{"SG"},


### PR DESCRIPTION
### #162 Qatar holiday calendars: QA (national) + QAR (QSE/QCB)

**Description**

- Added `QA` (Qatar national) and `QAR` (Qatar QSE/QCB) holiday calendars to the `holiday-calendar-mena` module
- Added new `DateRolls.previousThursdayOrFollowingSunday()` strategy — Qatar's Amiri Diwan rule: Friday holidays roll to preceding Thursday, Saturday holidays roll to following Sunday (confirmed from National Day 2020 and 2021 precedents)
- Added `QatarNationalSportsDay` observance (second Tuesday of February; Emiri Decree No. 80 of 2011, valid from 2012)
- Added `QatarBanksHoliday` observance (first Sunday of March; Cabinet Decision No. (33) of 2009; QAR-only)
- Added Eid al-Fitr and Eid al-Adha CSV lookup tables for Qatar (`eid-al-fitr-qa.csv`, `eid-al-adha-qa.csv`); 2024–2026 from official QCB announcements, 2027–2055 from Umm al-Qura tabular projection
- QA: 9 holidays (New Year's Day, Sports Day, Eid al-Fitr ×3, Eid al-Adha ×3, National Day)
- QAR: 10 holidays (same 9 + Qatar Banks Holiday)
- Islamic New Year and Prophet's Birthday intentionally excluded — not gazetted Qatar public holidays
- Bumped project version to `1.4.0-SNAPSHOT`
- Updated `overview.html` (Modules section) and `README.md` (calendar table, dependency comment, code list)

**Related Issue**

- [#162 Qatar holiday calendars: QA (national) + QAR (QSE/QCB)](https://github.com/holiday-calendar/holiday-calendar-java/issues/162)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed