### PR TITLE
#166 Added Morocco holiday calendars MA, MAD + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,43 +18,45 @@ Key design goals:
 
 ### Supported Calendars
 
-| Code | Region |
-|------|--------|
-| `AE` | UAE (National) Holidays |
-| `AED` | UAE (CBUAE/DFM/ADX) Holidays |
+| Code | Region                                        |
+|------|-----------------------------------------------|
+| `AE` | United Arab Emirates (National) Holidays      |
+| `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays |
-| `BH` | Bahrain (National) Holidays |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
-| `CA` | Canada National Holidays |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
-| `CH` | Switzerland (SIX) Holidays |
-| `CHF` | Switzerland (SIC/SNB) Holidays |
-| `CN` | China National Holidays |
-| `CNY` | China (PBOC) Holidays |
-| `DE` | Germany (Xetra) Holidays |
-| `EG` | Egypt (National) Holidays |
-| `EGP` | Egypt (EGX/CBE) Holidays |
-| `EUR` | Euro (TARGET2) Holidays |
-| `FR` | France (Euronext Paris) Holidays |
-| `GBP` | United Kingdom (CHAPS) Holidays |
-| `IL` | Israel (National) Holidays |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays |
-| `KW` | Kuwait (National) Holidays |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
-| `JP` | Japan (TSE) Holidays |
-| `JPY` | Japan (BOJ) Holidays |
-| `QA` | Qatar (National) Holidays |
-| `QAR` | Qatar (QSE/QCB) Holidays |
-| `SA` | Saudi Arabia (National) Holidays |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
-| `SG` | Singapore (SGX) Holidays |
-| `SGD` | Singapore (MAS/MEPS+) Holidays |
-| `TR`  | Turkey (National) Holidays |
-| `TRY` | Turkey (BIST/TCMB) Holidays |
-| `UK` | United Kingdom National Holidays |
-| `US` | United States National Holidays |
-| `USD` | United States (Federal Reserve) Holidays |
+| `AUD` | Australia (RBA) Holidays                      |
+| `BH` | Bahrain (National) Holidays                   |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
+| `CA` | Canada National Holidays                      |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
+| `CH` | Switzerland (SIX) Holidays                    |
+| `CHF` | Switzerland (SIC/SNB) Holidays                |
+| `CN` | China National Holidays                       |
+| `CNY` | China (PBOC) Holidays                         |
+| `DE` | Germany (Xetra) Holidays                      |
+| `EG` | Egypt (National) Holidays                     |
+| `EGP` | Egypt (EGX/CBE) Holidays                      |
+| `EUR` | Euro (TARGET2) Holidays                       |
+| `FR` | France (Euronext Paris) Holidays              |
+| `GBP` | United Kingdom (CHAPS) Holidays               |
+| `IL` | Israel (National) Holidays                    |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
+| `JP` | Japan (TSE) Holidays                          |
+| `JPY` | Japan (BOJ) Holidays                          |
+| `MA` | Morocco (National) Holidays                   |
+| `MAD` | Morocco (CSE/BAM) Holidays                    |
+| `QA` | Qatar (National) Holidays                     |
+| `QAR` | Qatar (QSE/QCB) Holidays                      |
+| `SA` | Saudi Arabia (National) Holidays              |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
+| `SG` | Singapore (SGX) Holidays                      |
+| `SGD` | Singapore (MAS/MEPS+) Holidays                |
+| `TR`  | Turkey (National) Holidays                    |
+| `TRY` | Turkey (BIST/TCMB) Holidays                   |
+| `UK` | United Kingdom National Holidays              |
+| `US` | United States National Holidays               |
+| `USD` | United States (Federal Reserve) Holidays      |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 
@@ -98,7 +100,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -145,7 +147,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -46,5 +46,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceKW,
         org.holiday.calendar.impl.HolidayCalendarServiceKWD,
         org.holiday.calendar.impl.HolidayCalendarServiceBH,
-        org.holiday.calendar.impl.HolidayCalendarServiceBHD;
+        org.holiday.calendar.impl.HolidayCalendarServiceBHD,
+        org.holiday.calendar.impl.HolidayCalendarServiceMA,
+        org.holiday.calendar.impl.HolidayCalendarServiceMAD;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMA.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMA.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Morocco national public holiday calendar.
+ *
+ * <p>Calendar code: {@code MA}. Covers public holidays observed in the Kingdom of
+ * Morocco as declared by the Ministry of Interior.
+ *
+ * <p>Weekend: Saturday + Sunday. Morocco uses a standard Monday–Friday workweek
+ * (established in 2004), unlike GCC countries that observe Friday + Saturday.
+ *
+ * <p>Roll strategy: {@link DateRolls#followingMonday()} for fixed Gregorian
+ * holidays — when a fixed holiday falls on Saturday or Sunday it is observed on
+ * the following Monday, consistent with Moroccan Labour Code practice. Islamic
+ * holidays are {@code rollable(false)}: Islamic holiday substitutions are issued
+ * by case-by-case government decree in Morocco rather than by a statutory
+ * automatic roll rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-ma.csv},
+ * {@code eid-al-adha-ma.csv}, {@code islamic-new-year-ma.csv}, and
+ * {@code mawlid-ma.csv}. Dates for 2024–2025 are official Moroccan government /
+ * CSE holiday announcements. Dates for 2026–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Morocco determines Islamic holiday dates by
+ * moon sighting and may differ from GCC countries by ±1 day — verify projected
+ * dates against official Moroccan announcements as each year is published.
+ * Corrections require a new JAR release.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceMA extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "MA";
+    private static final String NAME = "Morocco (National) Holidays";
+
+    public HolidayCalendarServiceMA() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(MoroccoHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.followingMonday())
+                .weekendDays(MoroccoHolidays.MOROCCO_WEEKEND)
+                .holidays(MoroccoHolidays.maHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMAD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMAD.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Morocco exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code MAD}. Covers market closure days for the Bourse de
+ * Casablanca (CSE) and Bank Al-Maghrib (BAM) financial institutions.
+ *
+ * <p>Weekend: Saturday + Sunday. Morocco uses a standard Monday–Friday workweek.
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — the CSE observes holidays on
+ * their natural calendar dates, as confirmed by official CSE circular AV-2025-078.
+ * All holidays are {@code rollable(false)}. Settlement requires both counterparties
+ * to be available on the same calendar date; there is no roll-forward convention.
+ *
+ * <p>The CSE observes the same public holidays as the national calendar ({@code MA});
+ * there are no exchange-specific exclusions or additions.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-ma.csv},
+ * {@code eid-al-adha-ma.csv}, {@code islamic-new-year-ma.csv}, and
+ * {@code mawlid-ma.csv}. Dates for 2024–2025 are official Moroccan government /
+ * CSE holiday announcements. Dates for 2026–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Morocco determines Islamic holiday dates by
+ * moon sighting and may differ from GCC countries by ±1 day — verify projected
+ * dates against official Moroccan announcements as each year is published.
+ * Corrections require a new JAR release.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceMAD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "MAD";
+    private static final String NAME = "Morocco (CSE/BAM) Holidays";
+
+    public HolidayCalendarServiceMAD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(MoroccoHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(MoroccoHolidays.MOROCCO_WEEKEND)
+                .holidays(MoroccoHolidays.madHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/MoroccoHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/MoroccoHolidays.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthdayDay2;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Package-private factory building the Morocco public holiday list shared by
+ * the national ({@code MA}) and settlement ({@code MAD}) calendars.
+ *
+ * <p>Morocco observes 17 public holidays: ten fixed Gregorian holidays and seven
+ * Islamic holidays (two days each of Eid al-Fitr and Eid al-Adha, Islamic New Year,
+ * and two days of the Prophet's Birthday / Mawlid an-Nabi).
+ *
+ * <p>Morocco uses a <strong>Saturday + Sunday weekend</strong> — unlike GCC countries,
+ * which observe Friday + Saturday. Morocco switched to the Monday–Friday workweek in
+ * 2004 to align with European trading partners.
+ *
+ * <p>The national calendar ({@code MA}) applies {@link org.holiday.calendar.function.DateRolls#followingMonday()}
+ * to fixed Gregorian holidays ({@code rollable(true)}): when a fixed holiday falls on
+ * Saturday or Sunday, it is observed on the following Monday, consistent with Moroccan
+ * Labour Code practice. Islamic holidays are always {@code rollable(false)} — Islamic
+ * holiday substitutions in Morocco are issued by case-by-case government decree rather
+ * than by a statutory automatic roll rule.
+ *
+ * <p>The settlement calendar ({@code MAD}) uses {@link org.holiday.calendar.function.DateRolls#noRoll()}
+ * with all holidays {@code rollable(false)}: the Casablanca Stock Exchange (CSE /
+ * Bourse de Casablanca) observes holidays on their natural calendar dates, as reflected
+ * in official CSE circular AV-2025-078.
+ *
+ * <p>The Amazigh New Year (Yennayer, January 14) was officially gazetted in November
+ * 2023 and takes effect from 2024. It is included unconditionally as a
+ * {@code FixedHoliday}; callers computing dates prior to 2024 should discard this
+ * holiday as it was not legally observed before that year.
+ *
+ * <p>All Islamic holiday dates are populated through {@value DATA_VALID_THROUGH}
+ * via country-specific CSV lookup tables (country code {@code ma}).
+ * Dates for 2024–2025 are sourced from official Moroccan government / CSE holiday
+ * announcements. Dates for 2026–2055 are projected from the Umm al-Qura tabular
+ * Islamic calendar. Morocco determines Islamic holiday dates by moon sighting and
+ * may differ from GCC countries by ±1 day — verify projected dates against official
+ * Moroccan announcements as each year is published. Corrections require a new JAR
+ * release; no runtime update mechanism exists.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. Similarly, 2039 contains two Eid al-Adha
+ * occurrences; only January is recorded.
+ */
+class MoroccoHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    static final List<DayOfWeek> MOROCCO_WEEKEND = List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+
+    private MoroccoHolidays() {}
+
+    /**
+     * Returns the 17 Morocco public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays are rollable; all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        List<Holiday> holidays = new ArrayList<>(17);
+        holidays.add(Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of the new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 1)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Manifesto of Independence Day")
+                .description("Anniversary of the submission of the Independence Manifesto to the French "
+                        + "Protectorate on 11 January 1944")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 11)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Amazigh New Year")
+                .description("Yennayer — Amazigh (Berber) New Year; gazetted as a national public holiday "
+                        + "in November 2023, effective from 2024. Callers computing dates prior to 2024 "
+                        + "should discard this holiday as it was not legally observed before that year.")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 14)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr")
+                .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitr("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr (2nd Day)")
+                .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitrDay2("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Labour Day")
+                .description("International Workers' Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.MAY, 1)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha")
+                .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdha("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha (2nd Day)")
+                .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdhaDay2("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Throne Day")
+                .description("Anniversary of the accession of King Mohammed VI to the throne on 30 July 1999")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JULY, 30)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Islamic New Year")
+                .description("First day of the Islamic lunar year (1 Muharram AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new IslamicNewYear("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Oued Ed-Dahab Allegiance Day")
+                .description("Anniversary of the allegiance of Oued Ed-Dahab to Morocco on 14 August 1979")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 14)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Revolution of the King and the People")
+                .description("Anniversary of the exile of Sultan Mohammed V by France on 20 August 1953")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 20)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Youth Day")
+                .description("Birthday of King Mohammed VI (21 August 1963); national Youth Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 21)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Prophet's Birthday")
+                .description("First day of Mawlid an-Nabi, commemorating the birth of the Prophet Muhammad "
+                        + "(12 Rabi' al-Awwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ProphetsBirthday("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Prophet's Birthday (2nd Day)")
+                .description("Second day of Mawlid an-Nabi (13 Rabi' al-Awwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ProphetsBirthdayDay2("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Green March Anniversary")
+                .description("Anniversary of the Green March on 6 November 1975, marking Morocco's claim "
+                        + "to the Western Sahara")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.NOVEMBER, 6)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Independence Day")
+                .description("Independence of Morocco from the French Protectorate on 18 November 1956")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.NOVEMBER, 18)
+                .build());
+        return List.copyOf(holidays);
+    }
+
+    static List<Holiday> maHolidays() {
+        return baseHolidays(true);
+    }
+
+    static List<Holiday> madHolidays() {
+        return baseHolidays(false);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ProphetsBirthdayDay2.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ProphetsBirthdayDay2.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of the second day of the Prophet's Birthday (Mawlid an-Nabi),
+ * commemorating the continuation of the Mawlid celebration (13 Rabi' al-Awwal AH).
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link ProphetsBirthday})
+ * by one calendar day. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ProphetsBirthdayDay2 extends AbstractObservance {
+
+    private final ProphetsBirthday base;
+
+    public ProphetsBirthdayDay2(String countryCode) {
+        this.base = new ProphetsBirthday(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -14,3 +14,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceKW
 org.holiday.calendar.impl.HolidayCalendarServiceKWD
 org.holiday.calendar.impl.HolidayCalendarServiceBH
 org.holiday.calendar.impl.HolidayCalendarServiceBHD
+org.holiday.calendar.impl.HolidayCalendarServiceMA
+org.holiday.calendar.impl.HolidayCalendarServiceMAD

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-ma.csv
@@ -1,0 +1,55 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Morocco public holiday dates
+# The Feast of Sacrifice. The observed date follows the official announcement
+# by the Moroccan Ministry of Interior.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,Official announcement
+2025,2025-06-07,Official announcement (CSE AV-2025-078; one day after GCC consensus)
+2026,2026-05-27,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-ma.csv
@@ -1,0 +1,54 @@
+# Eid al-Fitr (1 Shawwal) — Morocco public holiday dates
+# Marks the end of Ramadan. The observed date follows the official announcement
+# by the Moroccan Ministry of Interior.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,Official announcement
+2025,2025-03-31,Official announcement
+2026,2026-03-20,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-ma.csv
@@ -1,0 +1,52 @@
+# Islamic New Year (1 Muharram) — Morocco public holiday dates
+# First day of the Islamic lunar year.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,Official announcement
+2025,2025-06-27,Official announcement (CSE AV-2025-078; one day after GCC consensus)
+2026,2026-06-16,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-ma.csv
@@ -1,0 +1,56 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Morocco public holiday dates — Day 1.
+# Commemorates the birth of the Prophet Muhammad.
+# Morocco observes a two-day Mawlid; Day 2 is synthesized as Day 1 + 1 calendar day.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+#            2025: Day 1 = Fri Sep 5 (natural date of 12 Rabi' al-Awwal, observed as-is).
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,Official announcement
+2025,2025-09-05,Official announcement (CSE AV-2025-078; Fri Sep 5, observed on natural date)
+2026,2026-08-25,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMADTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMADTest.java
@@ -1,0 +1,382 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceMADTest {
+
+    // Same 17 holidays as MA — settlement calendar uses the full national holiday set, no-roll
+    private static final int MAD_HOLIDAY_COUNT = 17;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int MAD_FIXED_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceMAD service = new HolidayCalendarServiceMAD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("MAD"));
+        assertFalse(service.isProvided("MA"));
+        assertFalse(service.isProvided("EGP"));
+        assertFalse(service.isProvided("BHD"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "MAD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Morocco (CSE/BAM) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("MAD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "MAD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysSaturdayAndSunday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Morocco weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must NOT be a weekend day — Morocco uses Sat/Sun weekend");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), MAD_HOLIDAY_COUNT,
+                "Expected " + MAD_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), MAD_HOLIDAY_COUNT,
+                "Expected " + MAD_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── no-roll: fixed holidays stay on natural dates ─────────────────────────
+
+    // Jan 11, 2025 is Saturday — MAD must NOT roll; MA rolls this to Monday Jan 13
+    @Test
+    public void testManifestoDayOnSaturdayNotRolled2025() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 11).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> md = findFirst("Manifesto of Independence Day", 2025);
+        assertTrue(md.isPresent());
+        assertEquals(md.get().date(), LocalDate.of(2025, Month.JANUARY, 11),
+                "MAD must not roll Manifesto of Independence Day 2025 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Jan 14, 2024 is Sunday — MAD must NOT roll; MA rolls this to Monday Jan 15
+    @Test
+    public void testAmazighNewYear2024OnSundayNotRolled() {
+        assertEquals(LocalDate.of(2024, Month.JANUARY, 14).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2024);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2024, Month.JANUARY, 14),
+                "MAD must not roll Amazigh New Year 2024 (Sunday) — settlement uses no-roll convention");
+    }
+
+    // Jan 1, 2028 is Saturday — MAD must NOT roll; MA rolls this to Monday Jan 3
+    @Test
+    public void testNewYearsDay2028OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 1),
+                "MAD must not roll New Year's Day 2028 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Aug 14, 2027 is Saturday — MAD must NOT roll; MA rolls this to Monday Aug 16
+    @Test
+    public void testOuedEdDahab2027OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2027, Month.AUGUST, 14).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> odd = findFirst("Oued Ed-Dahab Allegiance Day", 2027);
+        assertTrue(odd.isPresent());
+        assertEquals(odd.get().date(), LocalDate.of(2027, Month.AUGUST, 14),
+                "MAD must not roll Oued Ed-Dahab Allegiance Day 2027 (Saturday)");
+    }
+
+    // Nov 18, 2028 is Saturday — MAD must NOT roll; MA rolls this to Monday Nov 20
+    @Test
+    public void testIndependenceDay2028OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2028, Month.NOVEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2028);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2028, Month.NOVEMBER, 18),
+                "MAD must not roll Independence Day 2028 (Saturday)");
+    }
+
+    // ── MAD differs from MA on fixed holidays that fall on weekends ───────────
+
+    @Test
+    public void testManifestoDayDiffersBetweenMaAndMad2025() {
+        // MA rolls Jan 11 (Saturday) to Jan 13 (Monday); MAD stays Jan 11
+        HolidayCalendar maCalendar = new HolidayCalendarServiceMA().getHolidayCalendar();
+        Optional<HolidayDate> madMd = findFirst("Manifesto of Independence Day", 2025);
+        Optional<HolidayDate> maMd  = maCalendar.calculate(2025).stream()
+                .filter(hd -> "Manifesto of Independence Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(madMd.isPresent());
+        assertTrue(maMd.isPresent());
+        assertNotEquals(madMd.get().date(), maMd.get().date(),
+                "MAD Manifesto of Independence Day 2025 must differ from MA (no-roll vs followingMonday)");
+        assertEquals(madMd.get().date(), LocalDate.of(2025, Month.JANUARY, 11));
+        assertEquals(maMd.get().date(), LocalDate.of(2025, Month.JANUARY, 13));
+    }
+
+    @Test
+    public void testAmazighNewYearDiffersBetweenMaAndMad2024() {
+        // MA rolls Jan 14, 2024 (Sunday) to Jan 15; MAD stays Jan 14
+        HolidayCalendar maCalendar = new HolidayCalendarServiceMA().getHolidayCalendar();
+        Optional<HolidayDate> madAny = findFirst("Amazigh New Year", 2024);
+        Optional<HolidayDate> maAny  = maCalendar.calculate(2024).stream()
+                .filter(hd -> "Amazigh New Year".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(madAny.isPresent());
+        assertTrue(maAny.isPresent());
+        assertNotEquals(madAny.get().date(), maAny.get().date(),
+                "MAD Amazigh New Year 2024 must differ from MA (no-roll vs followingMonday)");
+        assertEquals(madAny.get().date(), LocalDate.of(2024, Month.JANUARY, 14));
+        assertEquals(maAny.get().date(), LocalDate.of(2024, Month.JANUARY, 15));
+    }
+
+    // ── KEY EDGE CASE: Islamic holidays on weekend must not roll in MAD ───────
+
+    // Eid al-Adha 2025 = Saturday Jun 7 — must stay Jun 7
+    @Test
+    public void testEidAlAdha2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 7).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: June 7, 2025 must be a Saturday");
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "MAD Eid al-Adha 2025 must be 2025-06-07 per CSE AV-2025-078 — no-roll preserves Saturday date");
+    }
+
+    // Eid al-Adha Day 2, 2025 = Sunday Jun 8 — must stay Jun 8
+    @Test
+    public void testEidAlAdhaDay2_2025OnSundayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 8).getDayOfWeek(), DayOfWeek.SUNDAY,
+                "Pre-condition: June 8, 2025 must be a Sunday");
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2025);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2025, Month.JUNE, 8),
+                "MAD Eid al-Adha (2nd Day) 2025 must be 2025-06-08 (Sunday) — no-roll preserves date");
+    }
+
+    // Mawlid Day 2, 2025 = Saturday Sep 6 — must stay Sep 6
+    @Test
+    public void testProphetsBirthdayDay2_2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: September 6, 2025 must be a Saturday");
+        Optional<HolidayDate> pb2 = findFirst("Prophet's Birthday (2nd Day)", 2025);
+        assertTrue(pb2.isPresent());
+        assertEquals(pb2.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 6),
+                "MAD Prophet's Birthday (2nd Day) 2025 must be 2025-09-06 (Saturday) — no-roll preserves date");
+    }
+
+    // ── Islamic dates match MA (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testMadIslamicDatesMatchMa() {
+        HolidayCalendarServiceMA maService = new HolidayCalendarServiceMA();
+        for (String name : new String[]{
+                "Eid al-Fitr", "Eid al-Fitr (2nd Day)",
+                "Eid al-Adha", "Eid al-Adha (2nd Day)",
+                "Islamic New Year",
+                "Prophet's Birthday", "Prophet's Birthday (2nd Day)"}) {
+            for (int year : new int[]{2024, 2025}) {
+                Optional<HolidayDate> mad = findFirst(name, year);
+                Optional<HolidayDate> ma  = maService.getHolidayCalendar().calculate(year).stream()
+                        .filter(hd -> name.equals(hd.holiday().getName()))
+                        .findFirst();
+                assertTrue(mad.isPresent(), year + " MAD must contain " + name);
+                assertTrue(ma.isPresent(),  year + " MA must contain " + name);
+                assertEquals(mad.get().date(), ma.get().date(),
+                        year + " MAD and MA must share the same " + name + " date (same CSV source, both rollable=false)");
+            }
+        }
+    }
+
+    // ── Amazigh New Year ──────────────────────────────────────────────────────
+
+    @Test
+    public void testAmazighNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Amazigh New Year".equals(h.getName()));
+        assertTrue(found, "Amazigh New Year must be included in the MAD calendar");
+    }
+
+    @Test
+    public void testAmazighNewYear2025() {
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2025);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2025, Month.JANUARY, 14),
+                "MAD Amazigh New Year 2025 must be Jan 14 (Tuesday, no roll needed)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "MAD calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("MAD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"MAD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), MAD_HOLIDAY_COUNT,
+                "Expected all " + MAD_HOLIDAY_COUNT + " MAD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), MAD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + MAD_FIXED_HOLIDAY_COUNT +
+                " fixed Morocco holidays must remain (10 Gregorian)");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Manifesto of Independence Day"},
+            new Object[]{"Amazigh New Year"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Throne Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Oued Ed-Dahab Allegiance Day"},
+            new Object[]{"Revolution of the King and the People"},
+            new Object[]{"Youth Day"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Prophet's Birthday (2nd Day)"},
+            new Object[]{"Green March Anniversary"},
+            new Object[]{"Independence Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "MAD calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMATest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMATest.java
@@ -1,0 +1,515 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceMATest {
+
+    // 10 fixed Gregorian + 2 Eid al-Fitr + 2 Eid al-Adha
+    // + Islamic New Year + Prophet's Birthday × 2 = 17
+    private static final int MA_HOLIDAY_COUNT = 17;
+
+    // Beyond CSV ceiling: 10 fixed Gregorian holidays survive
+    private static final int MA_FIXED_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceMA service = new HolidayCalendarServiceMA();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("MA"));
+        assertFalse(service.isProvided("MAD"));
+        assertFalse(service.isProvided("EG"));
+        assertFalse(service.isProvided("BH"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "MA");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Morocco (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("MA");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "MA");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysSaturdayAndSunday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Morocco weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must NOT be a weekend day — Morocco uses Sat/Sun weekend");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), MA_HOLIDAY_COUNT,
+                "Expected " + MA_HOLIDAY_COUNT + " holidays for " + year +
+                ", got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ───────────────────────────────────
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // May 1, 2025 is Thursday — must not roll
+    @Test
+    public void testLabourDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.MAY, 1).getDayOfWeek(), DayOfWeek.THURSDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2025);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2025, Month.MAY, 1),
+                "Labour Day 2025 (Thursday) must not roll");
+    }
+
+    // Jul 30, 2025 is Wednesday — must not roll
+    @Test
+    public void testThroneDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JULY, 30).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> td = findFirst("Throne Day", 2025);
+        assertTrue(td.isPresent());
+        assertEquals(td.get().date(), LocalDate.of(2025, Month.JULY, 30),
+                "Throne Day 2025 (Wednesday) must not roll");
+    }
+
+    // ── fixed holidays — Saturday/Sunday roll to following Monday ─────────────
+
+    // Jan 11, 2025 is Saturday → rolls to Monday Jan 13
+    @Test
+    public void testManifestoDay2025OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 11).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> md = findFirst("Manifesto of Independence Day", 2025);
+        assertTrue(md.isPresent());
+        assertEquals(md.get().date(), LocalDate.of(2025, Month.JANUARY, 13),
+                "Manifesto of Independence Day 2025 (Saturday) must roll to Monday Jan 13");
+    }
+
+    // Jan 14, 2024 is Sunday → rolls to Monday Jan 15
+    @Test
+    public void testAmazighNewYear2024OnSundayRollsToMonday() {
+        assertEquals(LocalDate.of(2024, Month.JANUARY, 14).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2024);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2024, Month.JANUARY, 15),
+                "Amazigh New Year 2024 (Sunday) must roll to Monday Jan 15");
+    }
+
+    // Jan 14, 2025 is Tuesday — must not roll
+    @Test
+    public void testAmazighNewYear2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 14).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2025);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2025, Month.JANUARY, 14),
+                "Amazigh New Year 2025 (Tuesday) must not roll");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Monday Jan 3
+    @Test
+    public void testNewYearsDay2028OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 3),
+                "New Year's Day 2028 (Saturday) must roll to Monday Jan 3");
+    }
+
+    // Aug 14, 2027 is Saturday → rolls to Monday Aug 16
+    @Test
+    public void testOuedEdDahab2027OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2027, Month.AUGUST, 14).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> odd = findFirst("Oued Ed-Dahab Allegiance Day", 2027);
+        assertTrue(odd.isPresent());
+        assertEquals(odd.get().date(), LocalDate.of(2027, Month.AUGUST, 16),
+                "Oued Ed-Dahab Allegiance Day 2027 (Saturday) must roll to Monday Aug 16");
+    }
+
+    // Nov 18, 2028 is Saturday → rolls to Monday Nov 20
+    @Test
+    public void testIndependenceDay2028OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2028, Month.NOVEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2028);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2028, Month.NOVEMBER, 20),
+                "Independence Day 2028 (Saturday) must roll to Monday Nov 20");
+    }
+
+    // ── Islamic holidays — rollable(false): never roll even on weekend ─────────
+
+    // KEY EDGE CASE: Eid al-Adha 2025 = Saturday Jun 7 — must NOT roll despite MA using followingMonday
+    @Test
+    public void testEidAlAdha2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 7).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: June 7, 2025 must be a Saturday");
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "Eid al-Adha 2025 (Saturday) must stay Jun 7 — Islamic holidays are rollable(false) in MA");
+    }
+
+    // Eid al-Adha Day 2, 2025 = Sunday Jun 8 — must NOT roll
+    @Test
+    public void testEidAlAdhaDay2_2025OnSundayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 8).getDayOfWeek(), DayOfWeek.SUNDAY,
+                "Pre-condition: June 8, 2025 must be a Sunday");
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2025);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2025, Month.JUNE, 8),
+                "Eid al-Adha (2nd Day) 2025 (Sunday) must stay Jun 8 — rollable(false)");
+    }
+
+    // Islamic New Year 2025 = Friday Jun 27 — must NOT roll (Friday is not a Morocco weekend)
+    @Test
+    public void testIslamicNewYear2025OnFriday() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 27).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 27),
+                "Islamic New Year 2025 must be 2025-06-27 per CSE AV-2025-078");
+    }
+
+    // ── Islamic holiday spot-checks (official 2024–2025 dates) ───────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per official announcement");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11),
+                "Eid al-Fitr (2nd Day) 2024 must be 2024-04-11");
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 31),
+                "Eid al-Fitr 2025 must be 2025-03-31 per CSE AV-2025-078 (one day after GCC consensus)");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2025() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2025);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2025, Month.APRIL, 1),
+                "Eid al-Fitr (2nd Day) 2025 must be 2025-04-01");
+    }
+
+    @Test
+    public void testEidAlFitrDay2IsOneDayAfterDay1() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Fitr", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Fitr (2nd Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Fitr Day 1 must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Fitr Day 2 must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Fitr (2nd Day) must be exactly one day after Day 1");
+        }
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per official announcement");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "Eid al-Adha 2025 must be 2025-06-07 per CSE AV-2025-078 (one day after GCC consensus)");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2IsOneDayAfterDay1() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Adha", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Adha (2nd Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Adha Day 1 must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Adha Day 2 must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Adha (2nd Day) must be exactly one day after Day 1");
+        }
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per official announcement");
+    }
+
+    @Test
+    public void testIslamicNewYear2025() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 27),
+                "Islamic New Year 2025 must be 2025-06-27 per CSE AV-2025-078");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per official announcement");
+    }
+
+    // Mawlid 2025: Day 1 = Fri Sep 5 (natural date, observed as-is)
+    @Test
+    public void testProphetsBirthday2025OnFriday() {
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 5).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2025);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 5),
+                "Prophet's Birthday 2025 must be 2025-09-05 per CSE AV-2025-078");
+    }
+
+    // Mawlid Day 2, 2025 = Sat Sep 6 — must NOT roll (Islamic rollable=false)
+    @Test
+    public void testProphetsBirthdayDay2_2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: September 6, 2025 must be a Saturday");
+        Optional<HolidayDate> pb2 = findFirst("Prophet's Birthday (2nd Day)", 2025);
+        assertTrue(pb2.isPresent());
+        assertEquals(pb2.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 6),
+                "Prophet's Birthday (2nd Day) 2025 (Saturday) must stay Sep 6 — rollable(false)");
+    }
+
+    @Test
+    public void testProphetsBirthdayDay2IsOneDayAfterDay1() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Prophet's Birthday", year);
+            Optional<HolidayDate> day2 = findFirst("Prophet's Birthday (2nd Day)", year);
+            assertTrue(day1.isPresent(), year + ": Prophet's Birthday Day 1 must be present");
+            assertTrue(day2.isPresent(), year + ": Prophet's Birthday (2nd Day) must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Prophet's Birthday (2nd Day) must be exactly one day after Day 1");
+        }
+    }
+
+    // ── Amazigh New Year presence ─────────────────────────────────────────────
+
+    @Test
+    public void testAmazighNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Amazigh New Year".equals(h.getName()));
+        assertTrue(found,
+                "Amazigh New Year (Jan 14, added 2024) must be included in the MA calendar");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "MA calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("MA");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"MA\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), MA_HOLIDAY_COUNT,
+                "Expected all " + MA_HOLIDAY_COUNT + " MA holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), MA_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + MA_FIXED_HOLIDAY_COUNT +
+                " fixed Morocco holidays must remain (10 Gregorian)");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date().getMonth(), Month.JANUARY,
+                "The single 2033 Eid al-Fitr occurrence must be in January");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Manifesto of Independence Day"},
+            new Object[]{"Amazigh New Year"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Throne Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Oued Ed-Dahab Allegiance Day"},
+            new Object[]{"Revolution of the King and the People"},
+            new Object[]{"Youth Day"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Prophet's Birthday (2nd Day)"},
+            new Object[]{"Green March Anniversary"},
+            new Object[]{"Independence Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -18,43 +18,45 @@ Key design goals:
 
 ### Supported Calendars
 
-| Code | Region |
-|------|--------|
-| `AE` | UAE (National) Holidays |
-| `AED` | UAE (CBUAE/DFM/ADX) Holidays |
+| Code | Region                                        |
+|------|-----------------------------------------------|
+| `AE` | United Arab Emirates (National) Holidays      |
+| `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays |
-| `BH` | Bahrain (National) Holidays |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
-| `CA` | Canada National Holidays |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
-| `CH` | Switzerland (SIX) Holidays |
-| `CHF` | Switzerland (SIC/SNB) Holidays |
-| `CN` | China National Holidays |
-| `CNY` | China (PBOC) Holidays |
-| `DE` | Germany (Xetra) Holidays |
-| `EG` | Egypt (National) Holidays |
-| `EGP` | Egypt (EGX/CBE) Holidays |
-| `EUR` | Euro (TARGET2) Holidays |
-| `FR` | France (Euronext Paris) Holidays |
-| `GBP` | United Kingdom (CHAPS) Holidays |
-| `IL` | Israel (National) Holidays |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays |
-| `KW` | Kuwait (National) Holidays |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
-| `JP` | Japan (TSE) Holidays |
-| `JPY` | Japan (BOJ) Holidays |
-| `QA` | Qatar (National) Holidays |
-| `QAR` | Qatar (QSE/QCB) Holidays |
-| `SA` | Saudi Arabia (National) Holidays |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
-| `SG` | Singapore (SGX) Holidays |
-| `SGD` | Singapore (MAS/MEPS+) Holidays |
-| `TR`  | Turkey (National) Holidays |
-| `TRY` | Turkey (BIST/TCMB) Holidays |
-| `UK` | United Kingdom National Holidays |
-| `US` | United States National Holidays |
-| `USD` | United States (Federal Reserve) Holidays |
+| `AUD` | Australia (RBA) Holidays                      |
+| `BH` | Bahrain (National) Holidays                   |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
+| `CA` | Canada National Holidays                      |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
+| `CH` | Switzerland (SIX) Holidays                    |
+| `CHF` | Switzerland (SIC/SNB) Holidays                |
+| `CN` | China National Holidays                       |
+| `CNY` | China (PBOC) Holidays                         |
+| `DE` | Germany (Xetra) Holidays                      |
+| `EG` | Egypt (National) Holidays                     |
+| `EGP` | Egypt (EGX/CBE) Holidays                      |
+| `EUR` | Euro (TARGET2) Holidays                       |
+| `FR` | France (Euronext Paris) Holidays              |
+| `GBP` | United Kingdom (CHAPS) Holidays               |
+| `IL` | Israel (National) Holidays                    |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
+| `JP` | Japan (TSE) Holidays                          |
+| `JPY` | Japan (BOJ) Holidays                          |
+| `MA` | Morocco (National) Holidays                   |
+| `MAD` | Morocco (CSE/BAM) Holidays                    |
+| `QA` | Qatar (National) Holidays                     |
+| `QAR` | Qatar (QSE/QCB) Holidays                      |
+| `SA` | Saudi Arabia (National) Holidays              |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
+| `SG` | Singapore (SGX) Holidays                      |
+| `SGD` | Singapore (MAS/MEPS+) Holidays                |
+| `TR`  | Turkey (National) Holidays                    |
+| `TRY` | Turkey (BIST/TCMB) Holidays                   |
+| `UK` | United Kingdom National Holidays              |
+| `US` | United States National Holidays               |
+| `USD` | United States (Federal Reserve) Holidays      |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 
@@ -98,7 +100,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -145,7 +147,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar


### PR DESCRIPTION
### #166 Added Morocco holiday calendars MA, MAD + tests

**Description**

- Added `MA` (Morocco National) and `MAD` (Morocco CSE/Bank Al-Maghrib) holiday calendar services to `holiday-calendar-mena`
- Created `ProphetsBirthdayDay2` observance class (Morocco observes 2-day Mawlid — no such class existed)
- Created `MoroccoHolidays` factory following the `TurkeyHolidays` pattern with `baseHolidays(boolean rollableFixed)` — 17 holidays (10 fixed Gregorian + 7 Islamic)
- `MA` uses `DateRolls.followingMonday()` with `rollable(true)` for fixed holidays; Islamic holidays are `rollable(false)` (consistent with every other national calendar in the module)
- `MAD` uses `DateRolls.noRoll()` throughout, confirmed by official CSE circular AV-2025-078
- Weekend: Saturday + Sunday for both (Morocco switched to Mon–Fri workweek in 2004; confirmed by CSE notice)
- 4 CSV files with official Moroccan/CSE dates for 2024–2025 and Umm al-Qura projections through 2055; Morocco's 2025 Islamic dates are 1 day after GCC consensus (independent moon sighting)
- Updated `module-info.java`, `META-INF/services`, and `src/readme/README.md` (3 spots)

**Related Issue**

- Closes #166

**Type of Change**

- [x] New feature

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally (917 MENA suite tests pass; 105 MA+MAD tests)
- [x] Documentation has been updated, if needed
- [x] Screenshots or additional notes added, if needed