### PR TITLE
#163 Kuwait holiday calendars: KW (national) + KWD (Boursa Kuwait/CBK)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `IL` | Israel (National) Holidays |
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `KW` | Kuwait (National) Holidays |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `QA` | Qatar (National) Holidays |
@@ -92,7 +94,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -139,7 +141,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -39,5 +39,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceTR,
         org.holiday.calendar.impl.HolidayCalendarServiceTRY,
         org.holiday.calendar.impl.HolidayCalendarServiceQA,
-        org.holiday.calendar.impl.HolidayCalendarServiceQAR;
+        org.holiday.calendar.impl.HolidayCalendarServiceQAR,
+        org.holiday.calendar.impl.HolidayCalendarServiceKW,
+        org.holiday.calendar.impl.HolidayCalendarServiceKWD;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKW.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKW.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Kuwait national public holiday calendar.
+ *
+ * <p>Calendar code: {@code KW}. Covers public holidays observed in the State of
+ * Kuwait as declared by the Amiri Diwan and the Central Bank of Kuwait (CBK).
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}, consistent with the GCC market rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-kw.csv},
+ * {@code eid-al-adha-kw.csv}, {@code islamic-new-year-kw.csv}, and
+ * {@code mawlid-kw.csv}. Dates for 2024–2026 are official CBK / Boursa Kuwait
+ * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Kuwait determines Islamic holiday dates by moon sighting and may
+ * differ from Saudi Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceKW extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "KW";
+    private static final String NAME = "Kuwait (National) Holidays";
+
+    public HolidayCalendarServiceKW() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(KuwaitHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(KuwaitHolidays.KUWAIT_WEEKEND)
+                .holidays(KuwaitHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKWD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKWD.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Kuwait exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code KWD}. Covers market closure days for Boursa Kuwait
+ * and Central Bank of Kuwait (CBK) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED, SAR, and QAR convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-kw.csv},
+ * {@code eid-al-adha-kw.csv}, {@code islamic-new-year-kw.csv}, and
+ * {@code mawlid-kw.csv}. Dates for 2024–2026 are official CBK / Boursa Kuwait
+ * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Kuwait determines Islamic holiday dates by moon sighting and may
+ * differ from Saudi Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceKWD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "KWD";
+    private static final String NAME = "Kuwait (Boursa Kuwait/CBK) Holidays";
+
+    public HolidayCalendarServiceKWD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(KuwaitHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(KuwaitHolidays.KUWAIT_WEEKEND)
+                .holidays(KuwaitHolidays.kwdHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/KuwaitHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/KuwaitHolidays.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.IsraMiraj;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Kuwait public holiday lists for the
+ * national ({@code KW}) and settlement ({@code KWD}) calendars.
+ *
+ * <p>The national calendar ({@code KW}) observes 13 public holidays: New Year's Day,
+ * National Day, Liberation Day, Isra and Mi'raj, Arafat Day, three days of Eid al-Fitr,
+ * three days of Eid al-Adha, Islamic New Year, and Prophet's Birthday.
+ *
+ * <p>The settlement calendar ({@code KWD}) uses the identical holiday set with
+ * {@code rollable(false)} for all holidays — the exchange applies no date adjustment
+ * per the Boursa Kuwait / CBK no-roll convention.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code kw}). Dates for 2024–2026
+ * are sourced from official CBK and Boursa Kuwait market-holiday announcements;
+ * dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ * Kuwait determines Islamic holiday dates by moon sighting and may differ from
+ * Saudi Arabia by ±1 day; verify against official CBK / Boursa Kuwait announcements
+ * as each year is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class KuwaitHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> KUWAIT_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private KuwaitHolidays() {}
+
+    /**
+     * Returns the 13 Kuwait public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, National Day,
+     *                      Liberation Day) are rollable; all Islamic holidays are
+     *                      always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("Kuwait National Day, marking independence from Britain on 19 June 1961; observed 25 February")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.FEBRUARY, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Liberation Day")
+                    .description("Kuwait Liberation Day, marking liberation from Iraqi occupation on 26 February 1991")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.FEBRUARY, 26)
+                    .build(),
+            Holiday.builder()
+                    .name("Isra and Mi'raj")
+                    .description("Night journey and ascension of the Prophet Muhammad (27 Rajab AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IsraMiraj("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("kw"))
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 13 KWD holidays: the base holiday set with all holidays
+     * {@code rollable(false)}, for use with {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> kwdHolidays() {
+        return baseHolidays(false);
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ArafatDay.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ArafatDay.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Observance of Arafat Day (9 Dhu al-Hijjah AH), the day of standing at Mount
+ * Arafat — the day before Eid al-Adha.
+ *
+ * <p>Dates are determined by official moon sighting and cannot be computed
+ * algorithmically. Dates are derived from the official Eid al-Adha date minus
+ * one day, sourced from country-specific exchange and central bank holiday
+ * announcements.</p>
+ *
+ * <p>Date data is loaded at runtime from {@code arafat-day-{countryCode}.csv}
+ * in this package, where {@code countryCode} is the ISO 3166-1 alpha-2 country
+ * code in lower case (e.g. {@code kw}).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ArafatDay extends AbstractObservance {
+
+    static final int DATA_VALID_FROM = 2024;
+    static final int DATA_VALID_THROUGH = 2055;
+
+    private static final Logger log = LoggerFactory.getLogger(ArafatDay.class);
+    private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
+            new ConcurrentHashMap<>();
+
+    private final Map<Integer, LocalDate> dates;
+
+    public ArafatDay(String countryCode) {
+        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+                cc -> CsvObservanceLoader.loadSingle(ArafatDay.class, "arafat-day-" + cc + ".csv"));
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return dates.get(year);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        if (year > DATA_VALID_THROUGH) {
+            log.warn("Year {} exceeds data ceiling {}; Arafat Day date unavailable", year, DATA_VALID_THROUGH);
+            return false;
+        }
+        return dates.containsKey(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/IsraMiraj.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/IsraMiraj.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Observance of Isra and Mi'raj (27 Rajab AH), commemorating the night journey
+ * and ascension of the Prophet Muhammad.
+ *
+ * <p>Dates are determined by official moon sighting and cannot be computed
+ * algorithmically. Dates for 2024–2026 are sourced from official country
+ * exchange and central bank holiday announcements. Dates for 2027–2055 are
+ * projected from the Umm al-Qura tabular Islamic calendar (27 Rajab AH =
+ * 1 Muharram + 204 days); verify against official announcements as each year
+ * is published.</p>
+ *
+ * <p>Note: Gregorian year 2027 contains two 27 Rajab occurrences (~January 6
+ * AH 1448 and ~December 25 AH 1449). Only the first (January) occurrence is
+ * recorded in the CSV. The December occurrence cannot be represented under the
+ * single-date-per-year-key design.</p>
+ *
+ * <p>Date data is loaded at runtime from {@code isra-miraj-{countryCode}.csv}
+ * in this package, where {@code countryCode} is the ISO 3166-1 alpha-2 country
+ * code in lower case (e.g. {@code kw}).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class IsraMiraj extends AbstractObservance {
+
+    static final int DATA_VALID_FROM = 2024;
+    static final int DATA_VALID_THROUGH = 2055;
+
+    private static final Logger log = LoggerFactory.getLogger(IsraMiraj.class);
+    private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
+            new ConcurrentHashMap<>();
+
+    private final Map<Integer, LocalDate> dates;
+
+    public IsraMiraj(String countryCode) {
+        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+                cc -> CsvObservanceLoader.loadSingle(IsraMiraj.class, "isra-miraj-" + cc + ".csv"));
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return dates.get(year);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        if (year > DATA_VALID_THROUGH) {
+            log.warn("Year {} exceeds data ceiling {}; Isra and Mi'raj date unavailable", year, DATA_VALID_THROUGH);
+            return false;
+        }
+        return dates.containsKey(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -8,3 +8,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceTR
 org.holiday.calendar.impl.HolidayCalendarServiceTRY
 org.holiday.calendar.impl.HolidayCalendarServiceQA
 org.holiday.calendar.impl.HolidayCalendarServiceQAR
+org.holiday.calendar.impl.HolidayCalendarServiceKW
+org.holiday.calendar.impl.HolidayCalendarServiceKWD

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-kw.csv
@@ -1,0 +1,55 @@
+# Arafat Day (9 Dhu al-Hijjah) — Kuwait public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; Arafat Day
+#            falls one day before Eid al-Adha in both years.
+# 2026:      Boursa Kuwait official (May 26, one day before Eid al-Adha May 27).
+# 2027–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-kw.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,CBK official
+2025,2025-06-05,CBK official
+2026,2026-05-26,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-kw.csv
@@ -1,0 +1,56 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Kuwait public holiday dates
+# The Feast of Sacrifice. The observed date follows the Kuwait Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement (Boursa Kuwait market
+#            holidays page, 2026 calendar). Kuwait observed +1 day relative to SA.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH, Küçük 30-year cycle).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBK official
+2025,2025-06-06,CBK official
+2026,2026-05-27,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-kw.csv
@@ -1,0 +1,55 @@
+# Eid al-Fitr (1 Shawwal) — Kuwait public holiday dates
+# Marks the end of Ramadan. The observed date follows the Kuwait Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement (Boursa Kuwait market
+#            holidays page, 2026 calendar). Kuwait observed +1 day relative to SA.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,CBK official
+2025,2025-03-30,CBK official
+2026,2026-03-20,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-kw.csv
@@ -1,0 +1,53 @@
+# Islamic New Year (1 Muharram) — Kuwait public holiday dates
+# First day of the Islamic lunar year.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement. Kuwait observed +1 day
+#            relative to SA (June 16 vs SA June 15).
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBK official
+2025,2025-06-26,CBK official
+2026,2026-06-16,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/isra-miraj-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/isra-miraj-kw.csv
@@ -1,0 +1,52 @@
+# Isra and Mi'raj (27 Rajab) — Kuwait public holiday dates
+# Commemorates the night journey and ascension of the Prophet Muhammad.
+# 27 Rajab AH = 1 Muharram (Islamic New Year) + 204 days.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2026: CBK / Boursa Kuwait official holiday announcements.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (27 Rajab AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2027: Gregorian year 2027 contains two 27 Rajab occurrences
+# (~January 6 AH 1448 and ~December 25 AH 1449). Only the first (January)
+# occurrence is recorded here. The December occurrence cannot be represented
+# under the single-date-per-year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-02-08,CBK official
+2025,2025-01-27,CBK official
+2026,2026-01-16,CBK official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+# 2027: two 27 Rajab occurrences (~Jan 6 AH 1448 and ~Dec 25 AH 1449); Jan 6 recorded
+2027,2027-01-06,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2028,2028-12-13,Umm al-Qura projection
+2029,2029-12-02,Umm al-Qura projection
+2030,2030-11-21,Umm al-Qura projection
+2031,2031-11-10,Umm al-Qura projection
+2032,2032-10-29,Umm al-Qura projection
+2033,2033-10-18,Umm al-Qura projection
+2034,2034-10-07,Umm al-Qura projection
+2035,2035-09-26,Umm al-Qura projection
+2036,2036-09-14,Umm al-Qura projection
+2037,2037-09-03,Umm al-Qura projection
+2038,2038-08-23,Umm al-Qura projection
+2039,2039-08-12,Umm al-Qura projection
+2040,2040-08-01,Umm al-Qura projection
+2041,2041-07-21,Umm al-Qura projection
+2042,2042-07-10,Umm al-Qura projection
+2043,2043-06-29,Umm al-Qura projection
+2044,2044-06-17,Umm al-Qura projection
+2045,2045-06-06,Umm al-Qura projection
+2046,2046-05-26,Umm al-Qura projection
+2047,2047-05-15,Umm al-Qura projection
+2048,2048-05-03,Umm al-Qura projection
+2049,2049-04-22,Umm al-Qura projection
+2050,2050-04-11,Umm al-Qura projection
+2051,2051-03-31,Umm al-Qura projection
+2052,2052-03-19,Umm al-Qura projection
+2053,2053-03-08,Umm al-Qura projection
+2054,2054-02-25,Umm al-Qura projection
+2055,2055-02-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-kw.csv
@@ -1,0 +1,56 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Kuwait public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement. Kuwait observed +1 day
+#            relative to SA (August 25 vs SA August 24), consistent with the moon-
+#            sighting offset observed across other Islamic holidays in 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH, approximately 70 days after 1 Muharram).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,CBK official
+2025,2025-09-04,CBK official
+2026,2026-08-25,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWDTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWDTest.java
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceKWDTest {
+
+    // Same 13 holidays as KW — exchange uses the national holiday set, no-roll only
+    private static final int KWD_HOLIDAY_COUNT = 13;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int KWD_FIXED_HOLIDAY_COUNT = 3;
+
+    private final HolidayCalendarServiceKWD service = new HolidayCalendarServiceKWD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("KWD"));
+        assertFalse(service.isProvided("KW"));
+        assertFalse(service.isProvided("QAR"));
+        assertFalse(service.isProvided("SAR"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "KWD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Kuwait (Boursa Kuwait/CBK) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("KWD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "KWD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Kuwait weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KWD_HOLIDAY_COUNT,
+                "Expected " + KWD_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KWD_HOLIDAY_COUNT,
+                "Expected " + KWD_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── no-roll: Liberation Day stays on natural date (Friday 2027) ───────────
+
+    // Feb 26, 2027 is Friday — KWD must NOT roll (noRoll convention)
+    // KW rolls this to Sunday Feb 28; KWD stays on Feb 26
+    @Test
+    public void testLiberationDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2027);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2027, Month.FEBRUARY, 26),
+                "KWD must not roll Liberation Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── no-roll: National Day stays on natural date (Friday 2028) ────────────
+
+    // Feb 25, 2028 is Friday — KWD must NOT roll
+    @Test
+    public void testNationalDayOnFridayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.FEBRUARY, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.FEBRUARY, 25),
+                "KWD must not roll National Day 2028 (Friday) — settlement uses no-roll convention");
+    }
+
+    // Feb 26, 2028 is Saturday — KWD must NOT roll
+    @Test
+    public void testLiberationDayOnSaturdayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2028);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2028, Month.FEBRUARY, 26),
+                "KWD must not roll Liberation Day 2028 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Jan 1, 2027 is Friday — KWD must NOT roll
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "KWD must not roll New Year's Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── Islamic dates match KW (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testEidAlFitr2025MatchesKW() {
+        HolidayCalendar kwCalendar = new HolidayCalendarServiceKW().getHolidayCalendar();
+        Optional<HolidayDate> kwdEid = findFirst("Eid al-Fitr", 2025);
+        Optional<HolidayDate> kwEid  = kwCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(kwdEid.isPresent());
+        assertTrue(kwEid.isPresent());
+        assertEquals(kwdEid.get().date(), kwEid.get().date(),
+                "KWD Eid al-Fitr 2025 must match KW (same CSV source)");
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesKW() {
+        HolidayCalendar kwCalendar = new HolidayCalendarServiceKW().getHolidayCalendar();
+        Optional<HolidayDate> kwdAdha = findFirst("Eid al-Adha", 2025);
+        Optional<HolidayDate> kwAdha  = kwCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(kwdAdha.isPresent());
+        assertTrue(kwAdha.isPresent());
+        assertEquals(kwdAdha.get().date(), kwAdha.get().date(),
+                "KWD Eid al-Adha 2025 must match KW (same CSV source)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "KWD calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("KWD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"KWD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), KWD_HOLIDAY_COUNT,
+                "Expected all " + KWD_HOLIDAY_COUNT + " KWD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), KWD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + KWD_FIXED_HOLIDAY_COUNT +
+                " fixed KWD holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"National Day"},
+            new Object[]{"Liberation Day"},
+            new Object[]{"Isra and Mi'raj"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWTest.java
@@ -1,0 +1,473 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceKWTest {
+
+    // 3 fixed (New Year's, National Day, Liberation Day)
+    // + Isra and Mi'raj + 3 Eid al-Fitr + 3 Eid al-Adha + Arafat Day
+    // + Islamic New Year + Prophet's Birthday = 13
+    private static final int KW_HOLIDAY_COUNT = 13;
+
+    // Fixed holidays survive beyond the CSV ceiling (New Year's, National Day, Liberation Day)
+    private static final int KW_FIXED_HOLIDAY_COUNT = 3;
+
+    private final HolidayCalendarServiceKW service = new HolidayCalendarServiceKW();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("KW"));
+        assertFalse(service.isProvided("KWD"));
+        assertFalse(service.isProvided("QA"));
+        assertFalse(service.isProvided("SA"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "KW");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Kuwait (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("KW");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "KW");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Kuwait weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "Expected " + KW_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "Expected " + KW_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ──────────────────────────────────
+
+    // Feb 25, 2024 is Sunday — must not roll
+    @Test
+    public void testNationalDay2024NoRoll() {
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 25).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2024);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2024, Month.FEBRUARY, 25),
+                "National Day 2024 (Sunday) must not roll");
+    }
+
+    // Feb 26, 2024 is Monday — must not roll
+    @Test
+    public void testLiberationDay2024NoRoll() {
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.MONDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2024);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2024, Month.FEBRUARY, 26),
+                "Liberation Day 2024 (Monday) must not roll");
+    }
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // Feb 25, 2028 is Friday → rolls to Sunday Feb 27
+    @Test
+    public void testNationalDayRollFromFriday2028() {
+        assertEquals(LocalDate.of(2028, Month.FEBRUARY, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.FEBRUARY, 27),
+                "National Day 2028 (Friday) must roll to Sunday Feb 27");
+    }
+
+    // Feb 26, 2028 is Saturday → rolls to Sunday Feb 27; combined with National Day roll,
+    // both fixed holidays land on the same Sunday — assert total count is unchanged
+    @Test
+    public void testNoDuplicateDatesWhenNationalAndLiberationDayBothRoll2028() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        // Rolling does not deduplicate — all 11 holidays must still be returned even when
+        // multiple land on the same date (Eid al-Fitr Day 2 also falls on 2028-02-27)
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "2028 must still return " + KW_HOLIDAY_COUNT + " holidays even when multiple holidays share a date");
+        // Both fixed holidays must resolve to the same Sunday
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2028);
+        assertTrue(nd.isPresent());
+        assertTrue(ld.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.FEBRUARY, 27),
+                "National Day 2028 (Friday) must roll to Sunday Feb 27");
+        assertEquals(ld.get().date(), LocalDate.of(2028, Month.FEBRUARY, 27),
+                "Liberation Day 2028 (Saturday) must roll to Sunday Feb 27");
+    }
+
+    // Feb 26, 2027 is Friday → rolls to Sunday Feb 28
+    @Test
+    public void testLiberationDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2027);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2027, Month.FEBRUARY, 28),
+                "Liberation Day 2027 (Friday) must roll to Sunday Feb 28");
+    }
+
+    // Jan 1, 2027 is Friday → rolls to Sunday Jan 3
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 3),
+                "New Year's Day 2027 (Friday) must roll to Sunday Jan 3");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per CBK official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBK official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per CBK official");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per CBK official");
+    }
+
+    // ── Isra and Mi'raj spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testIsraMiraj2024() {
+        Optional<HolidayDate> im = findFirst("Isra and Mi'raj", 2024);
+        assertTrue(im.isPresent());
+        assertEquals(im.get().date(), LocalDate.of(2024, Month.FEBRUARY, 8),
+                "Isra and Mi'raj 2024 must be 2024-02-08 per CBK official");
+    }
+
+    @Test
+    public void testIsraMiraj2025() {
+        Optional<HolidayDate> im = findFirst("Isra and Mi'raj", 2025);
+        assertTrue(im.isPresent());
+        assertEquals(im.get().date(), LocalDate.of(2025, Month.JANUARY, 27),
+                "Isra and Mi'raj 2025 must be 2025-01-27 per CBK official");
+    }
+
+    // ── Arafat Day spot-checks ────────────────────────────────────────────────
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 (one day before Eid al-Adha June 16)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 (one day before Eid al-Adha June 6)");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    // ── Islamic New Year and Prophet's Birthday are gazetted in Kuwait ────────
+
+    @Test
+    public void testIslamicNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Islamic New Year".equals(h.getName()));
+        assertTrue(found, "Islamic New Year is a gazetted Kuwait public holiday and must be included");
+    }
+
+    @Test
+    public void testProphetsBirthdayIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Prophet's Birthday".equals(h.getName()));
+        assertTrue(found, "Prophet's Birthday is a gazetted Kuwait public holiday and must be included");
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBK official");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per CBK official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "KW calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("KW");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"KW\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "Expected all " + KW_HOLIDAY_COUNT + " KW holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), KW_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + KW_FIXED_HOLIDAY_COUNT +
+                " fixed Kuwait holidays must remain");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"National Day"},
+            new Object[]{"Liberation Day"},
+            new Object[]{"Isra and Mi'raj"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -61,7 +61,8 @@
         Saudi Arabia national (SA), Saudi Exchange / SAMA (SAR),
         Israel national (IL), Tel Aviv Stock Exchange / Bank of Israel (ILS),
         Turkey national (TR), Borsa İstanbul / TCMB (TRY),
-        Qatar national (QA), and Qatar Stock Exchange / QCB (QAR).
+        Qatar national (QA), Qatar Stock Exchange / QCB (QAR),
+        Kuwait national (KW), and Boursa Kuwait / CBK (KWD).
         Uses CSV lookup tables for Islamic lunar holidays.</dd>
   </dl>
 </body>

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -36,6 +36,8 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `IL` | Israel (National) Holidays |
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `KW` | Kuwait (National) Holidays |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `QA` | Qatar (National) Holidays |
@@ -92,7 +94,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -139,7 +141,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 29 implemented holiday calendars
+ * 30-year integration test suite validating all 31 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -73,6 +73,8 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"ILS"},
                 new Object[]{"JP"},
                 new Object[]{"JPY"},
+                new Object[]{"KW"},
+                new Object[]{"KWD"},
                 new Object[]{"QA"},
                 new Object[]{"QAR"},
                 new Object[]{"SA"},


### PR DESCRIPTION
### #163 Kuwait holiday calendars: KW (national) + KWD (Boursa Kuwait/CBK)

**Description**

- Added `KW` (Kuwait national) and `KWD` (Boursa Kuwait / CBK) holiday calendars to `holiday-calendar-mena`
- 13 holidays each: New Year's Day, National Day (Feb 25), Liberation Day (Feb 26), Isra and Mi'raj, Eid al-Fitr (3 days), Arafat Day, Eid al-Adha (3 days), Islamic New Year, Prophet's Birthday
- `KW` uses `DateRolls.followingSunday()` (GCC rule); `KWD` uses `DateRolls.noRoll()` (settlement convention)
- Weekend: Friday + Saturday
- 4 new Kuwait-specific CSV lookup tables with 2024–2026 official CBK / Boursa Kuwait dates and 2027–2055 Umm al-Qura tabular projections
- 2 new observance classes: `ArafatDay` and `IsraMiraj` (first use in the library)
- 86 unit tests across `HolidayCalendarServiceKWTest` and `HolidayCalendarServiceKWDTest`; `KW` and `KWD` added to `HolidayCalendar30YearIT`
- Updated `module-info.java`, `META-INF/services/`, `README.md`, and `overview.html`

**Related Issue**

- [#163 Kuwait holiday calendars: KW (national) + KWD (Boursa Kuwait/CBK)](https://github.com/holiday-calendar/holiday-calendar-java/issues/163)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed