### PR TITLE
#167 Added Jordan holiday calendars JO, JOD + tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,40 +23,42 @@ Key design goals:
 | `AE` | United Arab Emirates (National) Holidays      |
 | `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays                      |
-| `BH` | Bahrain (National) Holidays                   |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
-| `CA` | Canada National Holidays                      |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
-| `CH` | Switzerland (SIX) Holidays                    |
-| `CHF` | Switzerland (SIC/SNB) Holidays                |
-| `CN` | China National Holidays                       |
-| `CNY` | China (PBOC) Holidays                         |
-| `DE` | Germany (Xetra) Holidays                      |
-| `EG` | Egypt (National) Holidays                     |
-| `EGP` | Egypt (EGX/CBE) Holidays                      |
-| `EUR` | Euro (TARGET2) Holidays                       |
-| `FR` | France (Euronext Paris) Holidays              |
-| `GBP` | United Kingdom (CHAPS) Holidays               |
-| `IL` | Israel (National) Holidays                    |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
-| `KW` | Kuwait (National) Holidays                    |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
-| `JP` | Japan (TSE) Holidays                          |
-| `JPY` | Japan (BOJ) Holidays                          |
+| `AUD` | Australia (RBA) Holidays |
+| `BH` | Bahrain (National) Holidays |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
+| `CA` | Canada National Holidays |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
+| `CH` | Switzerland (SIX) Holidays |
+| `CHF` | Switzerland (SIC/SNB) Holidays |
+| `CN` | China National Holidays |
+| `CNY` | China (PBOC) Holidays |
+| `DE` | Germany (Xetra) Holidays |
+| `EG` | Egypt (National) Holidays |
+| `EGP` | Egypt (EGX/CBE) Holidays |
+| `EUR` | Euro (TARGET2) Holidays |
+| `FR` | France (Euronext Paris) Holidays |
+| `GBP` | United Kingdom (CHAPS) Holidays |
+| `IL` | Israel (National) Holidays |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `JO` | Jordan (National) Holidays |
+| `JOD` | Jordan (ASE/CBJ) Holidays |
+| `JP` | Japan (TSE) Holidays |
+| `JPY` | Japan (BOJ) Holidays |
+| `KW` | Kuwait (National) Holidays |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
 | `MA` | Morocco (National) Holidays                   |
 | `MAD` | Morocco (CSE/BAM) Holidays                    |
-| `QA` | Qatar (National) Holidays                     |
-| `QAR` | Qatar (QSE/QCB) Holidays                      |
-| `SA` | Saudi Arabia (National) Holidays              |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
-| `SG` | Singapore (SGX) Holidays                      |
-| `SGD` | Singapore (MAS/MEPS+) Holidays                |
-| `TR`  | Turkey (National) Holidays                    |
-| `TRY` | Turkey (BIST/TCMB) Holidays                   |
-| `UK` | United Kingdom National Holidays              |
-| `US` | United States National Holidays               |
-| `USD` | United States (Federal Reserve) Holidays      |
+| `QA` | Qatar (National) Holidays |
+| `QAR` | Qatar (QSE/QCB) Holidays |
+| `SA` | Saudi Arabia (National) Holidays |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
+| `SG` | Singapore (SGX) Holidays |
+| `SGD` | Singapore (MAS/MEPS+) Holidays |
+| `TR`  | Turkey (National) Holidays |
+| `TRY` | Turkey (BIST/TCMB) Holidays |
+| `UK` | United Kingdom National Holidays |
+| `US` | United States National Holidays |
+| `USD` | United States (Federal Reserve) Holidays |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 
@@ -100,7 +102,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -147,7 +149,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JO", "JOD", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/README.md
+++ b/README.md
@@ -23,42 +23,42 @@ Key design goals:
 | `AE` | United Arab Emirates (National) Holidays      |
 | `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays |
-| `BH` | Bahrain (National) Holidays |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
-| `CA` | Canada National Holidays |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
-| `CH` | Switzerland (SIX) Holidays |
-| `CHF` | Switzerland (SIC/SNB) Holidays |
-| `CN` | China National Holidays |
-| `CNY` | China (PBOC) Holidays |
-| `DE` | Germany (Xetra) Holidays |
-| `EG` | Egypt (National) Holidays |
-| `EGP` | Egypt (EGX/CBE) Holidays |
-| `EUR` | Euro (TARGET2) Holidays |
-| `FR` | France (Euronext Paris) Holidays |
-| `GBP` | United Kingdom (CHAPS) Holidays |
-| `IL` | Israel (National) Holidays |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `AUD` | Australia (RBA) Holidays                      |
+| `BH` | Bahrain (National) Holidays                   |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
+| `CA` | Canada National Holidays                      |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
+| `CH` | Switzerland (SIX) Holidays                    |
+| `CHF` | Switzerland (SIC/SNB) Holidays                |
+| `CN` | China National Holidays                       |
+| `CNY` | China (PBOC) Holidays                         |
+| `DE` | Germany (Xetra) Holidays                      |
+| `EG` | Egypt (National) Holidays                     |
+| `EGP` | Egypt (EGX/CBE) Holidays                      |
+| `EUR` | Euro (TARGET2) Holidays                       |
+| `FR` | France (Euronext Paris) Holidays              |
+| `GBP` | United Kingdom (CHAPS) Holidays               |
+| `IL` | Israel (National) Holidays                    |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
 | `JO` | Jordan (National) Holidays |
 | `JOD` | Jordan (ASE/CBJ) Holidays |
-| `JP` | Japan (TSE) Holidays |
-| `JPY` | Japan (BOJ) Holidays |
-| `KW` | Kuwait (National) Holidays |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
+| `JP` | Japan (TSE) Holidays                          |
+| `JPY` | Japan (BOJ) Holidays                          |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
 | `MA` | Morocco (National) Holidays                   |
 | `MAD` | Morocco (CSE/BAM) Holidays                    |
-| `QA` | Qatar (National) Holidays |
-| `QAR` | Qatar (QSE/QCB) Holidays |
-| `SA` | Saudi Arabia (National) Holidays |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
-| `SG` | Singapore (SGX) Holidays |
-| `SGD` | Singapore (MAS/MEPS+) Holidays |
-| `TR`  | Turkey (National) Holidays |
-| `TRY` | Turkey (BIST/TCMB) Holidays |
-| `UK` | United Kingdom National Holidays |
-| `US` | United States National Holidays |
-| `USD` | United States (Federal Reserve) Holidays |
+| `QA` | Qatar (National) Holidays                     |
+| `QAR` | Qatar (QSE/QCB) Holidays                      |
+| `SA` | Saudi Arabia (National) Holidays              |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
+| `SG` | Singapore (SGX) Holidays                      |
+| `SGD` | Singapore (MAS/MEPS+) Holidays                |
+| `TR`  | Turkey (National) Holidays                    |
+| `TRY` | Turkey (BIST/TCMB) Holidays                   |
+| `UK` | United Kingdom National Holidays              |
+| `US` | United States National Holidays               |
+| `USD` | United States (Federal Reserve) Holidays      |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -48,5 +48,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceBH,
         org.holiday.calendar.impl.HolidayCalendarServiceBHD,
         org.holiday.calendar.impl.HolidayCalendarServiceMA,
-        org.holiday.calendar.impl.HolidayCalendarServiceMAD;
+        org.holiday.calendar.impl.HolidayCalendarServiceMAD,
+        org.holiday.calendar.impl.HolidayCalendarServiceJO,
+        org.holiday.calendar.impl.HolidayCalendarServiceJOD;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJO.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJO.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Jordan national public holiday calendar.
+ *
+ * <p>Calendar code: {@code JO}. Covers public holidays observed in the Hashemite
+ * Kingdom of Jordan as declared by the Jordanian government.
+ *
+ * <p>Weekend: Friday + Saturday. Fixed holidays that fall on Friday or Saturday
+ * are observed on the following Sunday per {@link DateRolls#followingSunday()}.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-jo.csv},
+ * {@code eid-al-adha-jo.csv}, {@code arafat-day-jo.csv},
+ * {@code islamic-new-year-jo.csv}, and {@code mawlid-jo.csv}. Dates for 2024–2026
+ * are official CBJ / ASE announcements; 2027–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Jordan determines Islamic holiday dates by moon
+ * sighting (Ministry of Awqaf / Higher Judiciary Council) and may differ from Saudi
+ * Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceJO extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "JO";
+    private static final String NAME = "Jordan (National) Holidays";
+
+    public HolidayCalendarServiceJO() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(JordanHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // Jordan weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(JordanHolidays.JORDAN_WEEKEND)
+                .holidays(JordanHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJOD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJOD.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Jordan exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code JOD}. Covers market closure days for the Amman Stock
+ * Exchange (ASE) and Central Bank of Jordan (CBJ) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday. Fixed holidays are not rolled — the settlement
+ * calendar uses natural calendar dates per {@link DateRolls#noRoll()}, consistent
+ * with the AED, SAR, KWD, QAR, BHD, and EGP convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-jo.csv},
+ * {@code eid-al-adha-jo.csv}, {@code arafat-day-jo.csv},
+ * {@code islamic-new-year-jo.csv}, and {@code mawlid-jo.csv}. Dates for 2024–2026
+ * are official CBJ / ASE announcements; 2027–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Jordan determines Islamic holiday dates by moon
+ * sighting (Ministry of Awqaf / Higher Judiciary Council) and may differ from Saudi
+ * Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceJOD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "JOD";
+    private static final String NAME = "Jordan (ASE/CBJ) Holidays";
+
+    public HolidayCalendarServiceJOD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(JordanHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(JordanHolidays.JORDAN_WEEKEND)
+                .holidays(JordanHolidays.jodHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/JordanHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/JordanHolidays.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay4;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay4;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Jordan public holiday lists for the
+ * national ({@code JO}) and settlement ({@code JOD}) calendars.
+ *
+ * <p>The national calendar ({@code JO}) observes 15 public holidays: New Year's
+ * Day, Labour Day, Independence Day, Christmas Day (fixed Gregorian), four days of
+ * Eid al-Fitr, Arafat Day, four days of Eid al-Adha, Islamic New Year, and
+ * Prophet's Birthday (floating Islamic).
+ *
+ * <p>The settlement calendar ({@code JOD}) uses the identical holiday set with
+ * {@code rollable(false)} for all holidays — the Amman Stock Exchange (ASE) and
+ * Central Bank of Jordan (CBJ) apply no date adjustment per the no-roll convention.
+ *
+ * <p>Jordan observes four days of Eid al-Fitr (1–4 Shawwal) and four days of
+ * Eid al-Adha (10–13 Dhu al-Hijjah), with Arafat Day (9 Dhu al-Hijjah) as a
+ * separate public holiday. These durations are confirmed by official ASE and CBJ
+ * holiday announcements for 2024–2026.
+ *
+ * <p>Christmas Day (December 25) is gazetted as a national public holiday in Jordan
+ * and is an ASE closure day, as confirmed by official ASE holiday schedules for
+ * 2025 and 2026.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code jo}). Dates for 2024–2026
+ * are sourced from official CBJ and ASE holiday announcements; dates for 2027–2055
+ * are projected from the Umm al-Qura tabular Islamic calendar. Jordan determines
+ * Islamic holiday dates by moon sighting (Ministry of Awqaf / Higher Judiciary
+ * Council) and may differ from Saudi Arabia by ±1 day; verify against official
+ * CBJ / ASE announcements as each year is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class JordanHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // Jordan market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> JORDAN_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private JordanHolidays() {}
+
+    /**
+     * Returns the 15 Jordan public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, Labour Day,
+     *                      Independence Day, Christmas Day) are rollable; all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (4th Day)")
+                    .description("Fourth day of Eid al-Fitr (4 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay4("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Independence Day")
+                    .description("Jordanian Independence Day, marking independence from the British Mandate on 25 May 1946")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (4th Day)")
+                    .description("Fourth day of Eid al-Adha (13 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay4("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Christmas Day; gazetted national public holiday in Jordan and ASE closure day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 15 JOD holidays: the base holiday set with all holidays
+     * {@code rollable(false)}, for use with {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> jodHolidays() {
+        return baseHolidays(false);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay4.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay4.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of the fourth day of Eid al-Fitr (4 Shawwal AH), marking the
+ * final day of the Eid al-Fitr celebration.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlFitr})
+ * by three calendar days. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * <p>Jordan observes four days of Eid al-Fitr per official ASE and CBJ holiday
+ * announcements.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class EidAlFitrDay4 extends AbstractObservance {
+
+    private final EidAlFitr base;
+
+    public EidAlFitrDay4(String countryCode) {
+        this.base = new EidAlFitr(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(3);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -16,3 +16,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceBH
 org.holiday.calendar.impl.HolidayCalendarServiceBHD
 org.holiday.calendar.impl.HolidayCalendarServiceMA
 org.holiday.calendar.impl.HolidayCalendarServiceMAD
+org.holiday.calendar.impl.HolidayCalendarServiceJO
+org.holiday.calendar.impl.HolidayCalendarServiceJOD

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-jo.csv
@@ -1,0 +1,55 @@
+# Arafat Day (9 Dhu al-Hijjah) — Jordan public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2026: ASE official holiday announcements; Arafat Day falls one day before
+#            Eid al-Adha in all three years. Note: 2024 Arafat Day (Jun 15) falls
+#            on a Saturday (Jordan weekend); no additional settlement closure arises
+#            under the no-roll convention for JOD.
+# 2027–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-jo.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,ASE official
+2025,2025-06-05,ASE official
+2026,2026-05-26,ASE official
+# 2027–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-jo.csv
@@ -1,0 +1,54 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Jordan public holiday dates
+# The Feast of Sacrifice. The observed date follows the official announcement
+# by the Jordanian government (Ministry of Awqaf / Higher Judiciary Council).
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2026: CBJ / ASE official holiday announcements; aligned with Umm al-Qura
+#            in all three years.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH).
+#            Verify against official CBJ / ASE announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBJ official
+2025,2025-06-06,ASE official
+2026,2026-05-27,ASE official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-jo.csv
@@ -1,0 +1,53 @@
+# Eid al-Fitr (1 Shawwal) — Jordan public holiday dates
+# Marks the end of Ramadan. The observed date follows the official announcement
+# by the Jordanian government (Ministry of Awqaf / Higher Judiciary Council).
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBJ / ASE official holiday announcement; Jordan sighted moon one day
+#            earlier than Saudi Arabia (Apr 9 vs Apr 10).
+# 2025–2026: ASE official holiday announcements; aligned with Umm al-Qura in both years.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-09,CBJ official
+2025,2025-03-30,ASE official
+2026,2026-03-20,ASE official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-jo.csv
@@ -1,0 +1,52 @@
+# Islamic New Year (1 Muharram) — Jordan public holiday dates
+# First day of the Islamic lunar year.
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBJ / ASE official holiday announcements; aligned with Umm al-Qura
+#            in both years.
+# 2026:      Umm al-Qura tabular projection; verify against official CBJ / ASE
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBJ official
+2025,2025-06-26,ASE official
+2026,2026-06-16,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-jo.csv
@@ -1,0 +1,53 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Jordan public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBJ official announcement; Jordan date is Sep 16, one day later than
+#            the Bahrain / GCC consensus (Sep 15).
+# 2025–2026: ASE official holiday announcements; aligned with Umm al-Qura.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-16,CBJ official
+2025,2025-09-04,ASE official
+2026,2026-08-25,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJODTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJODTest.java
@@ -1,0 +1,361 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceJODTest {
+
+    // Same holiday set as JO — settlement calendar uses the national holiday set with no-roll.
+    // Keep in sync with JO_HOLIDAY_COUNT in HolidayCalendarServiceJOTest.
+    private static final int JOD_HOLIDAY_COUNT = 15;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int JOD_FIXED_HOLIDAY_COUNT = 4;
+
+    private final HolidayCalendarServiceJOD service = new HolidayCalendarServiceJOD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("JOD"));
+        assertFalse(service.isProvided("JO"));
+        assertFalse(service.isProvided("BHD"));
+        assertFalse(service.isProvided("EGP"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "JOD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Jordan (ASE/CBJ) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("JOD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "JOD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Jordan weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must not be a weekend day in Jordan");
+    }
+
+    // ── total count (S5976-compliant parameterized test) ──────────────────────
+
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), JOD_HOLIDAY_COUNT,
+                "Expected " + JOD_HOLIDAY_COUNT + " holidays for " + year +
+                ", got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── no-roll convention — fixed holidays stay on their natural dates ────────
+    //
+    // JOD uses DateRolls.noRoll(); all holidays have rollable(false).
+    // The same Fri/Sat collisions used in JO roll tests are the ideal no-roll
+    // verification points: JOD must return the NATURAL date, JO returns the rolled Sunday.
+
+    // May 25, 2024 is Saturday → JOD must NOT roll; JO rolls this to Sunday May 26
+    @Test
+    public void testIndependenceDayOnSaturdayNotRolled2024() {
+        assertEquals(LocalDate.of(2024, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2024);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2024, Month.MAY, 25),
+                "JOD must not roll Independence Day 2024 (Saturday) — settlement uses no-roll");
+    }
+
+    // May 1, 2026 is Friday → JOD must NOT roll; JO rolls this to Sunday May 3
+    @Test
+    public void testLabourDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 1),
+                "JOD must not roll Labour Day 2026 (Friday) — settlement uses no-roll");
+    }
+
+    // Dec 25, 2026 is Friday → JOD must NOT roll; JO rolls this to Sunday Dec 27
+    @Test
+    public void testChristmasDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cd = findFirst("Christmas Day", 2026);
+        assertTrue(cd.isPresent());
+        assertEquals(cd.get().date(), LocalDate.of(2026, Month.DECEMBER, 25),
+                "JOD must not roll Christmas Day 2026 (Friday) — settlement uses no-roll");
+    }
+
+    // Jan 1, 2027 is Friday → JOD must NOT roll; JO rolls this to Sunday Jan 3
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "JOD must not roll New Year's Day 2027 (Friday) — settlement uses no-roll");
+    }
+
+    // Jan 1, 2028 is Saturday → JOD must NOT roll; JO rolls this to Sunday Jan 2
+    @Test
+    public void testNewYearsDayOnSaturdayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 1),
+                "JOD must not roll New Year's Day 2028 (Saturday) — settlement uses no-roll");
+    }
+
+    // ── JOD differs from JO on rolled fixed holidays ──────────────────────────
+
+    @Test
+    public void testIndependenceDay2024DiffersBetweenJoAndJod() {
+        HolidayCalendar joCalendar = new HolidayCalendarServiceJO().getHolidayCalendar();
+        Optional<HolidayDate> jodDate = findFirst("Independence Day", 2024);
+        Optional<HolidayDate> joDate  = joCalendar.calculate(2024).stream()
+                .filter(hd -> "Independence Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(jodDate.isPresent());
+        assertTrue(joDate.isPresent());
+        assertNotEquals(jodDate.get().date(), joDate.get().date(),
+                "JOD Independence Day 2024 must differ from JO (no-roll vs roll-to-Sunday)");
+        assertEquals(jodDate.get().date(), LocalDate.of(2024, Month.MAY, 25));
+        assertEquals(joDate.get().date(),  LocalDate.of(2024, Month.MAY, 26));
+    }
+
+    @Test
+    public void testLabourDay2026DiffersBetweenJoAndJod() {
+        HolidayCalendar joCalendar = new HolidayCalendarServiceJO().getHolidayCalendar();
+        Optional<HolidayDate> jodDate = findFirst("Labour Day", 2026);
+        Optional<HolidayDate> joDate  = joCalendar.calculate(2026).stream()
+                .filter(hd -> "Labour Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(jodDate.isPresent());
+        assertTrue(joDate.isPresent());
+        assertNotEquals(jodDate.get().date(), joDate.get().date(),
+                "JOD Labour Day 2026 must differ from JO (no-roll vs roll-to-Sunday)");
+        assertEquals(jodDate.get().date(), LocalDate.of(2026, Month.MAY, 1));
+        assertEquals(joDate.get().date(),  LocalDate.of(2026, Month.MAY, 3));
+    }
+
+    // ── Islamic dates match JO (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testJodIslamicDatesMatchJo() {
+        HolidayCalendarServiceJO joService = new HolidayCalendarServiceJO();
+        for (String name : new String[]{
+                "Eid al-Fitr", "Eid al-Fitr (2nd Day)", "Eid al-Fitr (3rd Day)", "Eid al-Fitr (4th Day)",
+                "Arafat Day",
+                "Eid al-Adha", "Eid al-Adha (2nd Day)", "Eid al-Adha (3rd Day)", "Eid al-Adha (4th Day)",
+                "Islamic New Year", "Prophet's Birthday"}) {
+            for (int year : new int[]{2024, 2025}) {
+                Optional<HolidayDate> jod = findFirst(name, year);
+                Optional<HolidayDate> jo  = joService.getHolidayCalendar().calculate(year).stream()
+                        .filter(hd -> name.equals(hd.holiday().getName()))
+                        .findFirst();
+                assertTrue(jod.isPresent(), year + " JOD must contain " + name);
+                assertTrue(jo.isPresent(),  year + " JO must contain " + name);
+                assertEquals(jod.get().date(), jo.get().date(),
+                        year + " JOD and JO must share the same " + name + " date (same CSV source)");
+            }
+        }
+    }
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 9),
+                "JOD Eid al-Fitr 2024 must match CBJ official date");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "JOD Eid al-Adha 2024 must match CBJ official date");
+    }
+
+    // ── JOD holiday count equals JO (same holiday set, only rolling differs) ──
+
+    @Test
+    public void testJodHolidayCountEqualsJo() {
+        HolidayCalendarServiceJO joService = new HolidayCalendarServiceJO();
+        for (int year : new int[]{2024, 2025, 2026}) {
+            int joCount  = joService.getHolidayCalendar().calculate(year).size();
+            int jodCount = service.getHolidayCalendar().calculate(year).size();
+            assertEquals(jodCount, joCount,
+                    year + ": JOD holiday count must equal JO count");
+        }
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "JOD calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("JOD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"JOD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), JOD_HOLIDAY_COUNT,
+                "Expected all " + JOD_HOLIDAY_COUNT + " JOD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted)");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), JOD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + JOD_FIXED_HOLIDAY_COUNT +
+                " fixed JOD holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Fitr (4th Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Independence Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Eid al-Adha (4th Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Christmas Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "JOD calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJOTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJOTest.java
@@ -1,0 +1,544 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceJOTest {
+
+    // 4 fixed (New Year's Day, Labour Day, Independence Day, Christmas Day)
+    // + 4 Eid al-Fitr + Arafat Day + 4 Eid al-Adha
+    // + Islamic New Year + Prophet's Birthday = 15
+    private static final int JO_HOLIDAY_COUNT = 15;
+
+    // Beyond CSV ceiling: 4 fixed Gregorian holidays survive
+    private static final int JO_FIXED_HOLIDAY_COUNT = 4;
+
+    private final HolidayCalendarServiceJO service = new HolidayCalendarServiceJO();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("JO"));
+        assertFalse(service.isProvided("JOD"));
+        assertFalse(service.isProvided("BH"));
+        assertFalse(service.isProvided("EG"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "JO");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Jordan (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("JO");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "JO");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Jordan weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must not be a weekend day in Jordan");
+    }
+
+    // ── total count (S5976-compliant parameterized test) ──────────────────────
+
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), JO_HOLIDAY_COUNT,
+                "Expected " + JO_HOLIDAY_COUNT + " holidays for " + year +
+                ", got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday or Sunday ─────────────────────────
+    //
+    // In Jordan, Sunday is the first business day; it must NEVER trigger a roll.
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // May 25, 2025 is Sunday — must NOT roll (Sunday is the first business day in Jordan)
+    @Test
+    public void testIndependenceDayOnSundayNotRolled2025() {
+        assertEquals(LocalDate.of(2025, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2025);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2025, Month.MAY, 25),
+                "Independence Day 2025 (Sunday) must not roll — Sunday is first business day in Jordan");
+    }
+
+    // Jun 10, 2025 is Tuesday — unused (Army Day not in Jordan calendar; verifies no such holiday exists)
+    @Test
+    public void testNoArmyDayHoliday() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> h.getName().contains("Army Day"));
+        assertFalse(found, "Jordan calendar must not contain Army Day — not a gazetted public holiday");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // May 25, 2024 is Saturday → rolls to Sunday May 26
+    @Test
+    public void testIndependenceDayRollFromSaturday2024() {
+        assertEquals(LocalDate.of(2024, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2024);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2024, Month.MAY, 26),
+                "Independence Day 2024 (Saturday) must roll to Sunday May 26");
+    }
+
+    // May 1, 2026 is Friday → rolls to Sunday May 3
+    @Test
+    public void testLabourDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 3),
+                "Labour Day 2026 (Friday) must roll to Sunday May 3");
+    }
+
+    // Dec 25, 2026 is Friday → rolls to Sunday Dec 27
+    @Test
+    public void testChristmasDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cd = findFirst("Christmas Day", 2026);
+        assertTrue(cd.isPresent());
+        assertEquals(cd.get().date(), LocalDate.of(2026, Month.DECEMBER, 27),
+                "Christmas Day 2026 (Friday) must roll to Sunday Dec 27");
+    }
+
+    // Jan 1, 2027 is Friday → rolls to Sunday Jan 3
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 3),
+                "New Year's Day 2027 (Friday) must roll to Sunday Jan 3");
+    }
+
+    // May 1, 2027 is Saturday → rolls to Sunday May 2
+    @Test
+    public void testLabourDayRollFromSaturday2027() {
+        assertEquals(LocalDate.of(2027, Month.MAY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2027);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2027, Month.MAY, 2),
+                "Labour Day 2027 (Saturday) must roll to Sunday May 2");
+    }
+
+    // Dec 25, 2027 is Saturday → rolls to Sunday Dec 26
+    @Test
+    public void testChristmasDayRollFromSaturday2027() {
+        assertEquals(LocalDate.of(2027, Month.DECEMBER, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> cd = findFirst("Christmas Day", 2027);
+        assertTrue(cd.isPresent());
+        assertEquals(cd.get().date(), LocalDate.of(2027, Month.DECEMBER, 26),
+                "Christmas Day 2027 (Saturday) must roll to Sunday Dec 26");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // May 25, 2029 is Friday → rolls to Sunday May 27
+    @Test
+    public void testIndependenceDayRollFromFriday2029() {
+        assertEquals(LocalDate.of(2029, Month.MAY, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2029);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2029, Month.MAY, 27),
+                "Independence Day 2029 (Friday) must roll to Sunday May 27");
+    }
+
+    // May 25, 2030 is Saturday → rolls to Sunday May 26
+    @Test
+    public void testIndependenceDayRollFromSaturday2030() {
+        assertEquals(LocalDate.of(2030, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2030);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2030, Month.MAY, 26),
+                "Independence Day 2030 (Saturday) must roll to Sunday May 26");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+    //
+    // 2024: sourced from CBJ / ASE official announcements.
+    // 2025–2026: sourced from ASE official announcements.
+    // Jordan determines Islamic holiday dates by moon sighting (Ministry of Awqaf /
+    // Higher Judiciary Council) and may differ from Saudi Arabia by ±1 day.
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 9),
+                "Eid al-Fitr 2024 must be 2024-04-09 per CBJ official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 10));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay4_2024() {
+        Optional<HolidayDate> eid4 = findFirst("Eid al-Fitr (4th Day)", 2024);
+        assertTrue(eid4.isPresent());
+        assertEquals(eid4.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per ASE official");
+    }
+
+    @Test
+    public void testEidAlFitr2026() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2026);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2026, Month.MARCH, 20),
+                "Eid al-Fitr 2026 must be 2026-03-20 per ASE official");
+    }
+
+    @Test
+    public void testEidAlFitrConsecutiveDays() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Fitr", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Fitr (2nd Day)", year);
+            Optional<HolidayDate> day3 = findFirst("Eid al-Fitr (3rd Day)", year);
+            Optional<HolidayDate> day4 = findFirst("Eid al-Fitr (4th Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Fitr must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Fitr (2nd Day) must be present");
+            assertTrue(day3.isPresent(), year + ": Eid al-Fitr (3rd Day) must be present");
+            assertTrue(day4.isPresent(), year + ": Eid al-Fitr (4th Day) must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Fitr (2nd Day) must be Day 1 + 1");
+            assertEquals(day3.get().date(), day1.get().date().plusDays(2),
+                    year + ": Eid al-Fitr (3rd Day) must be Day 1 + 2");
+            assertEquals(day4.get().date(), day1.get().date().plusDays(3),
+                    year + ": Eid al-Fitr (4th Day) must be Day 1 + 3");
+        }
+    }
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 per ASE official (falls on Saturday)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 per ASE official");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBJ official");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per ASE official");
+    }
+
+    @Test
+    public void testEidAlAdha2026() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2026);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2026, Month.MAY, 27),
+                "Eid al-Adha 2026 must be 2026-05-27 per ASE official");
+    }
+
+    @Test
+    public void testEidAlAdhaConsecutiveDays() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Adha", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Adha (2nd Day)", year);
+            Optional<HolidayDate> day3 = findFirst("Eid al-Adha (3rd Day)", year);
+            Optional<HolidayDate> day4 = findFirst("Eid al-Adha (4th Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Adha must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Adha (2nd Day) must be present");
+            assertTrue(day3.isPresent(), year + ": Eid al-Adha (3rd Day) must be present");
+            assertTrue(day4.isPresent(), year + ": Eid al-Adha (4th Day) must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Adha (2nd Day) must be Day 1 + 1");
+            assertEquals(day3.get().date(), day1.get().date().plusDays(2),
+                    year + ": Eid al-Adha (3rd Day) must be Day 1 + 2");
+            assertEquals(day4.get().date(), day1.get().date().plusDays(3),
+                    year + ": Eid al-Adha (4th Day) must be Day 1 + 3");
+        }
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBJ official");
+    }
+
+    @Test
+    public void testIslamicNewYear2025() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 26),
+                "Islamic New Year 2025 must be 2025-06-26 per ASE official");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 16),
+                "Prophet's Birthday 2024 must be 2024-09-16 per CBJ official");
+    }
+
+    @Test
+    public void testProphetsBirthday2025() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2025);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 4),
+                "Prophet's Birthday 2025 must be 2025-09-04 per ASE official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "JO calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("JO");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"JO\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), JO_HOLIDAY_COUNT,
+                "Expected all " + JO_HOLIDAY_COUNT + " JO holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted)");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), JO_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + JO_FIXED_HOLIDAY_COUNT +
+                " fixed Jordan holidays must remain");
+    }
+
+    // ── 2033 dual Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Fitr (4th Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Independence Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Eid al-Adha (4th Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Christmas Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -40,10 +40,12 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays               |
 | `IL` | Israel (National) Holidays                    |
 | `ILS` | Israel (TASE/Bank of Israel) Holidays         |
-| `KW` | Kuwait (National) Holidays                    |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
+| `JO` | Jordan (National) Holidays |
+| `JOD` | Jordan (ASE/CBJ) Holidays |
 | `JP` | Japan (TSE) Holidays                          |
 | `JPY` | Japan (BOJ) Holidays                          |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
 | `MA` | Morocco (National) Holidays                   |
 | `MAD` | Morocco (CSE/BAM) Holidays                    |
 | `QA` | Qatar (National) Holidays                     |
@@ -100,7 +102,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -147,7 +149,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JO", "JOD", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar


### PR DESCRIPTION
### #167 Jordan holiday calendars: JO (national) + JOD (ASE/CBJ)

**Description**

- Added `JO` — Jordan (National) Holidays: 15 holidays (4 fixed Gregorian + 11 floating Islamic)
- Added `JOD` — Jordan (ASE/CBJ) Holidays: same 15 holidays with no-roll convention for settlement
- Added new `EidAlFitrDay4` observance class (4th day of Eid al-Fitr; Jordan observes 4 days per official ASE/CBJ announcements)
- Added 5 Jordan-specific CSV files (2024–2026 from CBJ/ASE official; 2027–2055 Umm al-Qura projection)
- Registered JO + JOD in `module-info.java`, `META-INF/services`, and `README.md`

Holiday set corrections vs. issue spec (verified against official ASE/CBJ sources):
- **Removed** Army Day (Jun 10) — confirmed working day; not a gazetted public holiday
- **Added** Arafat Day (9 Dhu al-Hijjah) — confirmed by ASE official holiday listings
- **Expanded** Eid al-Fitr to 4 days (ASE 2025: Mar 30–Apr 2; 2026: Mar 20–23)
- **Expanded** Eid al-Adha to 4 days + Arafat Day = 5 closures
- **Confirmed** Christmas Day (Dec 25) — gazetted national holiday and ASE closure day
- **Excluded** Isra and Mi'raj — 2005 government decree confirmed it is not a public holiday

**Related Issue**

- [#167 Jordan holiday calendars: JO (national) + JOD (ASE/CBJ)](https://github.com/holiday-calendar/holiday-calendar-java/issues/167)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed