### PR TITLE
#164 Added Egypt holiday calendars EG, EGP + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Key design goals:
 | `CN` | China National Holidays |
 | `CNY` | China (PBOC) Holidays |
 | `DE` | Germany (Xetra) Holidays |
+| `EG` | Egypt (National) Holidays |
+| `EGP` | Egypt (EGX/CBE) Holidays |
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France (Euronext Paris) Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
@@ -94,7 +96,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -24,7 +24,11 @@
             <artifactId>holiday-calendar-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- holiday-calendar-western added when a Christian observance (Good Friday, Christmas) is needed -->
+        <dependency>
+            <groupId>org.holiday.calendar</groupId>
+            <artifactId>holiday-calendar-western</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>net.time4j</groupId>

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -21,10 +21,11 @@
  */
 module org.holiday.calendar.mena {
     requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
+    requires org.holiday.calendar.western;
     requires net.time4j.base;
     requires org.slf4j;
 
+    exports org.holiday.calendar.observance.eg;
     exports org.holiday.calendar.observance.islamic.mena;
     exports org.holiday.calendar.observance.hebrew;
     exports org.holiday.calendar.observance.qa;
@@ -40,6 +41,8 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceTRY,
         org.holiday.calendar.impl.HolidayCalendarServiceQA,
         org.holiday.calendar.impl.HolidayCalendarServiceQAR,
+        org.holiday.calendar.impl.HolidayCalendarServiceEG,
+        org.holiday.calendar.impl.HolidayCalendarServiceEGP,
         org.holiday.calendar.impl.HolidayCalendarServiceKW,
         org.holiday.calendar.impl.HolidayCalendarServiceKWD;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/EgyptHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/EgyptHolidays.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.eg.ShamElNessim;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Egypt public holiday lists for the
+ * national ({@code EG}) and settlement ({@code EGP}) calendars.
+ *
+ * <p>The national calendar ({@code EG}) observes 17 public holidays: Coptic
+ * Christmas, Revolution Day (25 January), Sinai Liberation Day, Labour Day,
+ * June 30 Revolution, Revolution Day (23 July), Armed Forces Day, Sham El-Nessim,
+ * Arafat Day, three days of Eid al-Fitr, three days of Eid al-Adha, Islamic New
+ * Year, and Prophet's Birthday.
+ *
+ * <p>The settlement calendar ({@code EGP}) uses the same holiday set minus
+ * Arafat Day (16 holidays), with {@code rollable(false)} for all holidays — the
+ * Egyptian Exchange (EGX) and Central Bank of Egypt (CBE) apply no date adjustment
+ * per the no-roll convention.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code eg}). Dates for 2024–2025
+ * are sourced from official CBE / EGX announcements; dates for 2026–2055 are
+ * projected from the Umm al-Qura tabular Islamic calendar. Egypt determines Islamic
+ * holiday dates by moon sighting and may differ from Saudi Arabia by ±1 day; verify
+ * against official CBE / EGX announcements as each year is published.
+ *
+ * <p>Sham El-Nessim is computed algorithmically as the day after Coptic Easter
+ * (which uses the same Julian-calendar algorithm as Orthodox Easter) and is
+ * not subject to the CSV data ceiling.
+ *
+ * <p>Note: Egypt frequently announces ad hoc public holidays and bridge days via
+ * Prime Minister's decree. These are not capturable in a static calendar; consult
+ * official CBE / EGX announcements for the current year.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class EgyptHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> EGYPT_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private EgyptHolidays() {}
+
+    /**
+     * Returns the 17 Egypt public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays are rollable; Sham El-Nessim
+     *                      and all Islamic holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("Coptic Christmas")
+                    .description("Christmas celebration in the Coptic Orthodox Christian tradition (7 January)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 7)
+                    .build(),
+            Holiday.builder()
+                    .name("Revolution Day")
+                    .description("25 January Revolution, marking the start of the 2011 Egyptian uprising")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Sinai Liberation Day")
+                    .description("Return of the Sinai Peninsula to Egyptian sovereignty on 25 April 1982")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.APRIL, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Sham El-Nessim")
+                    .description("Egyptian spring festival celebrated the day after Coptic Easter; observed by all Egyptians regardless of religion")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ShamElNessim())
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("June 30 Revolution")
+                    .description("30 June Revolution, marking the removal of Mohamed Morsi from the presidency in 2013")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JUNE, 30)
+                    .build(),
+            Holiday.builder()
+                    .name("Revolution Day (July 23)")
+                    .description("23 July Revolution, marking the Free Officers' overthrow of King Farouk in 1952")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JULY, 23)
+                    .build(),
+            Holiday.builder()
+                    .name("Armed Forces Day")
+                    .description("Egyptian Armed Forces Day, commemorating the 1973 October War crossing of the Suez Canal")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.OCTOBER, 6)
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("eg"))
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 16 EGP holidays: the base holiday set without Arafat Day, with
+     * all holidays {@code rollable(false)}, for use with
+     * {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> egpHolidays() {
+        return baseHolidays(false).stream()
+                .filter(h -> !"Arafat Day".equals(h.getName()))
+                .toList();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEG.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEG.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Egypt national public holiday calendar.
+ *
+ * <p>Calendar code: {@code EG}. Covers public holidays observed in the Arab
+ * Republic of Egypt as declared by the Egyptian Government.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}, consistent with the GCC market rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-eg.csv},
+ * {@code eid-al-adha-eg.csv}, {@code arafat-day-eg.csv},
+ * {@code islamic-new-year-eg.csv}, and {@code mawlid-eg.csv}. Dates for 2024–2025
+ * are official CBE / EGX announcements; 2026–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Egypt determines Islamic holiday dates by moon
+ * sighting and may differ from Saudi Arabia by ±1 day.
+ *
+ * <p>Sham El-Nessim is computed algorithmically as the day after Coptic Easter
+ * and is available for all years within the valid range of the Orthodox Easter
+ * algorithm (530–3399 AD).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceEG extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "EG";
+    private static final String NAME = "Egypt (National) Holidays";
+
+    public HolidayCalendarServiceEG() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(EgyptHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(EgyptHolidays.EGYPT_WEEKEND)
+                .holidays(EgyptHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEGP.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEGP.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Egypt exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code EGP}. Covers market closure days for the Egyptian
+ * Exchange (EGX) and Central Bank of Egypt (CBE) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED, SAR, KWD, and QAR
+ * convention.
+ *
+ * <p>Arafat Day is excluded from this calendar: it is a national public holiday
+ * but is not an EGX / CBE settlement closure day.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-eg.csv},
+ * {@code eid-al-adha-eg.csv}, {@code islamic-new-year-eg.csv}, and
+ * {@code mawlid-eg.csv}. Dates for 2024–2025 are official CBE / EGX announcements;
+ * 2026–2055 are projected from the Umm al-Qura tabular Islamic calendar. Egypt
+ * determines Islamic holiday dates by moon sighting and may differ from Saudi
+ * Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceEGP extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "EGP";
+    private static final String NAME = "Egypt (EGX/CBE) Holidays";
+
+    public HolidayCalendarServiceEGP() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(EgyptHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(EgyptHolidays.EGYPT_WEEKEND)
+                .holidays(EgyptHolidays.egpHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/eg/ShamElNessim.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/eg/ShamElNessim.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.eg;
+
+import org.holiday.calendar.observance.CompositeObservance;
+import org.holiday.calendar.observance.christian.OrthodoxEaster;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of <em>Sham El-Nessim</em> (شم النسيم), the Egyptian spring festival.
+ *
+ * <p>Sham El-Nessim is celebrated on the day after Coptic Easter (Monday after
+ * Coptic Easter Sunday). The Coptic Orthodox Church uses the same Julian-calendar
+ * Easter algorithm as the Eastern Orthodox churches, implemented here via
+ * {@link OrthodoxEaster}.
+ *
+ * <p>Sham El-Nessim is an ancient Egyptian public holiday predating both Christianity
+ * and Islam. It is observed as a national public holiday in Egypt by all Egyptians
+ * regardless of religion and is a bank and exchange closure day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ShamElNessim extends CompositeObservance {
+
+    public ShamElNessim() {
+        super(new OrthodoxEaster());
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,3 +1,5 @@
+org.holiday.calendar.impl.HolidayCalendarServiceEG
+org.holiday.calendar.impl.HolidayCalendarServiceEGP
 org.holiday.calendar.impl.HolidayCalendarServiceAE
 org.holiday.calendar.impl.HolidayCalendarServiceAED
 org.holiday.calendar.impl.HolidayCalendarServiceSA

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-eg.csv
@@ -1,0 +1,53 @@
+# Arafat Day (9 Dhu al-Hijjah) — Egypt public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBE / EGX official holiday announcements; Arafat Day
+#            falls one day before Eid al-Adha in both years.
+# 2026–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-eg.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,CBE official
+2025,2025-06-05,CBE official
+# 2026–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2026,2026-05-25,Umm al-Qura projection
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-eg.csv
@@ -1,0 +1,54 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Egypt public holiday dates
+# The Feast of Sacrifice. The observed date follows the Central Bank of Egypt
+# (CBE) announcement, based on Egyptian moon-sighting observation.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBE / EGX official holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcement when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH, Küçük 30-year cycle).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBE official
+2025,2025-06-06,CBE official
+# 2026–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2026,2026-05-26,Umm al-Qura projection
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-eg.csv
@@ -1,0 +1,53 @@
+# Eid al-Fitr (1 Shawwal) — Egypt public holiday dates
+# Marks the end of Ramadan. The observed date follows the Central Bank of Egypt
+# (CBE) announcement, based on Egyptian moon-sighting observation.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBE / EGX official holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcement when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,CBE official
+2025,2025-03-30,CBE official
+# 2026–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2026,2026-03-19,Umm al-Qura projection
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-eg.csv
@@ -1,0 +1,51 @@
+# Islamic New Year (1 Muharram) — Egypt public holiday dates
+# First day of the Islamic lunar year.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBE / EGX official holiday announcement.
+# 2025–2026: Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcements when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBE official
+# 2025–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2025,2025-06-26,Umm al-Qura projection
+2026,2026-06-15,Umm al-Qura projection
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-eg.csv
@@ -1,0 +1,53 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Egypt public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBE / EGX official holiday announcement.
+# 2025–2026: Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcements when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH, approximately 70 days after 1 Muharram).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,CBE official
+# 2025–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2025,2025-09-04,Umm al-Qura projection
+2026,2026-08-24,Umm al-Qura projection
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGPTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGPTest.java
@@ -1,0 +1,336 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceEGPTest {
+
+    // EG holidays (17) minus Arafat Day = 16
+    private static final int EGP_HOLIDAY_COUNT = 16;
+
+    // Beyond CSV ceiling: 7 fixed Gregorian + Sham El-Nessim (algorithm-based) = 8
+    private static final int EGP_FIXED_HOLIDAY_COUNT = 8;
+
+    private final HolidayCalendarServiceEGP service = new HolidayCalendarServiceEGP();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("EGP"));
+        assertFalse(service.isProvided("EG"));
+        assertFalse(service.isProvided("KWD"));
+        assertFalse(service.isProvided("SAR"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "EGP");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Egypt (EGX/CBE) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("EGP");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "EGP");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Egypt weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day in Egypt");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EGP_HOLIDAY_COUNT,
+                "Expected " + EGP_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EGP_HOLIDAY_COUNT,
+                "Expected " + EGP_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── no-roll convention — fixed holidays stay on their natural dates ────────
+
+    // Jan 7, 2028 is Friday → EGP must NOT roll (stays Jan 7)
+    @Test
+    public void testCopticChristmasOnFridayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 7).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cc = findFirst("Coptic Christmas", 2028);
+        assertTrue(cc.isPresent());
+        assertEquals(cc.get().date(), LocalDate.of(2028, Month.JANUARY, 7),
+                "EGP must not roll Coptic Christmas 2028 (Friday) — CBE uses no-roll convention");
+    }
+
+    // May 1, 2026 is Friday → EGP must NOT roll (stays May 1)
+    @Test
+    public void testLabourDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 1),
+                "EGP must not roll Labour Day 2026 (Friday) — CBE uses no-roll convention");
+    }
+
+    // Oct 6, 2029 is Saturday → EGP must NOT roll (stays Oct 6)
+    @Test
+    public void testArmedForcesDayOnSaturdayNotRolled2029() {
+        assertEquals(LocalDate.of(2029, Month.OCTOBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> afd = findFirst("Armed Forces Day", 2029);
+        assertTrue(afd.isPresent());
+        assertEquals(afd.get().date(), LocalDate.of(2029, Month.OCTOBER, 6),
+                "EGP must not roll Armed Forces Day 2029 (Saturday) — CBE uses no-roll convention");
+    }
+
+    // Jul 23, 2027 is Friday → EGP must NOT roll (stays Jul 23)
+    @Test
+    public void testRevolutionDayJulyOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JULY, 23).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> rd2 = findFirst("Revolution Day (July 23)", 2027);
+        assertTrue(rd2.isPresent());
+        assertEquals(rd2.get().date(), LocalDate.of(2027, Month.JULY, 23),
+                "EGP must not roll Revolution Day (July 23) 2027 (Friday) — CBE uses no-roll convention");
+    }
+
+    // ── Arafat Day must be absent from EGP ───────────────────────────────────
+
+    @Test
+    public void testArafatDayAbsent() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Arafat Day".equals(h.getName()));
+        assertFalse(found, "Arafat Day is a national holiday only; it must not appear in the EGP settlement calendar");
+    }
+
+    @Test
+    public void testArafatDayAbsent2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertFalse(ad.isPresent(), "Arafat Day must not be present in EGP 2024");
+    }
+
+    // ── Islamic holiday spot-checks (same CSV as EG) ──────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "EGP Eid al-Fitr 2024 must match CBE official date");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "EGP Eid al-Adha 2024 must match CBE official date");
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "EGP Eid al-Fitr 2025 must match CBE official date");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "EGP Eid al-Adha 2025 must match CBE official date");
+    }
+
+    // ── EGP Islamic dates match EG ────────────────────────────────────────────
+
+    @Test
+    public void testEgpIslamicDatesMatchEg() {
+        HolidayCalendarServiceEG egService = new HolidayCalendarServiceEG();
+        for (String name : new String[]{"Eid al-Fitr", "Eid al-Adha", "Islamic New Year", "Prophet's Birthday"}) {
+            for (int year : new int[]{2024, 2025}) {
+                Optional<HolidayDate> egp = findFirst(name, year);
+                Optional<HolidayDate> eg  = egService.getHolidayCalendar().calculate(year).stream()
+                        .filter(hd -> name.equals(hd.holiday().getName()))
+                        .findFirst();
+                assertTrue(egp.isPresent(), year + " EGP must contain " + name);
+                assertTrue(eg.isPresent(),  year + " EG must contain " + name);
+                assertEquals(egp.get().date(), eg.get().date(),
+                        year + " EGP and EG must share the same " + name + " date");
+            }
+        }
+    }
+
+    // ── Sham El-Nessim spot-check ─────────────────────────────────────────────
+
+    @Test
+    public void testShamElNessim2024() {
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2024);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2024, Month.MAY, 6),
+                "EGP Sham El-Nessim 2024 must be May 6 (day after Coptic Easter May 5)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "EGP calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("EGP");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"EGP\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), EGP_HOLIDAY_COUNT,
+                "Expected all " + EGP_HOLIDAY_COUNT + " EGP holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedAndCopticHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), EGP_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + EGP_FIXED_HOLIDAY_COUNT +
+                " fixed and algorithmic EGP holidays must remain (7 Gregorian + Sham El-Nessim)");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Coptic Christmas"},
+            new Object[]{"Revolution Day"},
+            new Object[]{"Sinai Liberation Day"},
+            new Object[]{"Sham El-Nessim"},
+            new Object[]{"Labour Day"},
+            new Object[]{"June 30 Revolution"},
+            new Object[]{"Revolution Day (July 23)"},
+            new Object[]{"Armed Forces Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "EGP calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
@@ -95,28 +95,21 @@ public class HolidayCalendarServiceEGTest {
 
     // ── total count ───────────────────────────────────────────────────────────
 
-    @Test
-    public void testCalculate2024() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
-        assertNotNull(holidays);
-        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
-                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
     }
 
-    @Test
-    public void testCalculate2025() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
         assertNotNull(holidays);
         assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
-                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
-    }
-
-    @Test
-    public void testCalculate2026() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
-        assertNotNull(holidays);
-        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
-                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for " + year + ", got: " + holidays.size());
     }
 
     // ── chronological order ───────────────────────────────────────────────────

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
@@ -1,0 +1,502 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceEGTest {
+
+    // 7 fixed + Sham El-Nessim + Arafat Day + 3 Eid al-Fitr + 3 Eid al-Adha
+    // + Islamic New Year + Prophet's Birthday = 17
+    private static final int EG_HOLIDAY_COUNT = 17;
+
+    // Beyond CSV ceiling: 7 fixed Gregorian + Sham El-Nessim (algorithm-based, never drops) = 8
+    private static final int EG_FIXED_HOLIDAY_COUNT = 8;
+
+    private final HolidayCalendarServiceEG service = new HolidayCalendarServiceEG();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("EG"));
+        assertFalse(service.isProvided("EGP"));
+        assertFalse(service.isProvided("KW"));
+        assertFalse(service.isProvided("SA"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "EG");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Egypt (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("EG");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "EG");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Egypt weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day in Egypt");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2026() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ──────────────────────────────────
+
+    // Jan 7, 2025 is Tuesday — must not roll
+    @Test
+    public void testCopticChristmas2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 7).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> cc = findFirst("Coptic Christmas", 2025);
+        assertTrue(cc.isPresent());
+        assertEquals(cc.get().date(), LocalDate.of(2025, Month.JANUARY, 7),
+                "Coptic Christmas 2025 (Tuesday) must not roll");
+    }
+
+    // Jun 30, 2025 is Monday — must not roll
+    @Test
+    public void testJune30Revolution2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 30).getDayOfWeek(), DayOfWeek.MONDAY);
+        Optional<HolidayDate> j30 = findFirst("June 30 Revolution", 2025);
+        assertTrue(j30.isPresent());
+        assertEquals(j30.get().date(), LocalDate.of(2025, Month.JUNE, 30),
+                "June 30 Revolution 2025 (Monday) must not roll");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // Jan 7, 2028 is Friday → rolls to Sunday Jan 9
+    @Test
+    public void testCopticChristmasRollFromFriday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 7).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cc = findFirst("Coptic Christmas", 2028);
+        assertTrue(cc.isPresent());
+        assertEquals(cc.get().date(), LocalDate.of(2028, Month.JANUARY, 9),
+                "Coptic Christmas 2028 (Friday) must roll to Sunday Jan 9");
+    }
+
+    // Jan 25, 2025 is Saturday → rolls to Sunday Jan 26
+    @Test
+    public void testRevolutionDayRollFromSaturday2025() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> rd = findFirst("Revolution Day", 2025);
+        assertTrue(rd.isPresent());
+        assertEquals(rd.get().date(), LocalDate.of(2025, Month.JANUARY, 26),
+                "Revolution Day 2025 (Saturday) must roll to Sunday Jan 26");
+    }
+
+    // Apr 25, 2026 is Saturday → rolls to Sunday Apr 26
+    @Test
+    public void testSinaiLiberationDayRollFromSaturday2026() {
+        assertEquals(LocalDate.of(2026, Month.APRIL, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> sld = findFirst("Sinai Liberation Day", 2026);
+        assertTrue(sld.isPresent());
+        assertEquals(sld.get().date(), LocalDate.of(2026, Month.APRIL, 26),
+                "Sinai Liberation Day 2026 (Saturday) must roll to Sunday Apr 26");
+    }
+
+    // May 1, 2026 is Friday → rolls to Sunday May 3
+    @Test
+    public void testLabourDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 3),
+                "Labour Day 2026 (Friday) must roll to Sunday May 3");
+    }
+
+    // Jul 23, 2028 is Sunday — must not roll (Sunday is a business day in Egypt)
+    @Test
+    public void testRevolutionDayJuly2028NoRoll() {
+        assertEquals(LocalDate.of(2028, Month.JULY, 23).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> rd2 = findFirst("Revolution Day (July 23)", 2028);
+        assertTrue(rd2.isPresent());
+        assertEquals(rd2.get().date(), LocalDate.of(2028, Month.JULY, 23),
+                "Revolution Day (July 23) 2028 (Sunday) must not roll — Sunday is a business day in Egypt");
+    }
+
+    // Jul 23, 2027 is Friday → rolls to Sunday Jul 25
+    @Test
+    public void testRevolutionDayJulyRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JULY, 23).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> rd2 = findFirst("Revolution Day (July 23)", 2027);
+        assertTrue(rd2.isPresent());
+        assertEquals(rd2.get().date(), LocalDate.of(2027, Month.JULY, 25),
+                "Revolution Day (July 23) 2027 (Friday) must roll to Sunday Jul 25");
+    }
+
+    // Oct 6, 2029 is Saturday → rolls to Sunday Oct 7
+    @Test
+    public void testArmedForcesDayRollFromSaturday2029() {
+        assertEquals(LocalDate.of(2029, Month.OCTOBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> afd = findFirst("Armed Forces Day", 2029);
+        assertTrue(afd.isPresent());
+        assertEquals(afd.get().date(), LocalDate.of(2029, Month.OCTOBER, 7),
+                "Armed Forces Day 2029 (Saturday) must roll to Sunday Oct 7");
+    }
+
+    // ── Sham El-Nessim spot-checks (day after Coptic/Orthodox Easter) ─────────
+
+    @Test
+    public void testShamElNessim2024() {
+        // Coptic Easter 2024 = May 5 (Orthodox Easter algorithm); Sham El-Nessim = May 6
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2024);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2024, Month.MAY, 6),
+                "Sham El-Nessim 2024 must be May 6 (day after Coptic Easter May 5)");
+    }
+
+    @Test
+    public void testShamElNessim2025() {
+        // Coptic Easter 2025 = April 20; Sham El-Nessim = April 21
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2025);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2025, Month.APRIL, 21),
+                "Sham El-Nessim 2025 must be April 21 (day after Coptic Easter April 20)");
+    }
+
+    @Test
+    public void testShamElNessim2026() {
+        // Coptic Easter 2026 = April 12; Sham El-Nessim = April 13
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2026);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2026, Month.APRIL, 13),
+                "Sham El-Nessim 2026 must be April 13 (day after Coptic Easter April 12)");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per CBE official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per CBE official");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBE official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per CBE official");
+    }
+
+    // ── Arafat Day spot-checks ────────────────────────────────────────────────
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 (one day before Eid al-Adha June 16)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 (one day before Eid al-Adha June 6)");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    // ── Islamic New Year and Prophet's Birthday ───────────────────────────────
+
+    @Test
+    public void testIslamicNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Islamic New Year".equals(h.getName()));
+        assertTrue(found, "Islamic New Year is a gazetted Egypt public holiday and must be included");
+    }
+
+    @Test
+    public void testProphetsBirthdayIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Prophet's Birthday".equals(h.getName()));
+        assertTrue(found, "Prophet's Birthday is a gazetted Egypt public holiday and must be included");
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBE official");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per CBE official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "EG calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("EG");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"EG\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected all " + EG_HOLIDAY_COUNT + " EG holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedAndCopticHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), EG_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + EG_FIXED_HOLIDAY_COUNT +
+                " fixed and algorithmic EG holidays must remain (7 Gregorian + Sham El-Nessim)");
+    }
+
+    @Test
+    public void testShamElNessimPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        boolean found = holidays2056.stream().anyMatch(hd -> "Sham El-Nessim".equals(hd.holiday().getName()));
+        assertTrue(found, "Sham El-Nessim must be present beyond CSV ceiling — it is algorithm-based, not CSV-based");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Coptic Christmas"},
+            new Object[]{"Revolution Day"},
+            new Object[]{"Sinai Liberation Day"},
+            new Object[]{"Sham El-Nessim"},
+            new Object[]{"Labour Day"},
+            new Object[]{"June 30 Revolution"},
+            new Object[]{"Revolution Day (July 23)"},
+            new Object[]{"Armed Forces Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -31,6 +31,8 @@ Key design goals:
 | `CN` | China National Holidays |
 | `CNY` | China (PBOC) Holidays |
 | `DE` | Germany (Xetra) Holidays |
+| `EG` | Egypt (National) Holidays |
+| `EGP` | Egypt (EGX/CBE) Holidays |
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France (Euronext Paris) Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
@@ -94,7 +96,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>


### PR DESCRIPTION
### #164 Egypt Holiday Calendars: EG (National) + EGP (EGX/CBE)

**Description**

- Added `EG` — Egypt (National) Holidays calendar: 17 holidays with `followingSunday()` date roll
- Added `EGP` — Egypt (EGX/CBE) Holidays calendar: 16 holidays with `noRoll()` (Arafat Day excluded as it is a national-only holiday)
- Added `ShamElNessim` observance class: Egyptian spring festival computed as Coptic Easter + 1 day via the Orthodox Easter algorithm
- Created 5 Islamic holiday CSV files (`eid-al-fitr-eg`, `eid-al-adha-eg`, `arafat-day-eg`, `islamic-new-year-eg`, `mawlid-eg`) covering 2024–2055
- Enabled `holiday-calendar-western` dependency in the MENA module (required for `OrthodoxEaster`)
- Registered EG and EGP in `module-info.java` and `META-INF/services`
- Updated `src/readme/README.md` with EG and EGP entries

**Related Issue**

- [#164 Egypt holiday calendars: EG (national) + EGP (EGX/Central Bank of Egypt)](https://github.com/holiday-calendar/holiday-calendar-java/issues/164)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed