### PR TITLE
Release v1.4.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -20,9 +20,6 @@ on:
   schedule:
     - cron: '39 8 * * 4'
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   analyze:
     name: Analyze
@@ -41,11 +38,11 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v2
+      uses: github/codeql-action/init@v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -56,7 +53,7 @@ jobs:
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
     - name: Autobuild
-      uses: github/codeql-action/autobuild@v2
+      uses: github/codeql-action/autobuild@v4
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 https://git.io/JvXDl
@@ -70,4 +67,4 @@ jobs:
     #   make release
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v2
+      uses: github/codeql-action/analyze@v4

--- a/.github/workflows/maven-build.yml
+++ b/.github/workflows/maven-build.yml
@@ -8,30 +8,27 @@ on:
   pull_request:
     types: [opened, synchronize, reopened]
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   build:
     name: Build and analyze
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
       - name: Set up JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'adopt' # Alternative distribution options are available.
       - name: Cache SonarQube packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar
           restore-keys: ${{ runner.os }}-sonar
       - name: Cache Maven packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.m2
           key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -14,9 +14,6 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   publish-javadoc:
     runs-on: ubuntu-latest
@@ -24,9 +21,9 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'adopt'
@@ -38,13 +35,13 @@ jobs:
         run: mvn -B --no-transfer-progress javadoc:aggregate
       - name: Setup Pages
         if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Upload Pages artifact
         if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: target/reports/apidocs/
       - name: Deploy to GitHub Pages
         if: ${{ !endsWith(steps.get_version.outputs.version, '-SNAPSHOT') }}
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -5,16 +5,13 @@ on:
     branches:
       - main
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   publish-release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'adopt'

--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -7,16 +7,13 @@ on:
     types:
       - completed
 
-env:
-  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-
 jobs:
   publish-snapshot:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Setup JDK 21
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@v5
         with:
           java-version: 21
           distribution: 'adopt'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-05-22
+
+### Added
+
+- Qatar holiday calendars: QA (national) + QAR (QSE/Qatar Central Bank) (#162)
+- Kuwait holiday calendars: KW (national) + KWD (Boursa Kuwait/CBK) (#163)
+- Egypt holiday calendars: EG (national) + EGP (EGX/Central Bank of Egypt) (#164)
+- Bahrain holiday calendars: BH (national) + BHD (Boursa Bahrain/CBB) (#165)
+- Morocco holiday calendars: MA (national) + MAD (Casablanca SE/Bank Al-Maghrib) (#166)
+- Jordan holiday calendars: JO (national) + JOD (ASE/Central Bank of Jordan) (#167)
+
+### Changed
+
+- Upgraded GitHub Actions to Node.js 24-compatible versions (#185)
+
 ## [1.3.1] - 2026-05-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Key design goals:
 | `CN` | China National Holidays |
 | `CNY` | China (PBOC) Holidays |
 | `DE` | Germany (Xetra) Holidays |
+| `EG` | Egypt (National) Holidays |
+| `EGP` | Egypt (EGX/CBE) Holidays |
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France (Euronext Paris) Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
@@ -94,7 +96,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>

--- a/README.md
+++ b/README.md
@@ -23,40 +23,42 @@ Key design goals:
 | `AE` | United Arab Emirates (National) Holidays      |
 | `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays                      |
-| `BH` | Bahrain (National) Holidays                   |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
-| `CA` | Canada National Holidays                      |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
-| `CH` | Switzerland (SIX) Holidays                    |
-| `CHF` | Switzerland (SIC/SNB) Holidays                |
-| `CN` | China National Holidays                       |
-| `CNY` | China (PBOC) Holidays                         |
-| `DE` | Germany (Xetra) Holidays                      |
-| `EG` | Egypt (National) Holidays                     |
-| `EGP` | Egypt (EGX/CBE) Holidays                      |
-| `EUR` | Euro (TARGET2) Holidays                       |
-| `FR` | France (Euronext Paris) Holidays              |
-| `GBP` | United Kingdom (CHAPS) Holidays               |
-| `IL` | Israel (National) Holidays                    |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
-| `KW` | Kuwait (National) Holidays                    |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
-| `JP` | Japan (TSE) Holidays                          |
-| `JPY` | Japan (BOJ) Holidays                          |
+| `AUD` | Australia (RBA) Holidays |
+| `BH` | Bahrain (National) Holidays |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
+| `CA` | Canada National Holidays |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
+| `CH` | Switzerland (SIX) Holidays |
+| `CHF` | Switzerland (SIC/SNB) Holidays |
+| `CN` | China National Holidays |
+| `CNY` | China (PBOC) Holidays |
+| `DE` | Germany (Xetra) Holidays |
+| `EG` | Egypt (National) Holidays |
+| `EGP` | Egypt (EGX/CBE) Holidays |
+| `EUR` | Euro (TARGET2) Holidays |
+| `FR` | France (Euronext Paris) Holidays |
+| `GBP` | United Kingdom (CHAPS) Holidays |
+| `IL` | Israel (National) Holidays |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `JO` | Jordan (National) Holidays |
+| `JOD` | Jordan (ASE/CBJ) Holidays |
+| `JP` | Japan (TSE) Holidays |
+| `JPY` | Japan (BOJ) Holidays |
+| `KW` | Kuwait (National) Holidays |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
 | `MA` | Morocco (National) Holidays                   |
 | `MAD` | Morocco (CSE/BAM) Holidays                    |
-| `QA` | Qatar (National) Holidays                     |
-| `QAR` | Qatar (QSE/QCB) Holidays                      |
-| `SA` | Saudi Arabia (National) Holidays              |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
-| `SG` | Singapore (SGX) Holidays                      |
-| `SGD` | Singapore (MAS/MEPS+) Holidays                |
-| `TR`  | Turkey (National) Holidays                    |
-| `TRY` | Turkey (BIST/TCMB) Holidays                   |
-| `UK` | United Kingdom National Holidays              |
-| `US` | United States National Holidays               |
-| `USD` | United States (Federal Reserve) Holidays      |
+| `QA` | Qatar (National) Holidays |
+| `QAR` | Qatar (QSE/QCB) Holidays |
+| `SA` | Saudi Arabia (National) Holidays |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
+| `SG` | Singapore (SGX) Holidays |
+| `SGD` | Singapore (MAS/MEPS+) Holidays |
+| `TR`  | Turkey (National) Holidays |
+| `TRY` | Turkey (BIST/TCMB) Holidays |
+| `UK` | United Kingdom National Holidays |
+| `US` | United States National Holidays |
+| `USD` | United States (Federal Reserve) Holidays |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 
@@ -100,7 +102,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -147,7 +149,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JO", "JOD", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/README.md
+++ b/README.md
@@ -85,28 +85,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.0</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.0</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.0</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>1.4.0-SNAPSHOT</version>
+  <version>1.4.0</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ Key design goals:
 | `AED` | UAE (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
 | `AUD` | Australia (RBA) Holidays |
+| `BH` | Bahrain (National) Holidays |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
 | `CA` | Canada National Holidays |
 | `CAD` | Bank of Canada (Lynx) Holiday Schedule |
 | `CH` | Switzerland (SIX) Holidays |
@@ -96,7 +98,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -143,7 +145,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/README.md
+++ b/README.md
@@ -73,28 +73,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, IL, ILS, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>1.3.1</version>
+  <version>1.4.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `IL` | Israel (National) Holidays |
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `KW` | Kuwait (National) Holidays |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `QA` | Qatar (National) Holidays |
@@ -92,7 +94,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -139,7 +141,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/README.md
+++ b/README.md
@@ -18,43 +18,45 @@ Key design goals:
 
 ### Supported Calendars
 
-| Code | Region |
-|------|--------|
-| `AE` | UAE (National) Holidays |
-| `AED` | UAE (CBUAE/DFM/ADX) Holidays |
+| Code | Region                                        |
+|------|-----------------------------------------------|
+| `AE` | United Arab Emirates (National) Holidays      |
+| `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays |
-| `BH` | Bahrain (National) Holidays |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
-| `CA` | Canada National Holidays |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
-| `CH` | Switzerland (SIX) Holidays |
-| `CHF` | Switzerland (SIC/SNB) Holidays |
-| `CN` | China National Holidays |
-| `CNY` | China (PBOC) Holidays |
-| `DE` | Germany (Xetra) Holidays |
-| `EG` | Egypt (National) Holidays |
-| `EGP` | Egypt (EGX/CBE) Holidays |
-| `EUR` | Euro (TARGET2) Holidays |
-| `FR` | France (Euronext Paris) Holidays |
-| `GBP` | United Kingdom (CHAPS) Holidays |
-| `IL` | Israel (National) Holidays |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays |
-| `KW` | Kuwait (National) Holidays |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
-| `JP` | Japan (TSE) Holidays |
-| `JPY` | Japan (BOJ) Holidays |
-| `QA` | Qatar (National) Holidays |
-| `QAR` | Qatar (QSE/QCB) Holidays |
-| `SA` | Saudi Arabia (National) Holidays |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
-| `SG` | Singapore (SGX) Holidays |
-| `SGD` | Singapore (MAS/MEPS+) Holidays |
-| `TR`  | Turkey (National) Holidays |
-| `TRY` | Turkey (BIST/TCMB) Holidays |
-| `UK` | United Kingdom National Holidays |
-| `US` | United States National Holidays |
-| `USD` | United States (Federal Reserve) Holidays |
+| `AUD` | Australia (RBA) Holidays                      |
+| `BH` | Bahrain (National) Holidays                   |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
+| `CA` | Canada National Holidays                      |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
+| `CH` | Switzerland (SIX) Holidays                    |
+| `CHF` | Switzerland (SIC/SNB) Holidays                |
+| `CN` | China National Holidays                       |
+| `CNY` | China (PBOC) Holidays                         |
+| `DE` | Germany (Xetra) Holidays                      |
+| `EG` | Egypt (National) Holidays                     |
+| `EGP` | Egypt (EGX/CBE) Holidays                      |
+| `EUR` | Euro (TARGET2) Holidays                       |
+| `FR` | France (Euronext Paris) Holidays              |
+| `GBP` | United Kingdom (CHAPS) Holidays               |
+| `IL` | Israel (National) Holidays                    |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
+| `JP` | Japan (TSE) Holidays                          |
+| `JPY` | Japan (BOJ) Holidays                          |
+| `MA` | Morocco (National) Holidays                   |
+| `MAD` | Morocco (CSE/BAM) Holidays                    |
+| `QA` | Qatar (National) Holidays                     |
+| `QAR` | Qatar (QSE/QCB) Holidays                      |
+| `SA` | Saudi Arabia (National) Holidays              |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
+| `SG` | Singapore (SGX) Holidays                      |
+| `SGD` | Singapore (MAS/MEPS+) Holidays                |
+| `TR`  | Turkey (National) Holidays                    |
+| `TRY` | Turkey (BIST/TCMB) Holidays                   |
+| `UK` | United Kingdom National Holidays              |
+| `US` | United States National Holidays               |
+| `USD` | United States (Federal Reserve) Holidays      |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 
@@ -98,7 +100,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -145,7 +147,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Key design goals:
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
+| `QA` | Qatar (National) Holidays |
+| `QAR` | Qatar (QSE/QCB) Holidays |
 | `SA` | Saudi Arabia (National) Holidays |
 | `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
 | `SG` | Singapore (SGX) Holidays |
@@ -90,7 +92,7 @@ Then add the modules you need:
   <version>1.4.0-SNAPSHOT</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -137,7 +139,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/README.md
+++ b/README.md
@@ -23,42 +23,42 @@ Key design goals:
 | `AE` | United Arab Emirates (National) Holidays      |
 | `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays |
-| `BH` | Bahrain (National) Holidays |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
-| `CA` | Canada National Holidays |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
-| `CH` | Switzerland (SIX) Holidays |
-| `CHF` | Switzerland (SIC/SNB) Holidays |
-| `CN` | China National Holidays |
-| `CNY` | China (PBOC) Holidays |
-| `DE` | Germany (Xetra) Holidays |
-| `EG` | Egypt (National) Holidays |
-| `EGP` | Egypt (EGX/CBE) Holidays |
-| `EUR` | Euro (TARGET2) Holidays |
-| `FR` | France (Euronext Paris) Holidays |
-| `GBP` | United Kingdom (CHAPS) Holidays |
-| `IL` | Israel (National) Holidays |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `AUD` | Australia (RBA) Holidays                      |
+| `BH` | Bahrain (National) Holidays                   |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
+| `CA` | Canada National Holidays                      |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
+| `CH` | Switzerland (SIX) Holidays                    |
+| `CHF` | Switzerland (SIC/SNB) Holidays                |
+| `CN` | China National Holidays                       |
+| `CNY` | China (PBOC) Holidays                         |
+| `DE` | Germany (Xetra) Holidays                      |
+| `EG` | Egypt (National) Holidays                     |
+| `EGP` | Egypt (EGX/CBE) Holidays                      |
+| `EUR` | Euro (TARGET2) Holidays                       |
+| `FR` | France (Euronext Paris) Holidays              |
+| `GBP` | United Kingdom (CHAPS) Holidays               |
+| `IL` | Israel (National) Holidays                    |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
 | `JO` | Jordan (National) Holidays |
 | `JOD` | Jordan (ASE/CBJ) Holidays |
-| `JP` | Japan (TSE) Holidays |
-| `JPY` | Japan (BOJ) Holidays |
-| `KW` | Kuwait (National) Holidays |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
+| `JP` | Japan (TSE) Holidays                          |
+| `JPY` | Japan (BOJ) Holidays                          |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
 | `MA` | Morocco (National) Holidays                   |
 | `MAD` | Morocco (CSE/BAM) Holidays                    |
-| `QA` | Qatar (National) Holidays |
-| `QAR` | Qatar (QSE/QCB) Holidays |
-| `SA` | Saudi Arabia (National) Holidays |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
-| `SG` | Singapore (SGX) Holidays |
-| `SGD` | Singapore (MAS/MEPS+) Holidays |
-| `TR`  | Turkey (National) Holidays |
-| `TRY` | Turkey (BIST/TCMB) Holidays |
-| `UK` | United Kingdom National Holidays |
-| `US` | United States National Holidays |
-| `USD` | United States (Federal Reserve) Holidays |
+| `QA` | Qatar (National) Holidays                     |
+| `QAR` | Qatar (QSE/QCB) Holidays                      |
+| `SA` | Saudi Arabia (National) Holidays              |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
+| `SG` | Singapore (SGX) Holidays                      |
+| `SGD` | Singapore (MAS/MEPS+) Holidays                |
+| `TR`  | Turkey (National) Holidays                    |
+| `TRY` | Turkey (BIST/TCMB) Holidays                   |
+| `UK` | United Kingdom National Holidays              |
+| `US` | United States National Holidays               |
+| `USD` | United States (Federal Reserve) Holidays      |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/function/DateRolls.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/function/DateRolls.java
@@ -75,9 +75,10 @@ public final class DateRolls {
     /**
      * Friday and Saturday both roll forward to Sunday.
      *
-     * <p>Implements the GCC market rule (Saudi Arabia, UAE, Kuwait, Qatar, Bahrain, Oman):
+     * <p>Implements the GCC market rule (Saudi Arabia, UAE, Kuwait, Bahrain, Oman):
      * the weekend is Friday + Saturday; Sunday is the first business day of the week.
      *
+     * @see #previousThursdayOrFollowingSunday() for Qatar's asymmetric substitute rule
      * @see #followingMonday() for the analogous Sat/Sun → Mon rule used by Western markets
      */
     public static DateRoll followingSunday() {
@@ -85,6 +86,28 @@ public final class DateRolls {
             if (date.getDayOfWeek() == DayOfWeek.FRIDAY)   return date.plusDays(2);
             if (date.getDayOfWeek() == DayOfWeek.SATURDAY) return date.plusDays(1);
             return date;
+        };
+    }
+
+    /**
+     * Friday rolls back to Thursday; Saturday rolls forward to Sunday.
+     *
+     * <p>Implements the Qatar national holiday substitute rule as announced by the
+     * Amiri Diwan: when a public holiday falls on Friday (the first weekend day),
+     * it is observed on the preceding Thursday; when it falls on Saturday (the
+     * second weekend day), it is observed on the following Sunday.
+     *
+     * <p>Confirmed precedents: Qatar National Day 2020 (18 Dec = Friday → 17 Dec
+     * Thursday official); Qatar National Day 2021 (18 Dec = Saturday → 19 Dec
+     * Sunday official).
+     *
+     * @see #followingSunday() for the always-forward GCC convention used by Saudi Arabia and UAE
+     */
+    public static DateRoll previousThursdayOrFollowingSunday() {
+        return date -> switch (date.getDayOfWeek()) {
+            case FRIDAY   -> date.minusDays(1);
+            case SATURDAY -> date.plusDays(1);
+            default       -> date;
         };
     }
 

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/function/DateRollsTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/function/DateRollsTest.java
@@ -126,4 +126,39 @@ public class DateRollsTest {
     public void testFollowingSunday_Workday_NoRoll(LocalDate workday) {
         assertEquals(DateRolls.followingSunday().rollToObservedDate(workday), workday);
     }
+
+    // ── previousThursdayOrFollowingSunday ─────────────────────────────────────
+    // Qatar Amiri Diwan rule: Friday → preceding Thursday; Saturday → following Sunday
+
+    @Test
+    public void testPreviousThursdayOrFollowingSunday_Friday_RollsToThursday() {
+        // Dec 18, 2020 is Friday → Dec 17, 2020 (Thursday); confirmed Amiri Diwan
+        LocalDate fri = LocalDate.of(2020, 12, 18);
+        assertEquals(DateRolls.previousThursdayOrFollowingSunday().rollToObservedDate(fri),
+                LocalDate.of(2020, 12, 17));
+    }
+
+    @Test
+    public void testPreviousThursdayOrFollowingSunday_Saturday_RollsToSunday() {
+        // Dec 18, 2021 is Saturday → Dec 19, 2021 (Sunday); confirmed Amiri Diwan
+        LocalDate sat = LocalDate.of(2021, 12, 18);
+        assertEquals(DateRolls.previousThursdayOrFollowingSunday().rollToObservedDate(sat),
+                LocalDate.of(2021, 12, 19));
+    }
+
+    @DataProvider(name = "qatarWorkdays")
+    public Object[][] qatarWorkdays() {
+        return new Object[][] {
+            { LocalDate.of(2025, 1, 5)  },  // Sunday
+            { LocalDate.of(2025, 1, 6)  },  // Monday
+            { LocalDate.of(2025, 1, 7)  },  // Tuesday
+            { LocalDate.of(2025, 1, 8)  },  // Wednesday
+            { LocalDate.of(2025, 1, 9)  },  // Thursday
+        };
+    }
+
+    @Test(dataProvider = "qatarWorkdays")
+    public void testPreviousThursdayOrFollowingSunday_Workday_NoRoll(LocalDate workday) {
+        assertEquals(DateRolls.previousThursdayOrFollowingSunday().rollToObservedDate(workday), workday);
+    }
 }

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -24,7 +24,11 @@
             <artifactId>holiday-calendar-core</artifactId>
             <version>${project.version}</version>
         </dependency>
-        <!-- holiday-calendar-western added when a Christian observance (Good Friday, Christmas) is needed -->
+        <dependency>
+            <groupId>org.holiday.calendar</groupId>
+            <artifactId>holiday-calendar-western</artifactId>
+            <version>${project.version}</version>
+        </dependency>
 
         <dependency>
             <groupId>net.time4j</groupId>

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -46,5 +46,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceKW,
         org.holiday.calendar.impl.HolidayCalendarServiceKWD,
         org.holiday.calendar.impl.HolidayCalendarServiceBH,
-        org.holiday.calendar.impl.HolidayCalendarServiceBHD;
+        org.holiday.calendar.impl.HolidayCalendarServiceBHD,
+        org.holiday.calendar.impl.HolidayCalendarServiceMA,
+        org.holiday.calendar.impl.HolidayCalendarServiceMAD;
 }

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -48,5 +48,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceBH,
         org.holiday.calendar.impl.HolidayCalendarServiceBHD,
         org.holiday.calendar.impl.HolidayCalendarServiceMA,
-        org.holiday.calendar.impl.HolidayCalendarServiceMAD;
+        org.holiday.calendar.impl.HolidayCalendarServiceMAD,
+        org.holiday.calendar.impl.HolidayCalendarServiceJO,
+        org.holiday.calendar.impl.HolidayCalendarServiceJOD;
 }

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -39,5 +39,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceTR,
         org.holiday.calendar.impl.HolidayCalendarServiceTRY,
         org.holiday.calendar.impl.HolidayCalendarServiceQA,
-        org.holiday.calendar.impl.HolidayCalendarServiceQAR;
+        org.holiday.calendar.impl.HolidayCalendarServiceQAR,
+        org.holiday.calendar.impl.HolidayCalendarServiceKW,
+        org.holiday.calendar.impl.HolidayCalendarServiceKWD;
 }

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -27,6 +27,7 @@ module org.holiday.calendar.mena {
 
     exports org.holiday.calendar.observance.islamic.mena;
     exports org.holiday.calendar.observance.hebrew;
+    exports org.holiday.calendar.observance.qa;
 
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceAE,
@@ -36,5 +37,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceIL,
         org.holiday.calendar.impl.HolidayCalendarServiceILS,
         org.holiday.calendar.impl.HolidayCalendarServiceTR,
-        org.holiday.calendar.impl.HolidayCalendarServiceTRY;
+        org.holiday.calendar.impl.HolidayCalendarServiceTRY,
+        org.holiday.calendar.impl.HolidayCalendarServiceQA,
+        org.holiday.calendar.impl.HolidayCalendarServiceQAR;
 }

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -21,10 +21,11 @@
  */
 module org.holiday.calendar.mena {
     requires org.holiday.calendar.core;
-    // requires org.holiday.calendar.western; // Add when a Christian observance (Good Friday, Christmas) is needed
+    requires org.holiday.calendar.western;
     requires net.time4j.base;
     requires org.slf4j;
 
+    exports org.holiday.calendar.observance.eg;
     exports org.holiday.calendar.observance.islamic.mena;
     exports org.holiday.calendar.observance.hebrew;
     exports org.holiday.calendar.observance.qa;
@@ -40,6 +41,8 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceTRY,
         org.holiday.calendar.impl.HolidayCalendarServiceQA,
         org.holiday.calendar.impl.HolidayCalendarServiceQAR,
+        org.holiday.calendar.impl.HolidayCalendarServiceEG,
+        org.holiday.calendar.impl.HolidayCalendarServiceEGP,
         org.holiday.calendar.impl.HolidayCalendarServiceKW,
         org.holiday.calendar.impl.HolidayCalendarServiceKWD;
 }

--- a/holiday-calendar-mena/src/main/java/module-info.java
+++ b/holiday-calendar-mena/src/main/java/module-info.java
@@ -44,5 +44,7 @@ module org.holiday.calendar.mena {
         org.holiday.calendar.impl.HolidayCalendarServiceEG,
         org.holiday.calendar.impl.HolidayCalendarServiceEGP,
         org.holiday.calendar.impl.HolidayCalendarServiceKW,
-        org.holiday.calendar.impl.HolidayCalendarServiceKWD;
+        org.holiday.calendar.impl.HolidayCalendarServiceKWD,
+        org.holiday.calendar.impl.HolidayCalendarServiceBH,
+        org.holiday.calendar.impl.HolidayCalendarServiceBHD;
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/BahrainHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/BahrainHolidays.java
@@ -1,0 +1,201 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.Ashura;
+import org.holiday.calendar.observance.islamic.mena.AshuraDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Bahrain public holiday lists for the
+ * national ({@code BH}) and settlement ({@code BHD}) calendars.
+ *
+ * <p>The national calendar ({@code BH}) observes 15 public holidays: New Year's
+ * Day, Labour Day, National Day, Accession Day (fixed Gregorian), Arafat Day,
+ * three days of Eid al-Fitr, three days of Eid al-Adha, Islamic New Year, two days
+ * of Ashura, and Prophet's Birthday (floating Islamic).
+ *
+ * <p>The settlement calendar ({@code BHD}) uses the identical holiday set with
+ * {@code rollable(false)} for all holidays — the Central Bank of Bahrain (CBB) and
+ * Boursa Bahrain apply no date adjustment per the no-roll convention consistent with
+ * other GCC settlement calendars (AED, SAR, KWD, QAR, EGP).
+ *
+ * <p>Ashura (10–11 Muharram) is included in both BH and BHD. Bahrain gazetted
+ * Ashura as a national public holiday under the Labour Law, and CBB circulars
+ * confirm Boursa Bahrain closes on both days.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code bh}). Dates for 2024–2025
+ * are sourced from official CBB and Boursa Bahrain holiday announcements; dates for
+ * 2026–2055 are projected from the Umm al-Qura tabular Islamic calendar. Bahrain
+ * determines Islamic holiday dates by moon sighting and may differ from Saudi Arabia
+ * by ±1 day; verify against official CBB / Boursa Bahrain announcements as each year
+ * is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class BahrainHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> BAHRAIN_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private BahrainHolidays() {}
+
+    /**
+     * Returns the 15 Bahrain public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, Labour Day,
+     *                      National Day, Accession Day) are rollable; all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Ashura")
+                    .description("First day of Ashura, marking 10 Muharram AH; two-day national holiday in Bahrain")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new Ashura("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Ashura (2nd Day)")
+                    .description("Second day of Ashura (11 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new AshuraDay2("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("bh"))
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("National Day of the Kingdom of Bahrain, marking independence from Britain on 15 August 1971; observed 16 December")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 16)
+                    .build(),
+            Holiday.builder()
+                    .name("Accession Day")
+                    .description("Accession of King Hamad bin Isa Al Khalifa to the throne on 6 March 1999; observed 17 December")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 17)
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 15 BHD holidays: the base holiday set with all holidays
+     * {@code rollable(false)}, for use with {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> bhdHolidays() {
+        return baseHolidays(false);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/EgyptHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/EgyptHolidays.java
@@ -1,0 +1,220 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.eg.ShamElNessim;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Egypt public holiday lists for the
+ * national ({@code EG}) and settlement ({@code EGP}) calendars.
+ *
+ * <p>The national calendar ({@code EG}) observes 17 public holidays: Coptic
+ * Christmas, Revolution Day (25 January), Sinai Liberation Day, Labour Day,
+ * June 30 Revolution, Revolution Day (23 July), Armed Forces Day, Sham El-Nessim,
+ * Arafat Day, three days of Eid al-Fitr, three days of Eid al-Adha, Islamic New
+ * Year, and Prophet's Birthday.
+ *
+ * <p>The settlement calendar ({@code EGP}) uses the same holiday set minus
+ * Arafat Day (16 holidays), with {@code rollable(false)} for all holidays — the
+ * Egyptian Exchange (EGX) and Central Bank of Egypt (CBE) apply no date adjustment
+ * per the no-roll convention.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code eg}). Dates for 2024–2025
+ * are sourced from official CBE / EGX announcements; dates for 2026–2055 are
+ * projected from the Umm al-Qura tabular Islamic calendar. Egypt determines Islamic
+ * holiday dates by moon sighting and may differ from Saudi Arabia by ±1 day; verify
+ * against official CBE / EGX announcements as each year is published.
+ *
+ * <p>Sham El-Nessim is computed algorithmically as the day after Coptic Easter
+ * (which uses the same Julian-calendar algorithm as Orthodox Easter) and is
+ * not subject to the CSV data ceiling.
+ *
+ * <p>Note: Egypt frequently announces ad hoc public holidays and bridge days via
+ * Prime Minister's decree. These are not capturable in a static calendar; consult
+ * official CBE / EGX announcements for the current year.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class EgyptHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> EGYPT_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private EgyptHolidays() {}
+
+    /**
+     * Returns the 17 Egypt public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays are rollable; Sham El-Nessim
+     *                      and all Islamic holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("Coptic Christmas")
+                    .description("Christmas celebration in the Coptic Orthodox Christian tradition (7 January)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 7)
+                    .build(),
+            Holiday.builder()
+                    .name("Revolution Day")
+                    .description("25 January Revolution, marking the start of the 2011 Egyptian uprising")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Sinai Liberation Day")
+                    .description("Return of the Sinai Peninsula to Egyptian sovereignty on 25 April 1982")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.APRIL, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Sham El-Nessim")
+                    .description("Egyptian spring festival celebrated the day after Coptic Easter; observed by all Egyptians regardless of religion")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ShamElNessim())
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("June 30 Revolution")
+                    .description("30 June Revolution, marking the removal of Mohamed Morsi from the presidency in 2013")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JUNE, 30)
+                    .build(),
+            Holiday.builder()
+                    .name("Revolution Day (July 23)")
+                    .description("23 July Revolution, marking the Free Officers' overthrow of King Farouk in 1952")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JULY, 23)
+                    .build(),
+            Holiday.builder()
+                    .name("Armed Forces Day")
+                    .description("Egyptian Armed Forces Day, commemorating the 1973 October War crossing of the Suez Canal")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.OCTOBER, 6)
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("eg"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("eg"))
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 16 EGP holidays: the base holiday set without Arafat Day, with
+     * all holidays {@code rollable(false)}, for use with
+     * {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> egpHolidays() {
+        return baseHolidays(false).stream()
+                .filter(h -> !"Arafat Day".equals(h.getName()))
+                .toList();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceBH.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceBH.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Bahrain national public holiday calendar.
+ *
+ * <p>Calendar code: {@code BH}. Covers public holidays observed in the Kingdom of
+ * Bahrain as declared by the Crown Prince and Prime Minister.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}, consistent with the GCC market rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-bh.csv},
+ * {@code eid-al-adha-bh.csv}, {@code arafat-day-bh.csv},
+ * {@code islamic-new-year-bh.csv}, {@code ashura-bh.csv}, and
+ * {@code mawlid-bh.csv}. Dates for 2024–2025 are official CBB / Boursa Bahrain
+ * announcements; 2026–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Bahrain determines Islamic holiday dates by moon sighting and may
+ * differ from Saudi Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceBH extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "BH";
+    private static final String NAME = "Bahrain (National) Holidays";
+
+    public HolidayCalendarServiceBH() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(BahrainHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(BahrainHolidays.BAHRAIN_WEEKEND)
+                .holidays(BahrainHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceBHD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceBHD.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Bahrain exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code BHD}. Covers market closure days for Boursa Bahrain
+ * and Central Bank of Bahrain (CBB) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED, SAR, KWD, QAR, and EGP
+ * convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-bh.csv},
+ * {@code eid-al-adha-bh.csv}, {@code arafat-day-bh.csv},
+ * {@code islamic-new-year-bh.csv}, {@code ashura-bh.csv}, and
+ * {@code mawlid-bh.csv}. Dates for 2024–2025 are official CBB / Boursa Bahrain
+ * announcements; 2026–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Bahrain determines Islamic holiday dates by moon sighting and may
+ * differ from Saudi Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceBHD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "BHD";
+    private static final String NAME = "Bahrain (Boursa Bahrain/CBB) Holidays";
+
+    public HolidayCalendarServiceBHD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(BahrainHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(BahrainHolidays.BAHRAIN_WEEKEND)
+                .holidays(BahrainHolidays.bhdHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEG.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEG.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Egypt national public holiday calendar.
+ *
+ * <p>Calendar code: {@code EG}. Covers public holidays observed in the Arab
+ * Republic of Egypt as declared by the Egyptian Government.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}, consistent with the GCC market rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-eg.csv},
+ * {@code eid-al-adha-eg.csv}, {@code arafat-day-eg.csv},
+ * {@code islamic-new-year-eg.csv}, and {@code mawlid-eg.csv}. Dates for 2024–2025
+ * are official CBE / EGX announcements; 2026–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Egypt determines Islamic holiday dates by moon
+ * sighting and may differ from Saudi Arabia by ±1 day.
+ *
+ * <p>Sham El-Nessim is computed algorithmically as the day after Coptic Easter
+ * and is available for all years within the valid range of the Orthodox Easter
+ * algorithm (530–3399 AD).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceEG extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "EG";
+    private static final String NAME = "Egypt (National) Holidays";
+
+    public HolidayCalendarServiceEG() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(EgyptHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(EgyptHolidays.EGYPT_WEEKEND)
+                .holidays(EgyptHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEGP.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceEGP.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Egypt exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code EGP}. Covers market closure days for the Egyptian
+ * Exchange (EGX) and Central Bank of Egypt (CBE) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED, SAR, KWD, and QAR
+ * convention.
+ *
+ * <p>Arafat Day is excluded from this calendar: it is a national public holiday
+ * but is not an EGX / CBE settlement closure day.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-eg.csv},
+ * {@code eid-al-adha-eg.csv}, {@code islamic-new-year-eg.csv}, and
+ * {@code mawlid-eg.csv}. Dates for 2024–2025 are official CBE / EGX announcements;
+ * 2026–2055 are projected from the Umm al-Qura tabular Islamic calendar. Egypt
+ * determines Islamic holiday dates by moon sighting and may differ from Saudi
+ * Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceEGP extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "EGP";
+    private static final String NAME = "Egypt (EGX/CBE) Holidays";
+
+    public HolidayCalendarServiceEGP() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(EgyptHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(EgyptHolidays.EGYPT_WEEKEND)
+                .holidays(EgyptHolidays.egpHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJO.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJO.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Jordan national public holiday calendar.
+ *
+ * <p>Calendar code: {@code JO}. Covers public holidays observed in the Hashemite
+ * Kingdom of Jordan as declared by the Jordanian government.
+ *
+ * <p>Weekend: Friday + Saturday. Fixed holidays that fall on Friday or Saturday
+ * are observed on the following Sunday per {@link DateRolls#followingSunday()}.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-jo.csv},
+ * {@code eid-al-adha-jo.csv}, {@code arafat-day-jo.csv},
+ * {@code islamic-new-year-jo.csv}, and {@code mawlid-jo.csv}. Dates for 2024–2026
+ * are official CBJ / ASE announcements; 2027–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Jordan determines Islamic holiday dates by moon
+ * sighting (Ministry of Awqaf / Higher Judiciary Council) and may differ from Saudi
+ * Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceJO extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "JO";
+    private static final String NAME = "Jordan (National) Holidays";
+
+    public HolidayCalendarServiceJO() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(JordanHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // Jordan weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(JordanHolidays.JORDAN_WEEKEND)
+                .holidays(JordanHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJOD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJOD.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Jordan exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code JOD}. Covers market closure days for the Amman Stock
+ * Exchange (ASE) and Central Bank of Jordan (CBJ) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday. Fixed holidays are not rolled — the settlement
+ * calendar uses natural calendar dates per {@link DateRolls#noRoll()}, consistent
+ * with the AED, SAR, KWD, QAR, BHD, and EGP convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-jo.csv},
+ * {@code eid-al-adha-jo.csv}, {@code arafat-day-jo.csv},
+ * {@code islamic-new-year-jo.csv}, and {@code mawlid-jo.csv}. Dates for 2024–2026
+ * are official CBJ / ASE announcements; 2027–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Jordan determines Islamic holiday dates by moon
+ * sighting (Ministry of Awqaf / Higher Judiciary Council) and may differ from Saudi
+ * Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceJOD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "JOD";
+    private static final String NAME = "Jordan (ASE/CBJ) Holidays";
+
+    public HolidayCalendarServiceJOD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(JordanHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(JordanHolidays.JORDAN_WEEKEND)
+                .holidays(JordanHolidays.jodHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKW.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKW.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Kuwait national public holiday calendar.
+ *
+ * <p>Calendar code: {@code KW}. Covers public holidays observed in the State of
+ * Kuwait as declared by the Amiri Diwan and the Central Bank of Kuwait (CBK).
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday or Saturday are observed on the following Sunday per
+ * {@link DateRolls#followingSunday()}, consistent with the GCC market rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-kw.csv},
+ * {@code eid-al-adha-kw.csv}, {@code islamic-new-year-kw.csv}, and
+ * {@code mawlid-kw.csv}. Dates for 2024–2026 are official CBK / Boursa Kuwait
+ * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Kuwait determines Islamic holiday dates by moon sighting and may
+ * differ from Saudi Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceKW extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "KW";
+    private static final String NAME = "Kuwait (National) Holidays";
+
+    public HolidayCalendarServiceKW() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(KuwaitHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // GCC weekend is Friday + Saturday; holidays on these days roll to Sunday
+                .dateRoll(DateRolls.followingSunday())
+                .weekendDays(KuwaitHolidays.KUWAIT_WEEKEND)
+                .holidays(KuwaitHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKWD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceKWD.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Kuwait exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code KWD}. Covers market closure days for Boursa Kuwait
+ * and Central Bank of Kuwait (CBK) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED, SAR, and QAR convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-kw.csv},
+ * {@code eid-al-adha-kw.csv}, {@code islamic-new-year-kw.csv}, and
+ * {@code mawlid-kw.csv}. Dates for 2024–2026 are official CBK / Boursa Kuwait
+ * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
+ * calendar. Kuwait determines Islamic holiday dates by moon sighting and may
+ * differ from Saudi Arabia by ±1 day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceKWD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "KWD";
+    private static final String NAME = "Kuwait (Boursa Kuwait/CBK) Holidays";
+
+    public HolidayCalendarServiceKWD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(KuwaitHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(KuwaitHolidays.KUWAIT_WEEKEND)
+                .holidays(KuwaitHolidays.kwdHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMA.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMA.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Morocco national public holiday calendar.
+ *
+ * <p>Calendar code: {@code MA}. Covers public holidays observed in the Kingdom of
+ * Morocco as declared by the Ministry of Interior.
+ *
+ * <p>Weekend: Saturday + Sunday. Morocco uses a standard Monday–Friday workweek
+ * (established in 2004), unlike GCC countries that observe Friday + Saturday.
+ *
+ * <p>Roll strategy: {@link DateRolls#followingMonday()} for fixed Gregorian
+ * holidays — when a fixed holiday falls on Saturday or Sunday it is observed on
+ * the following Monday, consistent with Moroccan Labour Code practice. Islamic
+ * holidays are {@code rollable(false)}: Islamic holiday substitutions are issued
+ * by case-by-case government decree in Morocco rather than by a statutory
+ * automatic roll rule.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-ma.csv},
+ * {@code eid-al-adha-ma.csv}, {@code islamic-new-year-ma.csv}, and
+ * {@code mawlid-ma.csv}. Dates for 2024–2025 are official Moroccan government /
+ * CSE holiday announcements. Dates for 2026–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Morocco determines Islamic holiday dates by
+ * moon sighting and may differ from GCC countries by ±1 day — verify projected
+ * dates against official Moroccan announcements as each year is published.
+ * Corrections require a new JAR release.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceMA extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "MA";
+    private static final String NAME = "Morocco (National) Holidays";
+
+    public HolidayCalendarServiceMA() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(MoroccoHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.followingMonday())
+                .weekendDays(MoroccoHolidays.MOROCCO_WEEKEND)
+                .holidays(MoroccoHolidays.maHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMAD.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceMAD.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Morocco exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code MAD}. Covers market closure days for the Bourse de
+ * Casablanca (CSE) and Bank Al-Maghrib (BAM) financial institutions.
+ *
+ * <p>Weekend: Saturday + Sunday. Morocco uses a standard Monday–Friday workweek.
+ *
+ * <p>Roll strategy: {@link DateRolls#noRoll()} — the CSE observes holidays on
+ * their natural calendar dates, as confirmed by official CSE circular AV-2025-078.
+ * All holidays are {@code rollable(false)}. Settlement requires both counterparties
+ * to be available on the same calendar date; there is no roll-forward convention.
+ *
+ * <p>The CSE observes the same public holidays as the national calendar ({@code MA});
+ * there are no exchange-specific exclusions or additions.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-ma.csv},
+ * {@code eid-al-adha-ma.csv}, {@code islamic-new-year-ma.csv}, and
+ * {@code mawlid-ma.csv}. Dates for 2024–2025 are official Moroccan government /
+ * CSE holiday announcements. Dates for 2026–2055 are projected from the Umm
+ * al-Qura tabular Islamic calendar. Morocco determines Islamic holiday dates by
+ * moon sighting and may differ from GCC countries by ±1 day — verify projected
+ * dates against official Moroccan announcements as each year is published.
+ * Corrections require a new JAR release.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceMAD extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "MAD";
+    private static final String NAME = "Morocco (CSE/BAM) Holidays";
+
+    public HolidayCalendarServiceMAD() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(MoroccoHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(MoroccoHolidays.MOROCCO_WEEKEND)
+                .holidays(MoroccoHolidays.madHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQA.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQA.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Qatar national public holiday calendar.
+ *
+ * <p>Calendar code: {@code QA}. Covers public holidays observed in the State of
+ * Qatar as declared by the Amiri Diwan and the Qatar Central Bank (QCB).
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays that fall
+ * on Friday are observed on the preceding Thursday; holidays that fall on Saturday
+ * are observed on the following Sunday, per {@link DateRolls#previousThursdayOrFollowingSunday()}
+ * and confirmed Amiri Diwan precedents (National Day 2020 and 2021).
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-qa.csv} and
+ * {@code eid-al-adha-qa.csv}. Dates for 2024–2026 are official QCB announcements;
+ * 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * <p>Islamic New Year and Prophet's Birthday are not gazetted public holidays in
+ * Qatar and are not included.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceQA extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "QA";
+    private static final String NAME = "Qatar (National) Holidays";
+
+    public HolidayCalendarServiceQA() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(QatarHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                // Friday → preceding Thursday; Saturday → following Sunday (Amiri Diwan rule)
+                .dateRoll(DateRolls.previousThursdayOrFollowingSunday())
+                .weekendDays(QatarHolidays.QATAR_WEEKEND)
+                .holidays(QatarHolidays.baseHolidays(true))
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQAR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceQAR.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Qatar exchange and central bank holiday calendar.
+ *
+ * <p>Calendar code: {@code QAR}. Covers market closure days for the Qatar Stock
+ * Exchange (QSE) and Qatar Central Bank (QCB) financial institutions.
+ *
+ * <p>Weekend: Friday + Saturday (GCC market convention). Fixed holidays are not
+ * rolled — the settlement calendar uses natural calendar dates per
+ * {@link DateRolls#noRoll()}, consistent with the AED and SAR convention.
+ *
+ * <p>Islamic holidays are sourced from {@code eid-al-fitr-qa.csv} and
+ * {@code eid-al-adha-qa.csv}. Dates for 2024–2026 are official QCB announcements;
+ * 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ *
+ * <p>In addition to the 9 national holidays shared with {@code QA}, this calendar
+ * includes the Qatar Banks Holiday (first Sunday of March), mandated by Cabinet
+ * Decision No. (33) of 2009 for all QCB-supervised financial institutions.
+ *
+ * <p>Islamic New Year and Prophet's Birthday are not gazetted public holidays in
+ * Qatar and are not included.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceQAR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "QAR";
+    private static final String NAME = "Qatar (QSE/QCB) Holidays";
+
+    public HolidayCalendarServiceQAR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(QatarHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.noRoll())
+                .weekendDays(QatarHolidays.QATAR_WEEKEND)
+                .holidays(QatarHolidays.qarHolidays())
+                .build();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/JordanHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/JordanHolidays.java
@@ -1,0 +1,205 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay4;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay4;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Jordan public holiday lists for the
+ * national ({@code JO}) and settlement ({@code JOD}) calendars.
+ *
+ * <p>The national calendar ({@code JO}) observes 15 public holidays: New Year's
+ * Day, Labour Day, Independence Day, Christmas Day (fixed Gregorian), four days of
+ * Eid al-Fitr, Arafat Day, four days of Eid al-Adha, Islamic New Year, and
+ * Prophet's Birthday (floating Islamic).
+ *
+ * <p>The settlement calendar ({@code JOD}) uses the identical holiday set with
+ * {@code rollable(false)} for all holidays — the Amman Stock Exchange (ASE) and
+ * Central Bank of Jordan (CBJ) apply no date adjustment per the no-roll convention.
+ *
+ * <p>Jordan observes four days of Eid al-Fitr (1–4 Shawwal) and four days of
+ * Eid al-Adha (10–13 Dhu al-Hijjah), with Arafat Day (9 Dhu al-Hijjah) as a
+ * separate public holiday. These durations are confirmed by official ASE and CBJ
+ * holiday announcements for 2024–2026.
+ *
+ * <p>Christmas Day (December 25) is gazetted as a national public holiday in Jordan
+ * and is an ASE closure day, as confirmed by official ASE holiday schedules for
+ * 2025 and 2026.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code jo}). Dates for 2024–2026
+ * are sourced from official CBJ and ASE holiday announcements; dates for 2027–2055
+ * are projected from the Umm al-Qura tabular Islamic calendar. Jordan determines
+ * Islamic holiday dates by moon sighting (Ministry of Awqaf / Higher Judiciary
+ * Council) and may differ from Saudi Arabia by ±1 day; verify against official
+ * CBJ / ASE announcements as each year is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class JordanHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // Jordan market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> JORDAN_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private JordanHolidays() {}
+
+    /**
+     * Returns the 15 Jordan public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, Labour Day,
+     *                      Independence Day, Christmas Day) are rollable; all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (4th Day)")
+                    .description("Fourth day of Eid al-Fitr (4 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay4("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Independence Day")
+                    .description("Jordanian Independence Day, marking independence from the British Mandate on 25 May 1946")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.MAY, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (4th Day)")
+                    .description("Fourth day of Eid al-Adha (13 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay4("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("jo"))
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Christmas Day; gazetted national public holiday in Jordan and ASE closure day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 15 JOD holidays: the base holiday set with all holidays
+     * {@code rollable(false)}, for use with {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> jodHolidays() {
+        return baseHolidays(false);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/KuwaitHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/KuwaitHolidays.java
@@ -1,0 +1,179 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.ArafatDay;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.IsraMiraj;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the Kuwait public holiday lists for the
+ * national ({@code KW}) and settlement ({@code KWD}) calendars.
+ *
+ * <p>The national calendar ({@code KW}) observes 13 public holidays: New Year's Day,
+ * National Day, Liberation Day, Isra and Mi'raj, Arafat Day, three days of Eid al-Fitr,
+ * three days of Eid al-Adha, Islamic New Year, and Prophet's Birthday.
+ *
+ * <p>The settlement calendar ({@code KWD}) uses the identical holiday set with
+ * {@code rollable(false)} for all holidays — the exchange applies no date adjustment
+ * per the Boursa Kuwait / CBK no-roll convention.
+ *
+ * <p>Islamic holiday dates are populated through {@value DATA_VALID_THROUGH} via
+ * country-specific CSV lookup tables (country code {@code kw}). Dates for 2024–2026
+ * are sourced from official CBK and Boursa Kuwait market-holiday announcements;
+ * dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar.
+ * Kuwait determines Islamic holiday dates by moon sighting and may differ from
+ * Saudi Arabia by ±1 day; verify against official CBK / Boursa Kuwait announcements
+ * as each year is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class KuwaitHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> KUWAIT_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private KuwaitHolidays() {}
+
+    /**
+     * Returns the 13 Kuwait public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, National Day,
+     *                      Liberation Day) are rollable; all Islamic holidays are
+     *                      always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("Kuwait National Day, marking independence from Britain on 19 June 1961; observed 25 February")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.FEBRUARY, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Liberation Day")
+                    .description("Kuwait Liberation Day, marking liberation from Iraqi occupation on 26 February 1991")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.FEBRUARY, 26)
+                    .build(),
+            Holiday.builder()
+                    .name("Isra and Mi'raj")
+                    .description("Night journey and ascension of the Prophet Muhammad (27 Rajab AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IsraMiraj("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Arafat Day")
+                    .description("Day of standing at Mount Arafat, the day before Eid al-Adha (9 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ArafatDay("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Islamic New Year")
+                    .description("First day of the Islamic lunar year (1 Muharram AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new IslamicNewYear("kw"))
+                    .build(),
+            Holiday.builder()
+                    .name("Prophet's Birthday")
+                    .description("Birthday of the Prophet Muhammad (12 Rabi' al-Awwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new ProphetsBirthday("kw"))
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 13 KWD holidays: the base holiday set with all holidays
+     * {@code rollable(false)}, for use with {@link org.holiday.calendar.function.DateRolls#noRoll()}.
+     */
+    static List<Holiday> kwdHolidays() {
+        return baseHolidays(false);
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/MoroccoHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/MoroccoHolidays.java
@@ -1,0 +1,228 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.IslamicNewYear;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthday;
+import org.holiday.calendar.observance.islamic.mena.ProphetsBirthdayDay2;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Package-private factory building the Morocco public holiday list shared by
+ * the national ({@code MA}) and settlement ({@code MAD}) calendars.
+ *
+ * <p>Morocco observes 17 public holidays: ten fixed Gregorian holidays and seven
+ * Islamic holidays (two days each of Eid al-Fitr and Eid al-Adha, Islamic New Year,
+ * and two days of the Prophet's Birthday / Mawlid an-Nabi).
+ *
+ * <p>Morocco uses a <strong>Saturday + Sunday weekend</strong> — unlike GCC countries,
+ * which observe Friday + Saturday. Morocco switched to the Monday–Friday workweek in
+ * 2004 to align with European trading partners.
+ *
+ * <p>The national calendar ({@code MA}) applies {@link org.holiday.calendar.function.DateRolls#followingMonday()}
+ * to fixed Gregorian holidays ({@code rollable(true)}): when a fixed holiday falls on
+ * Saturday or Sunday, it is observed on the following Monday, consistent with Moroccan
+ * Labour Code practice. Islamic holidays are always {@code rollable(false)} — Islamic
+ * holiday substitutions in Morocco are issued by case-by-case government decree rather
+ * than by a statutory automatic roll rule.
+ *
+ * <p>The settlement calendar ({@code MAD}) uses {@link org.holiday.calendar.function.DateRolls#noRoll()}
+ * with all holidays {@code rollable(false)}: the Casablanca Stock Exchange (CSE /
+ * Bourse de Casablanca) observes holidays on their natural calendar dates, as reflected
+ * in official CSE circular AV-2025-078.
+ *
+ * <p>The Amazigh New Year (Yennayer, January 14) was officially gazetted in November
+ * 2023 and takes effect from 2024. It is included unconditionally as a
+ * {@code FixedHoliday}; callers computing dates prior to 2024 should discard this
+ * holiday as it was not legally observed before that year.
+ *
+ * <p>All Islamic holiday dates are populated through {@value DATA_VALID_THROUGH}
+ * via country-specific CSV lookup tables (country code {@code ma}).
+ * Dates for 2024–2025 are sourced from official Moroccan government / CSE holiday
+ * announcements. Dates for 2026–2055 are projected from the Umm al-Qura tabular
+ * Islamic calendar. Morocco determines Islamic holiday dates by moon sighting and
+ * may differ from GCC countries by ±1 day — verify projected dates against official
+ * Moroccan announcements as each year is published. Corrections require a new JAR
+ * release; no runtime update mechanism exists.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. Similarly, 2039 contains two Eid al-Adha
+ * occurrences; only January is recorded.
+ */
+class MoroccoHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    static final List<DayOfWeek> MOROCCO_WEEKEND = List.of(DayOfWeek.SATURDAY, DayOfWeek.SUNDAY);
+
+    private MoroccoHolidays() {}
+
+    /**
+     * Returns the 17 Morocco public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays are rollable; all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        List<Holiday> holidays = new ArrayList<>(17);
+        holidays.add(Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of the new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 1)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Manifesto of Independence Day")
+                .description("Anniversary of the submission of the Independence Manifesto to the French "
+                        + "Protectorate on 11 January 1944")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 11)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Amazigh New Year")
+                .description("Yennayer — Amazigh (Berber) New Year; gazetted as a national public holiday "
+                        + "in November 2023, effective from 2024. Callers computing dates prior to 2024 "
+                        + "should discard this holiday as it was not legally observed before that year.")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JANUARY, 14)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr")
+                .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitr("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Fitr (2nd Day)")
+                .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlFitrDay2("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Labour Day")
+                .description("International Workers' Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.MAY, 1)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha")
+                .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdha("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Eid al-Adha (2nd Day)")
+                .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new EidAlAdhaDay2("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Throne Day")
+                .description("Anniversary of the accession of King Mohammed VI to the throne on 30 July 1999")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.JULY, 30)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Islamic New Year")
+                .description("First day of the Islamic lunar year (1 Muharram AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new IslamicNewYear("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Oued Ed-Dahab Allegiance Day")
+                .description("Anniversary of the allegiance of Oued Ed-Dahab to Morocco on 14 August 1979")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 14)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Revolution of the King and the People")
+                .description("Anniversary of the exile of Sultan Mohammed V by France on 20 August 1953")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 20)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Youth Day")
+                .description("Birthday of King Mohammed VI (21 August 1963); national Youth Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.AUGUST, 21)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Prophet's Birthday")
+                .description("First day of Mawlid an-Nabi, commemorating the birth of the Prophet Muhammad "
+                        + "(12 Rabi' al-Awwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ProphetsBirthday("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Prophet's Birthday (2nd Day)")
+                .description("Second day of Mawlid an-Nabi (13 Rabi' al-Awwal AH)")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ProphetsBirthdayDay2("ma"))
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Green March Anniversary")
+                .description("Anniversary of the Green March on 6 November 1975, marking Morocco's claim "
+                        + "to the Western Sahara")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.NOVEMBER, 6)
+                .build());
+        holidays.add(Holiday.builder()
+                .name("Independence Day")
+                .description("Independence of Morocco from the French Protectorate on 18 November 1956")
+                .type(Holiday.Type.FIXED)
+                .rollable(rollableFixed)
+                .monthDay(Month.NOVEMBER, 18)
+                .build());
+        return List.copyOf(holidays);
+    }
+
+    static List<Holiday> maHolidays() {
+        return baseHolidays(true);
+    }
+
+    static List<Holiday> madHolidays() {
+        return baseHolidays(false);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/QatarHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/QatarHolidays.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay3;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.qa.QatarBanksHoliday;
+import org.holiday.calendar.observance.qa.QatarNationalSportsDay;
+
+import java.time.DayOfWeek;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Package-private factory building the Qatar public holiday lists for the
+ * national ({@code QA}) and settlement ({@code QAR}) calendars.
+ *
+ * <p>The national calendar ({@code QA}) observes 9 public holidays: New Year's Day,
+ * Qatar National Sports Day, three days of Eid al-Fitr, three days of Eid al-Adha,
+ * and National Day.
+ *
+ * <p>The settlement calendar ({@code QAR}) adds one QCB-specific closure:
+ * the Qatar Banks Holiday (first Sunday of March, Cabinet Decision No. (33) of 2009),
+ * for a total of 10 holidays.
+ *
+ * <p>Islamic New Year and Prophet's Birthday are not gazetted public holidays in
+ * Qatar and are not included (cf. UAE and Saudi Arabia which observe both).
+ *
+ * <p>Eid al-Fitr and Eid al-Adha dates are populated through
+ * {@value DATA_VALID_THROUGH} via country-specific CSV lookup tables
+ * (country code {@code qa}). Dates for 2024–2026 are official Qatar Central Bank
+ * (QCB) announcements; dates for 2027–2055 are projected from the Umm al-Qura
+ * tabular Islamic calendar. Verify against official QCB/QSE announcements as
+ * each year is published.
+ *
+ * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
+ * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
+ */
+class QatarHolidays {
+
+    static final int DATA_VALID_THROUGH = 2055;
+
+    // GCC market weekend: Friday + Saturday; Sunday is the first business day.
+    static final List<DayOfWeek> QATAR_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
+
+    private QatarHolidays() {}
+
+    /**
+     * Returns the 9 Qatar public holidays.
+     *
+     * @param rollableFixed whether fixed-date holidays (New Year's Day, National Day)
+     *                      are rollable; the floating Sports Day and all Islamic
+     *                      holidays are always {@code rollable(false)}
+     */
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Qatar National Sports Day")
+                    .description("Qatar National Sports Day — second Tuesday of February (Emiri Decree No. 80 of 2011)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new QatarNationalSportsDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr")
+                    .description("First day of Eid al-Fitr, marking the end of Ramadan (1 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitr("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (2nd Day)")
+                    .description("Second day of Eid al-Fitr (2 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay2("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Fitr (3rd Day)")
+                    .description("Third day of Eid al-Fitr (3 Shawwal AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlFitrDay3("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha")
+                    .description("First day of Eid al-Adha, the Feast of Sacrifice (10 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdha("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (2nd Day)")
+                    .description("Second day of Eid al-Adha (11 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay2("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("Eid al-Adha (3rd Day)")
+                    .description("Third day of Eid al-Adha (12 Dhu al-Hijjah AH)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EidAlAdhaDay3("qa"))
+                    .build(),
+            Holiday.builder()
+                    .name("National Day")
+                    .description("Qatar National Day, marking independence from Britain on 18 December 1971")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(rollableFixed)
+                    .monthDay(Month.DECEMBER, 18)
+                    .build()
+        );
+    }
+
+    /**
+     * Returns the 10 Qatar QSE/QCB holidays: the 9 base holidays (with
+     * {@code rollableFixed=false}) plus the Qatar Banks Holiday.
+     */
+    static List<Holiday> qarHolidays() {
+        List<Holiday> holidays = new ArrayList<>(baseHolidays(false));
+        holidays.add(
+            Holiday.builder()
+                    .name("Qatar Banks Holiday")
+                    .description("Annual bank holiday for all QCB-supervised financial institutions — first Sunday of March (Cabinet Decision No. (33) of 2009)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new QatarBanksHoliday())
+                    .build()
+        );
+        return Collections.unmodifiableList(holidays);
+    }
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/eg/ShamElNessim.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/eg/ShamElNessim.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.eg;
+
+import org.holiday.calendar.observance.CompositeObservance;
+import org.holiday.calendar.observance.christian.OrthodoxEaster;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of <em>Sham El-Nessim</em> (شم النسيم), the Egyptian spring festival.
+ *
+ * <p>Sham El-Nessim is celebrated on the day after Coptic Easter (Monday after
+ * Coptic Easter Sunday). The Coptic Orthodox Church uses the same Julian-calendar
+ * Easter algorithm as the Eastern Orthodox churches, implemented here via
+ * {@link OrthodoxEaster}.
+ *
+ * <p>Sham El-Nessim is an ancient Egyptian public holiday predating both Christianity
+ * and Islam. It is observed as a national public holiday in Egypt by all Egyptians
+ * regardless of religion and is a bank and exchange closure day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ShamElNessim extends CompositeObservance {
+
+    public ShamElNessim() {
+        super(new OrthodoxEaster());
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ArafatDay.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ArafatDay.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Observance of Arafat Day (9 Dhu al-Hijjah AH), the day of standing at Mount
+ * Arafat — the day before Eid al-Adha.
+ *
+ * <p>Dates are determined by official moon sighting and cannot be computed
+ * algorithmically. Dates are derived from the official Eid al-Adha date minus
+ * one day, sourced from country-specific exchange and central bank holiday
+ * announcements.</p>
+ *
+ * <p>Date data is loaded at runtime from {@code arafat-day-{countryCode}.csv}
+ * in this package, where {@code countryCode} is the ISO 3166-1 alpha-2 country
+ * code in lower case (e.g. {@code kw}).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ArafatDay extends AbstractObservance {
+
+    static final int DATA_VALID_FROM = 2024;
+    static final int DATA_VALID_THROUGH = 2055;
+
+    private static final Logger log = LoggerFactory.getLogger(ArafatDay.class);
+    private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
+            new ConcurrentHashMap<>();
+
+    private final Map<Integer, LocalDate> dates;
+
+    public ArafatDay(String countryCode) {
+        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+                cc -> CsvObservanceLoader.loadSingle(ArafatDay.class, "arafat-day-" + cc + ".csv"));
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return dates.get(year);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        if (year > DATA_VALID_THROUGH) {
+            log.warn("Year {} exceeds data ceiling {}; Arafat Day date unavailable", year, DATA_VALID_THROUGH);
+            return false;
+        }
+        return dates.containsKey(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/Ashura.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/Ashura.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Observance of Ashura (10 Muharram AH), the first day of the two-day Ashura
+ * public holiday in Bahrain.
+ *
+ * <p>Ashura marks the 10th day of Muharram and is of particular significance for
+ * Shia Muslims. Bahrain, which has a large Shia Muslim population, gazetted it as
+ * a two-day national public holiday (10–11 Muharram). The Central Bank of Bahrain
+ * (CBB) and Boursa Bahrain observe both days as closure days.</p>
+ *
+ * <p>Dates are determined by official moon sighting and cannot be computed
+ * algorithmically. Dates for 2024–2026 are sourced from official CBB / Boursa
+ * Bahrain holiday announcements. Dates for 2027–2055 are projected as
+ * 10 Muharram (Islamic New Year + 9 days) from the Umm al-Qura tabular Islamic
+ * calendar; verify against official CBB announcements as each year is published.</p>
+ *
+ * <p>The second day of Ashura (11 Muharram) is provided by {@link AshuraDay2}.</p>
+ *
+ * <p>Date data is loaded at runtime from {@code ashura-{countryCode}.csv} in this
+ * package, where {@code countryCode} is the ISO 3166-1 alpha-2 country code in
+ * lower case (e.g. {@code bh}).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class Ashura extends AbstractObservance {
+
+    static final int DATA_VALID_FROM = 2024;
+    static final int DATA_VALID_THROUGH = 2055;
+
+    private static final Logger log = LoggerFactory.getLogger(Ashura.class);
+    private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
+            new ConcurrentHashMap<>();
+
+    private final Map<Integer, LocalDate> dates;
+
+    public Ashura(String countryCode) {
+        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+                cc -> CsvObservanceLoader.loadSingle(Ashura.class, "ashura-" + cc + ".csv"));
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return dates.get(year);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        if (year > DATA_VALID_THROUGH) {
+            log.warn("Year {} exceeds data ceiling {}; Ashura date unavailable", year, DATA_VALID_THROUGH);
+            return false;
+        }
+        return dates.containsKey(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/AshuraDay2.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/AshuraDay2.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of the second day of Ashura (11 Muharram AH).
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link Ashura})
+ * by one calendar day. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class AshuraDay2 extends AbstractObservance {
+
+    private final Ashura base;
+
+    public AshuraDay2(String countryCode) {
+        this.base = new Ashura(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay4.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrDay4.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of the fourth day of Eid al-Fitr (4 Shawwal AH), marking the
+ * final day of the Eid al-Fitr celebration.
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link EidAlFitr})
+ * by three calendar days. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.</p>
+ *
+ * <p>Jordan observes four days of Eid al-Fitr per official ASE and CBJ holiday
+ * announcements.</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class EidAlFitrDay4 extends AbstractObservance {
+
+    private final EidAlFitr base;
+
+    public EidAlFitrDay4(String countryCode) {
+        this.base = new EidAlFitr(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(3);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/IsraMiraj.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/IsraMiraj.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.time.LocalDate;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Observance of Isra and Mi'raj (27 Rajab AH), commemorating the night journey
+ * and ascension of the Prophet Muhammad.
+ *
+ * <p>Dates are determined by official moon sighting and cannot be computed
+ * algorithmically. Dates for 2024–2026 are sourced from official country
+ * exchange and central bank holiday announcements. Dates for 2027–2055 are
+ * projected from the Umm al-Qura tabular Islamic calendar (27 Rajab AH =
+ * 1 Muharram + 204 days); verify against official announcements as each year
+ * is published.</p>
+ *
+ * <p>Note: Gregorian year 2027 contains two 27 Rajab occurrences (~January 6
+ * AH 1448 and ~December 25 AH 1449). Only the first (January) occurrence is
+ * recorded in the CSV. The December occurrence cannot be represented under the
+ * single-date-per-year-key design.</p>
+ *
+ * <p>Date data is loaded at runtime from {@code isra-miraj-{countryCode}.csv}
+ * in this package, where {@code countryCode} is the ISO 3166-1 alpha-2 country
+ * code in lower case (e.g. {@code kw}).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class IsraMiraj extends AbstractObservance {
+
+    static final int DATA_VALID_FROM = 2024;
+    static final int DATA_VALID_THROUGH = 2055;
+
+    private static final Logger log = LoggerFactory.getLogger(IsraMiraj.class);
+    private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
+            new ConcurrentHashMap<>();
+
+    private final Map<Integer, LocalDate> dates;
+
+    public IsraMiraj(String countryCode) {
+        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+                cc -> CsvObservanceLoader.loadSingle(IsraMiraj.class, "isra-miraj-" + cc + ".csv"));
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return dates.get(year);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        if (year > DATA_VALID_THROUGH) {
+            log.warn("Year {} exceeds data ceiling {}; Isra and Mi'raj date unavailable", year, DATA_VALID_THROUGH);
+            return false;
+        }
+        return dates.containsKey(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ProphetsBirthdayDay2.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ProphetsBirthdayDay2.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of the second day of the Prophet's Birthday (Mawlid an-Nabi),
+ * commemorating the continuation of the Mawlid celebration (13 Rabi' al-Awwal AH).
+ *
+ * <p>The date is synthesized by advancing the first-day date ({@link ProphetsBirthday})
+ * by one calendar day. Data validity range and country-specific CSV source are
+ * inherited from the first-day observance.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ProphetsBirthdayDay2 extends AbstractObservance {
+
+    private final ProphetsBirthday base;
+
+    public ProphetsBirthdayDay2(String countryCode) {
+        this.base = new ProphetsBirthday(countryCode);
+    }
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return base.apply(year).plusDays(1);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return base.test(year);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarBanksHoliday.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarBanksHoliday.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Observance of the Qatar Banks Holiday — the first Sunday of March.
+ *
+ * <p>Mandated by Cabinet Decision No. (33) of 2009 for all banks, money exchange
+ * outlets, investment and financial companies, insurance firms, and insurance
+ * broker companies operating in the State of Qatar. Sunday is a working day in
+ * Qatar (Friday + Saturday weekend), so this closure falls on the first business
+ * day of March in most years.
+ *
+ * <p>This holiday applies to the {@code QAR} (QSE/QCB) settlement calendar only;
+ * it is not a gazetted national public holiday and is not included in {@code QA}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class QatarBanksHoliday extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.MARCH, 1)
+                        .with(TemporalAdjusters.dayOfWeekInMonth(1, DayOfWeek.SUNDAY));
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return year >= 2009;
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarNationalSportsDay.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/qa/QatarNationalSportsDay.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.time.temporal.TemporalAdjusters;
+
+/**
+ * Observance of Qatar National Sports Day — the second Tuesday of February.
+ *
+ * <p>Established by Emiri Decree No. 80 of 2011; first observed on
+ * 14 February 2012. Falls on a Tuesday by definition and never requires a
+ * substitute holiday.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class QatarNationalSportsDay extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.FEBRUARY, 1)
+                        .with(TemporalAdjusters.dayOfWeekInMonth(2, DayOfWeek.TUESDAY));
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        return year >= 2012;
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -16,3 +16,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceBH
 org.holiday.calendar.impl.HolidayCalendarServiceBHD
 org.holiday.calendar.impl.HolidayCalendarServiceMA
 org.holiday.calendar.impl.HolidayCalendarServiceMAD
+org.holiday.calendar.impl.HolidayCalendarServiceJO
+org.holiday.calendar.impl.HolidayCalendarServiceJOD

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -8,3 +8,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceTR
 org.holiday.calendar.impl.HolidayCalendarServiceTRY
 org.holiday.calendar.impl.HolidayCalendarServiceQA
 org.holiday.calendar.impl.HolidayCalendarServiceQAR
+org.holiday.calendar.impl.HolidayCalendarServiceKW
+org.holiday.calendar.impl.HolidayCalendarServiceKWD

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -12,3 +12,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceQA
 org.holiday.calendar.impl.HolidayCalendarServiceQAR
 org.holiday.calendar.impl.HolidayCalendarServiceKW
 org.holiday.calendar.impl.HolidayCalendarServiceKWD
+org.holiday.calendar.impl.HolidayCalendarServiceBH
+org.holiday.calendar.impl.HolidayCalendarServiceBHD

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,3 +1,5 @@
+org.holiday.calendar.impl.HolidayCalendarServiceEG
+org.holiday.calendar.impl.HolidayCalendarServiceEGP
 org.holiday.calendar.impl.HolidayCalendarServiceAE
 org.holiday.calendar.impl.HolidayCalendarServiceAED
 org.holiday.calendar.impl.HolidayCalendarServiceSA

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -14,3 +14,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceKW
 org.holiday.calendar.impl.HolidayCalendarServiceKWD
 org.holiday.calendar.impl.HolidayCalendarServiceBH
 org.holiday.calendar.impl.HolidayCalendarServiceBHD
+org.holiday.calendar.impl.HolidayCalendarServiceMA
+org.holiday.calendar.impl.HolidayCalendarServiceMAD

--- a/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-mena/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -6,3 +6,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceIL
 org.holiday.calendar.impl.HolidayCalendarServiceILS
 org.holiday.calendar.impl.HolidayCalendarServiceTR
 org.holiday.calendar.impl.HolidayCalendarServiceTRY
+org.holiday.calendar.impl.HolidayCalendarServiceQA
+org.holiday.calendar.impl.HolidayCalendarServiceQAR

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-bh.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-bh.csv
@@ -1,0 +1,55 @@
+# Arafat Day (9 Dhu al-Hijjah) — Bahrain public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Bahrain observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBB / Boursa Bahrain official holiday announcements; Arafat Day
+#            falls one day before Eid al-Adha in both years.
+# 2026:      Umm al-Qura tabular projection (one day before Eid al-Adha May 27).
+# 2027–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-bh.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBB / Boursa Bahrain announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,CBB official
+2025,2025-06-05,CBB official
+2026,2026-05-26,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-eg.csv
@@ -1,0 +1,53 @@
+# Arafat Day (9 Dhu al-Hijjah) — Egypt public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBE / EGX official holiday announcements; Arafat Day
+#            falls one day before Eid al-Adha in both years.
+# 2026–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-eg.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,CBE official
+2025,2025-06-05,CBE official
+# 2026–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2026,2026-05-25,Umm al-Qura projection
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-jo.csv
@@ -1,0 +1,55 @@
+# Arafat Day (9 Dhu al-Hijjah) — Jordan public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2026: ASE official holiday announcements; Arafat Day falls one day before
+#            Eid al-Adha in all three years. Note: 2024 Arafat Day (Jun 15) falls
+#            on a Saturday (Jordan weekend); no additional settlement closure arises
+#            under the no-roll convention for JOD.
+# 2027–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-jo.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,ASE official
+2025,2025-06-05,ASE official
+2026,2026-05-26,ASE official
+# 2027–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/arafat-day-kw.csv
@@ -1,0 +1,55 @@
+# Arafat Day (9 Dhu al-Hijjah) — Kuwait public holiday dates
+# The day of standing at Mount Arafat; the day before Eid al-Adha.
+# Dates are derived as Eid al-Adha (10 Dhu al-Hijjah) minus one day.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; Arafat Day
+#            falls one day before Eid al-Adha in both years.
+# 2026:      Boursa Kuwait official (May 26, one day before Eid al-Adha May 27).
+# 2027–2055: Projected as one day before the Eid al-Adha date in eid-al-adha-kw.csv
+#            (Umm al-Qura tabular Islamic calendar, 9 Dhu al-Hijjah AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences;
+# only the first (January) Eid al-Adha is recorded, so Arafat Day 2039 is
+# January 3 (one day before January 4 Eid al-Adha).
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-15,CBK official
+2025,2025-06-05,CBK official
+2026,2026-05-26,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection (Eid al-Adha − 1 day); verify against official announcements
+2027,2027-05-14,Umm al-Qura projection
+2028,2028-05-03,Umm al-Qura projection
+2029,2029-04-22,Umm al-Qura projection
+2030,2030-04-11,Umm al-Qura projection
+2031,2031-03-31,Umm al-Qura projection
+2032,2032-03-19,Umm al-Qura projection
+2033,2033-03-09,Umm al-Qura projection
+2034,2034-02-26,Umm al-Qura projection
+2035,2035-02-15,Umm al-Qura projection
+2036,2036-02-05,Umm al-Qura projection
+2037,2037-01-24,Umm al-Qura projection
+2038,2038-01-14,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences; Arafat Day is one day before January 4 Eid
+2039,2039-01-03,Umm al-Qura projection (January occurrence only)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-12,Umm al-Qura projection
+2041,2041-12-01,Umm al-Qura projection
+2042,2042-11-20,Umm al-Qura projection
+2043,2043-11-10,Umm al-Qura projection
+2044,2044-10-29,Umm al-Qura projection
+2045,2045-10-19,Umm al-Qura projection
+2046,2046-10-08,Umm al-Qura projection
+2047,2047-09-27,Umm al-Qura projection
+2048,2048-09-16,Umm al-Qura projection
+2049,2049-09-05,Umm al-Qura projection
+2050,2050-08-25,Umm al-Qura projection
+2051,2051-08-15,Umm al-Qura projection
+2052,2052-08-03,Umm al-Qura projection
+2053,2053-07-23,Umm al-Qura projection
+2054,2054-07-13,Umm al-Qura projection
+2055,2055-07-02,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/ashura-bh.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/ashura-bh.csv
@@ -1,0 +1,55 @@
+# Ashura (10 Muharram) — Bahrain public holiday dates
+# First day of the two-day Ashura public holiday in Bahrain (10–11 Muharram AH).
+# Ashura marks the 10th of Muharram and is observed as a national public holiday
+# in Bahrain; the Central Bank of Bahrain (CBB) and Boursa Bahrain close on both days.
+#
+# Dates are derived as Islamic New Year (1 Muharram) + 9 days. Bahrain determines
+# Muharram dates by moon sighting and may differ from Saudi Arabia by ±1 day.
+#
+# 2024–2025: Based on CBB official Islamic New Year announcement + 9 days; consistent
+#            with BNA / Crown Prince circular Ashura holiday announcements.
+# 2026:      Umm al-Qura tabular projection (Islamic New Year + 9 days); verify against
+#            official CBB / Boursa Bahrain announcement for 2026.
+# 2027–2055: Projected as Islamic New Year (1 Muharram) + 9 days from the Umm al-Qura
+#            tabular Islamic calendar. Verify against official CBB / Boursa Bahrain
+#            announcements as each year is published.
+#
+# NOTE — 2040: Islamic New Year 2040 has two occurrences (~Jan 9 and ~Dec 29); only the
+# January Ashura (Jan 18) is recorded here. The December New Year's Ashura falls on
+# Jan 7, 2041 and is captured in the 2041 entry.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-16,CBB official (Islamic New Year Jul 7 + 9 days)
+2025,2025-07-05,CBB official (Islamic New Year Jun 26 + 9 days)
+2026,2026-06-25,Umm al-Qura projection (Islamic New Year Jun 16 + 9 days)
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBB / Boursa Bahrain announcements
+2027,2027-06-13,Umm al-Qura projection
+2028,2028-06-01,Umm al-Qura projection
+2029,2029-05-21,Umm al-Qura projection
+2030,2030-05-10,Umm al-Qura projection
+2031,2031-04-29,Umm al-Qura projection
+2032,2032-04-17,Umm al-Qura projection
+2033,2033-04-06,Umm al-Qura projection
+2034,2034-03-26,Umm al-Qura projection
+2035,2035-03-15,Umm al-Qura projection
+2036,2036-03-03,Umm al-Qura projection
+2037,2037-02-20,Umm al-Qura projection
+2038,2038-02-09,Umm al-Qura projection
+2039,2039-01-29,Umm al-Qura projection
+# 2040: two Islamic New Year occurrences; only January Ashura recorded (Jan 9 + 9 = Jan 18)
+2040,2040-01-18,Umm al-Qura projection (January occurrence only; December New Year yields Jan 7 2041)
+2041,2041-12-27,Umm al-Qura projection
+2042,2042-12-16,Umm al-Qura projection
+2043,2043-12-05,Umm al-Qura projection
+2044,2044-11-23,Umm al-Qura projection
+2045,2045-11-12,Umm al-Qura projection
+2046,2046-11-01,Umm al-Qura projection
+2047,2047-10-21,Umm al-Qura projection
+2048,2048-10-09,Umm al-Qura projection
+2049,2049-09-28,Umm al-Qura projection
+2050,2050-09-17,Umm al-Qura projection
+2051,2051-09-06,Umm al-Qura projection
+2052,2052-08-25,Umm al-Qura projection
+2053,2053-08-14,Umm al-Qura projection
+2054,2054-08-03,Umm al-Qura projection
+2055,2055-07-23,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-bh.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-bh.csv
@@ -1,0 +1,56 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Bahrain public holiday dates
+# The Feast of Sacrifice. The observed date follows the official announcement
+# by the Crown Prince and Prime Minister of Bahrain.
+#
+# Bahrain observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBB / Boursa Bahrain official holiday announcements; aligned with GCC
+#            consensus in both years.
+# 2026:      Umm al-Qura tabular projection; verify against official CBB / Boursa
+#            Bahrain announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH).
+#            Verify against official CBB / Boursa Bahrain announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBB official
+2025,2025-06-06,CBB official
+2026,2026-05-27,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBB / Boursa Bahrain announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-eg.csv
@@ -1,0 +1,54 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Egypt public holiday dates
+# The Feast of Sacrifice. The observed date follows the Central Bank of Egypt
+# (CBE) announcement, based on Egyptian moon-sighting observation.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBE / EGX official holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcement when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH, Küçük 30-year cycle).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBE official
+2025,2025-06-06,CBE official
+# 2026–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2026,2026-05-26,Umm al-Qura projection
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-jo.csv
@@ -1,0 +1,54 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Jordan public holiday dates
+# The Feast of Sacrifice. The observed date follows the official announcement
+# by the Jordanian government (Ministry of Awqaf / Higher Judiciary Council).
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2026: CBJ / ASE official holiday announcements; aligned with Umm al-Qura
+#            in all three years.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH).
+#            Verify against official CBJ / ASE announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBJ official
+2025,2025-06-06,ASE official
+2026,2026-05-27,ASE official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-kw.csv
@@ -1,0 +1,56 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Kuwait public holiday dates
+# The Feast of Sacrifice. The observed date follows the Kuwait Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement (Boursa Kuwait market
+#            holidays page, 2026 calendar). Kuwait observed +1 day relative to SA.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH, Küçük 30-year cycle).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,CBK official
+2025,2025-06-06,CBK official
+2026,2026-05-27,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-ma.csv
@@ -1,0 +1,55 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Morocco public holiday dates
+# The Feast of Sacrifice. The observed date follows the official announcement
+# by the Moroccan Ministry of Interior.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,Official announcement
+2025,2025-06-07,Official announcement (CSE AV-2025-078; one day after GCC consensus)
+2026,2026-05-27,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-qa.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-qa.csv
@@ -1,0 +1,51 @@
+# Eid al-Adha (10 Dhu al-Hijjah) — Qatar public holiday dates
+# The Feast of Sacrifice. The observed date follows the Qatar Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# 2024–2026: Qatar Central Bank (QCB) official holiday announcements for financial
+#            institutions; consistent with Umm al-Qura calendar in confirmed years.
+#            Source: The Peninsula Qatar / QCB circulars.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (10 Dhu al-Hijjah AH, Küçük 30-year cycle).
+#            Verify against official QCB/QSE announcements as each year is published.
+#
+# NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
+# (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
+# is recorded. As a consequence, the 2040 entry falls in December.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-06-16,QCB official
+2025,2025-06-06,QCB official
+2026,2026-05-26,QCB official
+# 2027–2055: Umm al-Qura tabular projection; verify against official QCB/QSE announcements
+2027,2027-05-15,Umm al-Qura projection
+2028,2028-05-04,Umm al-Qura projection
+2029,2029-04-23,Umm al-Qura projection
+2030,2030-04-12,Umm al-Qura projection
+2031,2031-04-01,Umm al-Qura projection
+2032,2032-03-20,Umm al-Qura projection
+2033,2033-03-10,Umm al-Qura projection
+2034,2034-02-27,Umm al-Qura projection
+2035,2035-02-16,Umm al-Qura projection
+2036,2036-02-06,Umm al-Qura projection
+2037,2037-01-25,Umm al-Qura projection
+2038,2038-01-15,Umm al-Qura projection
+# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
+2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+# 2040: falls in December because January slot was consumed by 2039 double-occurrence
+2040,2040-12-13,Umm al-Qura projection
+2041,2041-12-02,Umm al-Qura projection
+2042,2042-11-21,Umm al-Qura projection
+2043,2043-11-11,Umm al-Qura projection
+2044,2044-10-30,Umm al-Qura projection
+2045,2045-10-20,Umm al-Qura projection
+2046,2046-10-09,Umm al-Qura projection
+2047,2047-09-28,Umm al-Qura projection
+2048,2048-09-17,Umm al-Qura projection
+2049,2049-09-06,Umm al-Qura projection
+2050,2050-08-26,Umm al-Qura projection
+2051,2051-08-16,Umm al-Qura projection
+2052,2052-08-04,Umm al-Qura projection
+2053,2053-07-24,Umm al-Qura projection
+2054,2054-07-14,Umm al-Qura projection
+2055,2055-07-03,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-bh.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-bh.csv
@@ -1,0 +1,55 @@
+# Eid al-Fitr (1 Shawwal) — Bahrain public holiday dates
+# Marks the end of Ramadan. The observed date follows the official announcement
+# by the Crown Prince and Prime Minister of Bahrain.
+#
+# Bahrain observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBB / Boursa Bahrain official holiday announcements; aligned with GCC
+#            consensus in both years.
+# 2026:      Umm al-Qura tabular projection; verify against official CBB / Boursa
+#            Bahrain announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBB / Boursa Bahrain announcements as each year
+#            is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,CBB official
+2025,2025-03-30,CBB official
+2026,2026-03-20,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBB / Boursa Bahrain announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-eg.csv
@@ -1,0 +1,53 @@
+# Eid al-Fitr (1 Shawwal) — Egypt public holiday dates
+# Marks the end of Ramadan. The observed date follows the Central Bank of Egypt
+# (CBE) announcement, based on Egyptian moon-sighting observation.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBE / EGX official holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcement when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,CBE official
+2025,2025-03-30,CBE official
+# 2026–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2026,2026-03-19,Umm al-Qura projection
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-jo.csv
@@ -1,0 +1,53 @@
+# Eid al-Fitr (1 Shawwal) — Jordan public holiday dates
+# Marks the end of Ramadan. The observed date follows the official announcement
+# by the Jordanian government (Ministry of Awqaf / Higher Judiciary Council).
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBJ / ASE official holiday announcement; Jordan sighted moon one day
+#            earlier than Saudi Arabia (Apr 9 vs Apr 10).
+# 2025–2026: ASE official holiday announcements; aligned with Umm al-Qura in both years.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-09,CBJ official
+2025,2025-03-30,ASE official
+2026,2026-03-20,ASE official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-kw.csv
@@ -1,0 +1,55 @@
+# Eid al-Fitr (1 Shawwal) — Kuwait public holiday dates
+# Marks the end of Ramadan. The observed date follows the Kuwait Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement (Boursa Kuwait market
+#            holidays page, 2026 calendar). Kuwait observed +1 day relative to SA.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,CBK official
+2025,2025-03-30,CBK official
+2026,2026-03-20,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-ma.csv
@@ -1,0 +1,54 @@
+# Eid al-Fitr (1 Shawwal) — Morocco public holiday dates
+# Marks the end of Ramadan. The observed date follows the official announcement
+# by the Moroccan Ministry of Interior.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,Official announcement
+2025,2025-03-31,Official announcement
+2026,2026-03-20,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-qa.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-qa.csv
@@ -1,0 +1,50 @@
+# Eid al-Fitr (1 Shawwal) — Qatar public holiday dates
+# Marks the end of Ramadan. The observed date follows the Qatar Ministry of Awqaf
+# and Islamic Affairs Crescent Sighting Committee ruling.
+#
+# 2024–2026: Qatar Central Bank (QCB) official holiday announcements for financial
+#            institutions; consistent with Umm al-Qura calendar in confirmed years.
+#            Source: The Peninsula Qatar / QCB circulars.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Shawwal AH).
+#            Verify against official QCB/QSE announcements as each year is published.
+#
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
+# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
+# here. The December occurrence cannot be represented under the single-date-per-
+# year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-04-10,QCB official
+2025,2025-03-30,QCB official
+2026,2026-03-19,QCB official
+# 2027–2055: Umm al-Qura tabular projection; verify against official QCB/QSE announcements
+2027,2027-03-09,Umm al-Qura projection
+2028,2028-02-26,Umm al-Qura projection
+2029,2029-02-15,Umm al-Qura projection
+2030,2030-02-04,Umm al-Qura projection
+2031,2031-01-24,Umm al-Qura projection
+2032,2032-01-14,Umm al-Qura projection
+# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
+2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Umm al-Qura projection
+2035,2035-12-01,Umm al-Qura projection
+2036,2036-11-19,Umm al-Qura projection
+2037,2037-11-09,Umm al-Qura projection
+2038,2038-10-29,Umm al-Qura projection
+2039,2039-10-19,Umm al-Qura projection
+2040,2040-10-08,Umm al-Qura projection
+2041,2041-09-27,Umm al-Qura projection
+2042,2042-09-16,Umm al-Qura projection
+2043,2043-09-05,Umm al-Qura projection
+2044,2044-08-24,Umm al-Qura projection
+2045,2045-08-14,Umm al-Qura projection
+2046,2046-08-04,Umm al-Qura projection
+2047,2047-07-24,Umm al-Qura projection
+2048,2048-07-13,Umm al-Qura projection
+2049,2049-07-02,Umm al-Qura projection
+2050,2050-06-21,Umm al-Qura projection
+2051,2051-06-10,Umm al-Qura projection
+2052,2052-05-30,Umm al-Qura projection
+2053,2053-05-19,Umm al-Qura projection
+2054,2054-05-09,Umm al-Qura projection
+2055,2055-04-28,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-bh.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-bh.csv
@@ -1,0 +1,54 @@
+# Islamic New Year (1 Muharram) — Bahrain public holiday dates
+# First day of the Islamic lunar year.
+#
+# Bahrain observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBB / Boursa Bahrain official holiday announcements; aligned with GCC
+#            consensus in both years.
+# 2026:      Umm al-Qura tabular projection; verify against official CBB / Boursa
+#            Bahrain announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBB / Boursa Bahrain announcements as each year
+#            is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded. The Ashura derived from the December occurrence (January 7, 2041)
+# falls in 2041 and is captured there.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBB official
+2025,2025-06-26,CBB official
+2026,2026-06-16,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBB / Boursa Bahrain announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-eg.csv
@@ -1,0 +1,51 @@
+# Islamic New Year (1 Muharram) — Egypt public holiday dates
+# First day of the Islamic lunar year.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBE / EGX official holiday announcement.
+# 2025–2026: Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcements when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBE official
+# 2025–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2025,2025-06-26,Umm al-Qura projection
+2026,2026-06-15,Umm al-Qura projection
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-jo.csv
@@ -1,0 +1,52 @@
+# Islamic New Year (1 Muharram) — Jordan public holiday dates
+# First day of the Islamic lunar year.
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBJ / ASE official holiday announcements; aligned with Umm al-Qura
+#            in both years.
+# 2026:      Umm al-Qura tabular projection; verify against official CBJ / ASE
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBJ official
+2025,2025-06-26,ASE official
+2026,2026-06-16,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-kw.csv
@@ -1,0 +1,53 @@
+# Islamic New Year (1 Muharram) — Kuwait public holiday dates
+# First day of the Islamic lunar year.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement. Kuwait observed +1 day
+#            relative to SA (June 16 vs SA June 15).
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,CBK official
+2025,2025-06-26,CBK official
+2026,2026-06-16,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/islamic-new-year-ma.csv
@@ -1,0 +1,52 @@
+# Islamic New Year (1 Muharram) — Morocco public holiday dates
+# First day of the Islamic lunar year.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (1 Muharram AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2040: Gregorian year 2040 contains two 1 Muharram occurrences
+# (~January 9 AH 1462 and ~December 29 AH 1463). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-07-07,Official announcement
+2025,2025-06-27,Official announcement (CSE AV-2025-078; one day after GCC consensus)
+2026,2026-06-16,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-06-04,Umm al-Qura projection
+2028,2028-05-23,Umm al-Qura projection
+2029,2029-05-12,Umm al-Qura projection
+2030,2030-05-01,Umm al-Qura projection
+2031,2031-04-20,Umm al-Qura projection
+2032,2032-04-08,Umm al-Qura projection
+2033,2033-03-28,Umm al-Qura projection
+2034,2034-03-17,Umm al-Qura projection
+2035,2035-03-06,Umm al-Qura projection
+2036,2036-02-23,Umm al-Qura projection
+2037,2037-02-11,Umm al-Qura projection
+2038,2038-01-31,Umm al-Qura projection
+2039,2039-01-20,Umm al-Qura projection
+# 2040: two 1 Muharram occurrences (~Jan 9 AH 1462 and ~Dec 29 AH 1463); Jan 9 recorded
+2040,2040-01-09,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2041,2041-12-18,Umm al-Qura projection
+2042,2042-12-07,Umm al-Qura projection
+2043,2043-11-26,Umm al-Qura projection
+2044,2044-11-14,Umm al-Qura projection
+2045,2045-11-03,Umm al-Qura projection
+2046,2046-10-23,Umm al-Qura projection
+2047,2047-10-12,Umm al-Qura projection
+2048,2048-09-30,Umm al-Qura projection
+2049,2049-09-19,Umm al-Qura projection
+2050,2050-09-08,Umm al-Qura projection
+2051,2051-08-28,Umm al-Qura projection
+2052,2052-08-16,Umm al-Qura projection
+2053,2053-08-05,Umm al-Qura projection
+2054,2054-07-25,Umm al-Qura projection
+2055,2055-07-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/isra-miraj-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/isra-miraj-kw.csv
@@ -1,0 +1,52 @@
+# Isra and Mi'raj (27 Rajab) — Kuwait public holiday dates
+# Commemorates the night journey and ascension of the Prophet Muhammad.
+# 27 Rajab AH = 1 Muharram (Islamic New Year) + 204 days.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2026: CBK / Boursa Kuwait official holiday announcements.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar (27 Rajab AH).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2027: Gregorian year 2027 contains two 27 Rajab occurrences
+# (~January 6 AH 1448 and ~December 25 AH 1449). Only the first (January)
+# occurrence is recorded here. The December occurrence cannot be represented
+# under the single-date-per-year-key design.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-02-08,CBK official
+2025,2025-01-27,CBK official
+2026,2026-01-16,CBK official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+# 2027: two 27 Rajab occurrences (~Jan 6 AH 1448 and ~Dec 25 AH 1449); Jan 6 recorded
+2027,2027-01-06,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2028,2028-12-13,Umm al-Qura projection
+2029,2029-12-02,Umm al-Qura projection
+2030,2030-11-21,Umm al-Qura projection
+2031,2031-11-10,Umm al-Qura projection
+2032,2032-10-29,Umm al-Qura projection
+2033,2033-10-18,Umm al-Qura projection
+2034,2034-10-07,Umm al-Qura projection
+2035,2035-09-26,Umm al-Qura projection
+2036,2036-09-14,Umm al-Qura projection
+2037,2037-09-03,Umm al-Qura projection
+2038,2038-08-23,Umm al-Qura projection
+2039,2039-08-12,Umm al-Qura projection
+2040,2040-08-01,Umm al-Qura projection
+2041,2041-07-21,Umm al-Qura projection
+2042,2042-07-10,Umm al-Qura projection
+2043,2043-06-29,Umm al-Qura projection
+2044,2044-06-17,Umm al-Qura projection
+2045,2045-06-06,Umm al-Qura projection
+2046,2046-05-26,Umm al-Qura projection
+2047,2047-05-15,Umm al-Qura projection
+2048,2048-05-03,Umm al-Qura projection
+2049,2049-04-22,Umm al-Qura projection
+2050,2050-04-11,Umm al-Qura projection
+2051,2051-03-31,Umm al-Qura projection
+2052,2052-03-19,Umm al-Qura projection
+2053,2053-03-08,Umm al-Qura projection
+2054,2054-02-25,Umm al-Qura projection
+2055,2055-02-14,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-bh.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-bh.csv
@@ -1,0 +1,58 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Bahrain public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Bahrain observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates. When the 12 Rabi' al-Awwal falls on a Friday or
+# Saturday, the Crown Prince circular specifies a compensatory weekday; the CSV
+# stores the officially announced closure date.
+#
+# 2024–2025: CBB / Boursa Bahrain official holiday announcements; aligned with GCC
+#            consensus in both years. 2025: actual 12 Rabi' = Fri Sep 5; compensatory
+#            day announced as Thu Sep 4.
+# 2026:      Umm al-Qura tabular projection; verify against official CBB / Boursa
+#            Bahrain announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH).
+#            Verify against official CBB / Boursa Bahrain announcements as each year
+#            is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,CBB official
+2025,2025-09-04,CBB official (compensatory for Fri Sep 5)
+2026,2026-08-25,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBB / Boursa Bahrain announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-eg.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-eg.csv
@@ -1,0 +1,53 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Egypt public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Egypt observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBE / EGX official holiday announcement.
+# 2025–2026: Umm al-Qura tabular projection; verify against official CBE/EGX
+#            announcements when published.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH, approximately 70 days after 1 Muharram).
+#            Verify against official CBE/EGX announcements as each year is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,CBE official
+# 2025–2055: Umm al-Qura tabular projection; verify against official CBE/EGX announcements
+2025,2025-09-04,Umm al-Qura projection
+2026,2026-08-24,Umm al-Qura projection
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-jo.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-jo.csv
@@ -1,0 +1,53 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Jordan public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Jordan observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024:      CBJ official announcement; Jordan date is Sep 16, one day later than
+#            the Bahrain / GCC consensus (Sep 15).
+# 2025–2026: ASE official holiday announcements; aligned with Umm al-Qura.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH).
+#            Verify against official CBJ / ASE announcements as each year is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-16,CBJ official
+2025,2025-09-04,ASE official
+2026,2026-08-25,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBJ / ASE announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-kw.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-kw.csv
@@ -1,0 +1,56 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Kuwait public holiday dates.
+# Commemorates the birth of the Prophet Muhammad.
+#
+# Kuwait observes moon-sighting independently of Saudi Arabia and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: CBK / Boursa Kuwait official holiday announcements; aligned with GCC
+#            consensus in both years. Verify against CBK circulars if required.
+# 2026:      Boursa Kuwait official holiday announcement. Kuwait observed +1 day
+#            relative to SA (August 25 vs SA August 24), consistent with the moon-
+#            sighting offset observed across other Islamic holidays in 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH, approximately 70 days after 1 Muharram).
+#            Verify against official CBK / Boursa Kuwait announcements as each year
+#            is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,CBK official
+2025,2025-09-04,CBK official
+2026,2026-08-25,Boursa Kuwait official
+# 2027–2055: Umm al-Qura tabular projection; verify against official CBK / Boursa Kuwait announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-ma.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/mawlid-ma.csv
@@ -1,0 +1,56 @@
+# Prophet's Birthday (Mawlid an-Nabi / Al-Mawlid Al-Nabawi, 12 Rabi' al-Awwal)
+# Morocco public holiday dates — Day 1.
+# Commemorates the birth of the Prophet Muhammad.
+# Morocco observes a two-day Mawlid; Day 2 is synthesized as Day 1 + 1 calendar day.
+#
+# Morocco observes moon-sighting independently of GCC countries and may differ by ±1 day
+# from Umm al-Qura tabular dates.
+#
+# 2024–2025: Official Moroccan government / CSE holiday announcements.
+#            2025: Day 1 = Fri Sep 5 (natural date of 12 Rabi' al-Awwal, observed as-is).
+# 2026:      Umm al-Qura tabular projection; verify against official Moroccan government
+#            announcement for 2026.
+# 2027–2055: Projected from the Umm al-Qura tabular Islamic calendar
+#            (12 Rabi' al-Awwal AH).
+#            Verify against official Moroccan government announcements as each year
+#            is published.
+#
+# NOTE — 2047: Gregorian year 2047 contains two 12 Rabi' al-Awwal occurrences
+# (~January 1 AH 1469 and ~December 21 AH 1470). Only the first (January) occurrence
+# is recorded.
+#
+# Format: year,YYYY-MM-DD,source
+2024,2024-09-15,Official announcement
+2025,2025-09-05,Official announcement (CSE AV-2025-078; Fri Sep 5, observed on natural date)
+2026,2026-08-25,Umm al-Qura projection
+# 2027–2055: Umm al-Qura tabular projection; verify against official Moroccan government announcements
+2027,2027-08-13,Umm al-Qura projection
+2028,2028-08-01,Umm al-Qura projection
+2029,2029-07-21,Umm al-Qura projection
+2030,2030-07-10,Umm al-Qura projection
+2031,2031-06-29,Umm al-Qura projection
+2032,2032-06-17,Umm al-Qura projection
+2033,2033-06-06,Umm al-Qura projection
+2034,2034-05-26,Umm al-Qura projection
+2035,2035-05-15,Umm al-Qura projection
+2036,2036-05-03,Umm al-Qura projection
+2037,2037-04-22,Umm al-Qura projection
+2038,2038-04-11,Umm al-Qura projection
+2039,2039-03-31,Umm al-Qura projection
+2040,2040-03-19,Umm al-Qura projection
+2041,2041-03-08,Umm al-Qura projection
+2042,2042-02-26,Umm al-Qura projection
+2043,2043-02-15,Umm al-Qura projection
+2044,2044-02-03,Umm al-Qura projection
+2045,2045-01-23,Umm al-Qura projection
+2046,2046-01-12,Umm al-Qura projection
+# 2047: two 12 Rabi' al-Awwal occurrences (~Jan 1 AH 1469 and ~Dec 21 AH 1470); Jan 1 recorded
+2047,2047-01-01,Umm al-Qura projection (January occurrence only; December occurrence omitted)
+2048,2048-12-09,Umm al-Qura projection
+2049,2049-11-28,Umm al-Qura projection
+2050,2050-11-17,Umm al-Qura projection
+2051,2051-11-06,Umm al-Qura projection
+2052,2052-10-24,Umm al-Qura projection
+2053,2053-10-13,Umm al-Qura projection
+2054,2054-10-03,Umm al-Qura projection
+2055,2055-09-22,Umm al-Qura projection

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceBHDTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceBHDTest.java
@@ -1,0 +1,309 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceBHDTest {
+
+    // Same 15 holidays as BH — settlement calendar uses national holiday set, no-roll only
+    private static final int BHD_HOLIDAY_COUNT = 15;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int BHD_FIXED_HOLIDAY_COUNT = 4;
+
+    private final HolidayCalendarServiceBHD service = new HolidayCalendarServiceBHD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("BHD"));
+        assertFalse(service.isProvided("BH"));
+        assertFalse(service.isProvided("KWD"));
+        assertFalse(service.isProvided("SAR"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "BHD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Bahrain (Boursa Bahrain/CBB) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("BHD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "BHD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Bahrain weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), BHD_HOLIDAY_COUNT,
+                "Expected " + BHD_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), BHD_HOLIDAY_COUNT,
+                "Expected " + BHD_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── no-roll: New Year's Day stays on natural date (Friday 2027) ───────────
+
+    // Jan 1, 2027 is Friday — BHD must NOT roll; BH rolls this to Sunday Jan 3
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "BHD must not roll New Year's Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // Jan 1, 2028 is Saturday — BHD must NOT roll; BH rolls this to Sunday Jan 2
+    @Test
+    public void testNewYearsDayOnSaturdayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 1),
+                "BHD must not roll New Year's Day 2028 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // ── no-roll: National Day stays on natural date (Saturday 2028) ──────────
+
+    // Dec 16, 2028 is Saturday — BHD must NOT roll; BH rolls this to Sunday Dec 17
+    @Test
+    public void testNationalDayOnSaturdayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.DECEMBER, 16).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.DECEMBER, 16),
+                "BHD must not roll National Day 2028 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // ── no-roll: Labour Day stays on natural date ─────────────────────────────
+
+    // May 1, 2026 is Friday — BHD must NOT roll; BH rolls this to Sunday May 3
+    @Test
+    public void testLabourDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 1),
+                "BHD must not roll Labour Day 2026 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── BHD differs from BH on rolled fixed holidays ──────────────────────────
+
+    @Test
+    public void testNewYearsDay2027DiffersBetweenBhAndBhd() {
+        // BH rolls Jan 1 (Friday) to Jan 3 (Sunday); BHD stays Jan 1
+        HolidayCalendar bhCalendar = new HolidayCalendarServiceBH().getHolidayCalendar();
+        Optional<HolidayDate> bhdNy = findFirst("New Year's Day", 2027);
+        Optional<HolidayDate> bhNy  = bhCalendar.calculate(2027).stream()
+                .filter(hd -> "New Year's Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(bhdNy.isPresent());
+        assertTrue(bhNy.isPresent());
+        assertNotEquals(bhdNy.get().date(), bhNy.get().date(),
+                "BHD New Year's Day 2027 must differ from BH (no-roll vs roll-to-Sunday)");
+        assertEquals(bhdNy.get().date(), LocalDate.of(2027, Month.JANUARY, 1));
+        assertEquals(bhNy.get().date(), LocalDate.of(2027, Month.JANUARY, 3));
+    }
+
+    // ── Islamic dates match BH (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testEidAlFitr2025MatchesBH() {
+        HolidayCalendar bhCalendar = new HolidayCalendarServiceBH().getHolidayCalendar();
+        Optional<HolidayDate> bhdEid = findFirst("Eid al-Fitr", 2025);
+        Optional<HolidayDate> bhEid  = bhCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(bhdEid.isPresent());
+        assertTrue(bhEid.isPresent());
+        assertEquals(bhdEid.get().date(), bhEid.get().date(),
+                "BHD Eid al-Fitr 2025 must match BH (same CSV source)");
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesBH() {
+        HolidayCalendar bhCalendar = new HolidayCalendarServiceBH().getHolidayCalendar();
+        Optional<HolidayDate> bhdAdha = findFirst("Eid al-Adha", 2025);
+        Optional<HolidayDate> bhAdha  = bhCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(bhdAdha.isPresent());
+        assertTrue(bhAdha.isPresent());
+        assertEquals(bhdAdha.get().date(), bhAdha.get().date(),
+                "BHD Eid al-Adha 2025 must match BH (same CSV source)");
+    }
+
+    @Test
+    public void testAshura2025MatchesBH() {
+        HolidayCalendar bhCalendar = new HolidayCalendarServiceBH().getHolidayCalendar();
+        Optional<HolidayDate> bhdAshura = findFirst("Ashura", 2025);
+        Optional<HolidayDate> bhAshura  = bhCalendar.calculate(2025).stream()
+                .filter(hd -> "Ashura".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(bhdAshura.isPresent());
+        assertTrue(bhAshura.isPresent());
+        assertEquals(bhdAshura.get().date(), bhAshura.get().date(),
+                "BHD Ashura 2025 must match BH (same CSV source)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "BHD calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("BHD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"BHD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), BHD_HOLIDAY_COUNT,
+                "Expected all " + BHD_HOLIDAY_COUNT + " BHD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), BHD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + BHD_FIXED_HOLIDAY_COUNT +
+                " fixed BHD holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Ashura"},
+            new Object[]{"Ashura (2nd Day)"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"National Day"},
+            new Object[]{"Accession Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceBHTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceBHTest.java
@@ -1,0 +1,508 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceBHTest {
+
+    // 4 fixed (New Year's Day, Labour Day, National Day, Accession Day)
+    // + 3 Eid al-Fitr + Arafat Day + 3 Eid al-Adha
+    // + Islamic New Year + 2 Ashura + Prophet's Birthday = 15
+    private static final int BH_HOLIDAY_COUNT = 15;
+
+    // Beyond CSV ceiling: 4 fixed Gregorian holidays survive
+    private static final int BH_FIXED_HOLIDAY_COUNT = 4;
+
+    private final HolidayCalendarServiceBH service = new HolidayCalendarServiceBH();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("BH"));
+        assertFalse(service.isProvided("BHD"));
+        assertFalse(service.isProvided("KW"));
+        assertFalse(service.isProvided("AE"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "BH");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Bahrain (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("BH");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "BH");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Bahrain weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), BH_HOLIDAY_COUNT,
+                "Expected " + BH_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), BH_HOLIDAY_COUNT,
+                "Expected " + BH_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ──────────────────────────────────
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // May 1, 2025 is Thursday — must not roll
+    @Test
+    public void testLabourDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.MAY, 1).getDayOfWeek(), DayOfWeek.THURSDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2025);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2025, Month.MAY, 1),
+                "Labour Day 2025 (Thursday) must not roll");
+    }
+
+    // Dec 16, 2025 is Tuesday — must not roll
+    @Test
+    public void testNationalDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.DECEMBER, 16).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2025);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2025, Month.DECEMBER, 16),
+                "National Day 2025 (Tuesday) must not roll");
+    }
+
+    // Dec 17, 2025 is Wednesday — must not roll
+    @Test
+    public void testAccessionDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.DECEMBER, 17).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ad = findFirst("Accession Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.DECEMBER, 17),
+                "Accession Day 2025 (Wednesday) must not roll");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // Jan 1, 2027 is Friday → rolls to Sunday Jan 3
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 3),
+                "New Year's Day 2027 (Friday) must roll to Sunday Jan 3");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // May 1, 2026 is Friday → rolls to Sunday May 3
+    @Test
+    public void testLabourDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 3),
+                "Labour Day 2026 (Friday) must roll to Sunday May 3");
+    }
+
+    // Dec 16, 2028 is Saturday → rolls to Sunday Dec 17
+    // Note: Dec 17 (Accession Day) also lands on Sunday 2028 — calendars permit duplicate dates
+    @Test
+    public void testNationalDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.DECEMBER, 16).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.DECEMBER, 17),
+                "National Day 2028 (Saturday) must roll to Sunday Dec 17");
+    }
+
+    // Dec 17, 2028 is Sunday — must NOT roll (Sunday is first workday in Bahrain)
+    @Test
+    public void testAccessionDayOnSundayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.DECEMBER, 17).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> ad = findFirst("Accession Day", 2028);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2028, Month.DECEMBER, 17),
+                "Accession Day 2028 (Sunday) must not roll — Sunday is first workday in Bahrain");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per CBB official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per CBB official");
+    }
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 (one day before Eid al-Adha June 16)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 (one day before Eid al-Adha June 6)");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBB official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per CBB official");
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBB official");
+    }
+
+    @Test
+    public void testIslamicNewYear2025() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 26),
+                "Islamic New Year 2025 must be 2025-06-26 per CBB official");
+    }
+
+    // ── Ashura spot-checks ────────────────────────────────────────────────────
+
+    @Test
+    public void testAshura2024() {
+        // Islamic New Year 2024 = Jul 7; Ashura (10 Muharram) = Jul 7 + 9 = Jul 16
+        Optional<HolidayDate> ashura = findFirst("Ashura", 2024);
+        assertTrue(ashura.isPresent());
+        assertEquals(ashura.get().date(), LocalDate.of(2024, Month.JULY, 16),
+                "Ashura 2024 must be 2024-07-16 per CBB official (Islamic New Year Jul 7 + 9 days)");
+    }
+
+    @Test
+    public void testAshuraDay2_2024() {
+        // Ashura Day 2 (11 Muharram) = Jul 17
+        Optional<HolidayDate> ashura2 = findFirst("Ashura (2nd Day)", 2024);
+        assertTrue(ashura2.isPresent());
+        assertEquals(ashura2.get().date(), LocalDate.of(2024, Month.JULY, 17),
+                "Ashura (2nd Day) 2024 must be 2024-07-17");
+    }
+
+    @Test
+    public void testAshura2025() {
+        // Islamic New Year 2025 = Jun 26; Ashura = Jun 26 + 9 = Jul 5
+        Optional<HolidayDate> ashura = findFirst("Ashura", 2025);
+        assertTrue(ashura.isPresent());
+        assertEquals(ashura.get().date(), LocalDate.of(2025, Month.JULY, 5),
+                "Ashura 2025 must be 2025-07-05 per CBB official (Islamic New Year Jun 26 + 9 days)");
+    }
+
+    @Test
+    public void testAshuraDay2_2025() {
+        Optional<HolidayDate> ashura2 = findFirst("Ashura (2nd Day)", 2025);
+        assertTrue(ashura2.isPresent());
+        assertEquals(ashura2.get().date(), LocalDate.of(2025, Month.JULY, 6),
+                "Ashura (2nd Day) 2025 must be 2025-07-06");
+    }
+
+    @Test
+    public void testAshuraDay2IsDayAfterAshura() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ashura  = findFirst("Ashura", year);
+            Optional<HolidayDate> ashura2 = findFirst("Ashura (2nd Day)", year);
+            assertTrue(ashura.isPresent(),  year + ": Ashura must be present");
+            assertTrue(ashura2.isPresent(), year + ": Ashura (2nd Day) must be present");
+            assertEquals(ashura2.get().date(), ashura.get().date().plusDays(1),
+                    year + ": Ashura (2nd Day) must be exactly one day after Ashura");
+        }
+    }
+
+    // ── Prophet's Birthday ────────────────────────────────────────────────────
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per CBB official");
+    }
+
+    @Test
+    public void testProphetsBirthday2025() {
+        // Actual 12 Rabi' al-Awwal = Fri Sep 5; compensatory day announced as Thu Sep 4
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2025);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 4),
+                "Prophet's Birthday 2025 must be 2025-09-04 (compensatory for Fri Sep 5) per CBB official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "BH calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("BH");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"BH\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), BH_HOLIDAY_COUNT,
+                "Expected all " + BH_HOLIDAY_COUNT + " BH holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), BH_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + BH_FIXED_HOLIDAY_COUNT +
+                " fixed Bahrain holidays must remain (New Year's Day, Labour Day, National Day, Accession Day)");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Ashura"},
+            new Object[]{"Ashura (2nd Day)"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"National Day"},
+            new Object[]{"Accession Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGPTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGPTest.java
@@ -1,0 +1,336 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceEGPTest {
+
+    // EG holidays (17) minus Arafat Day = 16
+    private static final int EGP_HOLIDAY_COUNT = 16;
+
+    // Beyond CSV ceiling: 7 fixed Gregorian + Sham El-Nessim (algorithm-based) = 8
+    private static final int EGP_FIXED_HOLIDAY_COUNT = 8;
+
+    private final HolidayCalendarServiceEGP service = new HolidayCalendarServiceEGP();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("EGP"));
+        assertFalse(service.isProvided("EG"));
+        assertFalse(service.isProvided("KWD"));
+        assertFalse(service.isProvided("SAR"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "EGP");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Egypt (EGX/CBE) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("EGP");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "EGP");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Egypt weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day in Egypt");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EGP_HOLIDAY_COUNT,
+                "Expected " + EGP_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EGP_HOLIDAY_COUNT,
+                "Expected " + EGP_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── no-roll convention — fixed holidays stay on their natural dates ────────
+
+    // Jan 7, 2028 is Friday → EGP must NOT roll (stays Jan 7)
+    @Test
+    public void testCopticChristmasOnFridayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 7).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cc = findFirst("Coptic Christmas", 2028);
+        assertTrue(cc.isPresent());
+        assertEquals(cc.get().date(), LocalDate.of(2028, Month.JANUARY, 7),
+                "EGP must not roll Coptic Christmas 2028 (Friday) — CBE uses no-roll convention");
+    }
+
+    // May 1, 2026 is Friday → EGP must NOT roll (stays May 1)
+    @Test
+    public void testLabourDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 1),
+                "EGP must not roll Labour Day 2026 (Friday) — CBE uses no-roll convention");
+    }
+
+    // Oct 6, 2029 is Saturday → EGP must NOT roll (stays Oct 6)
+    @Test
+    public void testArmedForcesDayOnSaturdayNotRolled2029() {
+        assertEquals(LocalDate.of(2029, Month.OCTOBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> afd = findFirst("Armed Forces Day", 2029);
+        assertTrue(afd.isPresent());
+        assertEquals(afd.get().date(), LocalDate.of(2029, Month.OCTOBER, 6),
+                "EGP must not roll Armed Forces Day 2029 (Saturday) — CBE uses no-roll convention");
+    }
+
+    // Jul 23, 2027 is Friday → EGP must NOT roll (stays Jul 23)
+    @Test
+    public void testRevolutionDayJulyOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JULY, 23).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> rd2 = findFirst("Revolution Day (July 23)", 2027);
+        assertTrue(rd2.isPresent());
+        assertEquals(rd2.get().date(), LocalDate.of(2027, Month.JULY, 23),
+                "EGP must not roll Revolution Day (July 23) 2027 (Friday) — CBE uses no-roll convention");
+    }
+
+    // ── Arafat Day must be absent from EGP ───────────────────────────────────
+
+    @Test
+    public void testArafatDayAbsent() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Arafat Day".equals(h.getName()));
+        assertFalse(found, "Arafat Day is a national holiday only; it must not appear in the EGP settlement calendar");
+    }
+
+    @Test
+    public void testArafatDayAbsent2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertFalse(ad.isPresent(), "Arafat Day must not be present in EGP 2024");
+    }
+
+    // ── Islamic holiday spot-checks (same CSV as EG) ──────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "EGP Eid al-Fitr 2024 must match CBE official date");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "EGP Eid al-Adha 2024 must match CBE official date");
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "EGP Eid al-Fitr 2025 must match CBE official date");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "EGP Eid al-Adha 2025 must match CBE official date");
+    }
+
+    // ── EGP Islamic dates match EG ────────────────────────────────────────────
+
+    @Test
+    public void testEgpIslamicDatesMatchEg() {
+        HolidayCalendarServiceEG egService = new HolidayCalendarServiceEG();
+        for (String name : new String[]{"Eid al-Fitr", "Eid al-Adha", "Islamic New Year", "Prophet's Birthday"}) {
+            for (int year : new int[]{2024, 2025}) {
+                Optional<HolidayDate> egp = findFirst(name, year);
+                Optional<HolidayDate> eg  = egService.getHolidayCalendar().calculate(year).stream()
+                        .filter(hd -> name.equals(hd.holiday().getName()))
+                        .findFirst();
+                assertTrue(egp.isPresent(), year + " EGP must contain " + name);
+                assertTrue(eg.isPresent(),  year + " EG must contain " + name);
+                assertEquals(egp.get().date(), eg.get().date(),
+                        year + " EGP and EG must share the same " + name + " date");
+            }
+        }
+    }
+
+    // ── Sham El-Nessim spot-check ─────────────────────────────────────────────
+
+    @Test
+    public void testShamElNessim2024() {
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2024);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2024, Month.MAY, 6),
+                "EGP Sham El-Nessim 2024 must be May 6 (day after Coptic Easter May 5)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "EGP calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("EGP");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"EGP\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), EGP_HOLIDAY_COUNT,
+                "Expected all " + EGP_HOLIDAY_COUNT + " EGP holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedAndCopticHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), EGP_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + EGP_FIXED_HOLIDAY_COUNT +
+                " fixed and algorithmic EGP holidays must remain (7 Gregorian + Sham El-Nessim)");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Coptic Christmas"},
+            new Object[]{"Revolution Day"},
+            new Object[]{"Sinai Liberation Day"},
+            new Object[]{"Sham El-Nessim"},
+            new Object[]{"Labour Day"},
+            new Object[]{"June 30 Revolution"},
+            new Object[]{"Revolution Day (July 23)"},
+            new Object[]{"Armed Forces Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "EGP calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
@@ -95,28 +95,21 @@ public class HolidayCalendarServiceEGTest {
 
     // ── total count ───────────────────────────────────────────────────────────
 
-    @Test
-    public void testCalculate2024() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
-        assertNotNull(holidays);
-        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
-                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
     }
 
-    @Test
-    public void testCalculate2025() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
         assertNotNull(holidays);
         assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
-                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
-    }
-
-    @Test
-    public void testCalculate2026() {
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
-        assertNotNull(holidays);
-        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
-                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for " + year + ", got: " + holidays.size());
     }
 
     // ── chronological order ───────────────────────────────────────────────────

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceEGTest.java
@@ -1,0 +1,502 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceEGTest {
+
+    // 7 fixed + Sham El-Nessim + Arafat Day + 3 Eid al-Fitr + 3 Eid al-Adha
+    // + Islamic New Year + Prophet's Birthday = 17
+    private static final int EG_HOLIDAY_COUNT = 17;
+
+    // Beyond CSV ceiling: 7 fixed Gregorian + Sham El-Nessim (algorithm-based, never drops) = 8
+    private static final int EG_FIXED_HOLIDAY_COUNT = 8;
+
+    private final HolidayCalendarServiceEG service = new HolidayCalendarServiceEG();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("EG"));
+        assertFalse(service.isProvided("EGP"));
+        assertFalse(service.isProvided("KW"));
+        assertFalse(service.isProvided("SA"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "EG");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Egypt (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("EG");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "EG");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Egypt weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day in Egypt");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2026() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2026);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected " + EG_HOLIDAY_COUNT + " holidays for 2026, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ──────────────────────────────────
+
+    // Jan 7, 2025 is Tuesday — must not roll
+    @Test
+    public void testCopticChristmas2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 7).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> cc = findFirst("Coptic Christmas", 2025);
+        assertTrue(cc.isPresent());
+        assertEquals(cc.get().date(), LocalDate.of(2025, Month.JANUARY, 7),
+                "Coptic Christmas 2025 (Tuesday) must not roll");
+    }
+
+    // Jun 30, 2025 is Monday — must not roll
+    @Test
+    public void testJune30Revolution2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 30).getDayOfWeek(), DayOfWeek.MONDAY);
+        Optional<HolidayDate> j30 = findFirst("June 30 Revolution", 2025);
+        assertTrue(j30.isPresent());
+        assertEquals(j30.get().date(), LocalDate.of(2025, Month.JUNE, 30),
+                "June 30 Revolution 2025 (Monday) must not roll");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // Jan 7, 2028 is Friday → rolls to Sunday Jan 9
+    @Test
+    public void testCopticChristmasRollFromFriday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 7).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cc = findFirst("Coptic Christmas", 2028);
+        assertTrue(cc.isPresent());
+        assertEquals(cc.get().date(), LocalDate.of(2028, Month.JANUARY, 9),
+                "Coptic Christmas 2028 (Friday) must roll to Sunday Jan 9");
+    }
+
+    // Jan 25, 2025 is Saturday → rolls to Sunday Jan 26
+    @Test
+    public void testRevolutionDayRollFromSaturday2025() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> rd = findFirst("Revolution Day", 2025);
+        assertTrue(rd.isPresent());
+        assertEquals(rd.get().date(), LocalDate.of(2025, Month.JANUARY, 26),
+                "Revolution Day 2025 (Saturday) must roll to Sunday Jan 26");
+    }
+
+    // Apr 25, 2026 is Saturday → rolls to Sunday Apr 26
+    @Test
+    public void testSinaiLiberationDayRollFromSaturday2026() {
+        assertEquals(LocalDate.of(2026, Month.APRIL, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> sld = findFirst("Sinai Liberation Day", 2026);
+        assertTrue(sld.isPresent());
+        assertEquals(sld.get().date(), LocalDate.of(2026, Month.APRIL, 26),
+                "Sinai Liberation Day 2026 (Saturday) must roll to Sunday Apr 26");
+    }
+
+    // May 1, 2026 is Friday → rolls to Sunday May 3
+    @Test
+    public void testLabourDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 3),
+                "Labour Day 2026 (Friday) must roll to Sunday May 3");
+    }
+
+    // Jul 23, 2028 is Sunday — must not roll (Sunday is a business day in Egypt)
+    @Test
+    public void testRevolutionDayJuly2028NoRoll() {
+        assertEquals(LocalDate.of(2028, Month.JULY, 23).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> rd2 = findFirst("Revolution Day (July 23)", 2028);
+        assertTrue(rd2.isPresent());
+        assertEquals(rd2.get().date(), LocalDate.of(2028, Month.JULY, 23),
+                "Revolution Day (July 23) 2028 (Sunday) must not roll — Sunday is a business day in Egypt");
+    }
+
+    // Jul 23, 2027 is Friday → rolls to Sunday Jul 25
+    @Test
+    public void testRevolutionDayJulyRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JULY, 23).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> rd2 = findFirst("Revolution Day (July 23)", 2027);
+        assertTrue(rd2.isPresent());
+        assertEquals(rd2.get().date(), LocalDate.of(2027, Month.JULY, 25),
+                "Revolution Day (July 23) 2027 (Friday) must roll to Sunday Jul 25");
+    }
+
+    // Oct 6, 2029 is Saturday → rolls to Sunday Oct 7
+    @Test
+    public void testArmedForcesDayRollFromSaturday2029() {
+        assertEquals(LocalDate.of(2029, Month.OCTOBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> afd = findFirst("Armed Forces Day", 2029);
+        assertTrue(afd.isPresent());
+        assertEquals(afd.get().date(), LocalDate.of(2029, Month.OCTOBER, 7),
+                "Armed Forces Day 2029 (Saturday) must roll to Sunday Oct 7");
+    }
+
+    // ── Sham El-Nessim spot-checks (day after Coptic/Orthodox Easter) ─────────
+
+    @Test
+    public void testShamElNessim2024() {
+        // Coptic Easter 2024 = May 5 (Orthodox Easter algorithm); Sham El-Nessim = May 6
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2024);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2024, Month.MAY, 6),
+                "Sham El-Nessim 2024 must be May 6 (day after Coptic Easter May 5)");
+    }
+
+    @Test
+    public void testShamElNessim2025() {
+        // Coptic Easter 2025 = April 20; Sham El-Nessim = April 21
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2025);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2025, Month.APRIL, 21),
+                "Sham El-Nessim 2025 must be April 21 (day after Coptic Easter April 20)");
+    }
+
+    @Test
+    public void testShamElNessim2026() {
+        // Coptic Easter 2026 = April 12; Sham El-Nessim = April 13
+        Optional<HolidayDate> sen = findFirst("Sham El-Nessim", 2026);
+        assertTrue(sen.isPresent());
+        assertEquals(sen.get().date(), LocalDate.of(2026, Month.APRIL, 13),
+                "Sham El-Nessim 2026 must be April 13 (day after Coptic Easter April 12)");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per CBE official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per CBE official");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBE official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per CBE official");
+    }
+
+    // ── Arafat Day spot-checks ────────────────────────────────────────────────
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 (one day before Eid al-Adha June 16)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 (one day before Eid al-Adha June 6)");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    // ── Islamic New Year and Prophet's Birthday ───────────────────────────────
+
+    @Test
+    public void testIslamicNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Islamic New Year".equals(h.getName()));
+        assertTrue(found, "Islamic New Year is a gazetted Egypt public holiday and must be included");
+    }
+
+    @Test
+    public void testProphetsBirthdayIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Prophet's Birthday".equals(h.getName()));
+        assertTrue(found, "Prophet's Birthday is a gazetted Egypt public holiday and must be included");
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBE official");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per CBE official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "EG calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("EG");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"EG\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), EG_HOLIDAY_COUNT,
+                "Expected all " + EG_HOLIDAY_COUNT + " EG holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedAndCopticHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), EG_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + EG_FIXED_HOLIDAY_COUNT +
+                " fixed and algorithmic EG holidays must remain (7 Gregorian + Sham El-Nessim)");
+    }
+
+    @Test
+    public void testShamElNessimPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        boolean found = holidays2056.stream().anyMatch(hd -> "Sham El-Nessim".equals(hd.holiday().getName()));
+        assertTrue(found, "Sham El-Nessim must be present beyond CSV ceiling — it is algorithm-based, not CSV-based");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"Coptic Christmas"},
+            new Object[]{"Revolution Day"},
+            new Object[]{"Sinai Liberation Day"},
+            new Object[]{"Sham El-Nessim"},
+            new Object[]{"Labour Day"},
+            new Object[]{"June 30 Revolution"},
+            new Object[]{"Revolution Day (July 23)"},
+            new Object[]{"Armed Forces Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJODTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJODTest.java
@@ -1,0 +1,361 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceJODTest {
+
+    // Same holiday set as JO — settlement calendar uses the national holiday set with no-roll.
+    // Keep in sync with JO_HOLIDAY_COUNT in HolidayCalendarServiceJOTest.
+    private static final int JOD_HOLIDAY_COUNT = 15;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int JOD_FIXED_HOLIDAY_COUNT = 4;
+
+    private final HolidayCalendarServiceJOD service = new HolidayCalendarServiceJOD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("JOD"));
+        assertFalse(service.isProvided("JO"));
+        assertFalse(service.isProvided("BHD"));
+        assertFalse(service.isProvided("EGP"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "JOD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Jordan (ASE/CBJ) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("JOD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "JOD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Jordan weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must not be a weekend day in Jordan");
+    }
+
+    // ── total count (S5976-compliant parameterized test) ──────────────────────
+
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), JOD_HOLIDAY_COUNT,
+                "Expected " + JOD_HOLIDAY_COUNT + " holidays for " + year +
+                ", got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── no-roll convention — fixed holidays stay on their natural dates ────────
+    //
+    // JOD uses DateRolls.noRoll(); all holidays have rollable(false).
+    // The same Fri/Sat collisions used in JO roll tests are the ideal no-roll
+    // verification points: JOD must return the NATURAL date, JO returns the rolled Sunday.
+
+    // May 25, 2024 is Saturday → JOD must NOT roll; JO rolls this to Sunday May 26
+    @Test
+    public void testIndependenceDayOnSaturdayNotRolled2024() {
+        assertEquals(LocalDate.of(2024, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2024);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2024, Month.MAY, 25),
+                "JOD must not roll Independence Day 2024 (Saturday) — settlement uses no-roll");
+    }
+
+    // May 1, 2026 is Friday → JOD must NOT roll; JO rolls this to Sunday May 3
+    @Test
+    public void testLabourDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 1),
+                "JOD must not roll Labour Day 2026 (Friday) — settlement uses no-roll");
+    }
+
+    // Dec 25, 2026 is Friday → JOD must NOT roll; JO rolls this to Sunday Dec 27
+    @Test
+    public void testChristmasDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cd = findFirst("Christmas Day", 2026);
+        assertTrue(cd.isPresent());
+        assertEquals(cd.get().date(), LocalDate.of(2026, Month.DECEMBER, 25),
+                "JOD must not roll Christmas Day 2026 (Friday) — settlement uses no-roll");
+    }
+
+    // Jan 1, 2027 is Friday → JOD must NOT roll; JO rolls this to Sunday Jan 3
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "JOD must not roll New Year's Day 2027 (Friday) — settlement uses no-roll");
+    }
+
+    // Jan 1, 2028 is Saturday → JOD must NOT roll; JO rolls this to Sunday Jan 2
+    @Test
+    public void testNewYearsDayOnSaturdayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 1),
+                "JOD must not roll New Year's Day 2028 (Saturday) — settlement uses no-roll");
+    }
+
+    // ── JOD differs from JO on rolled fixed holidays ──────────────────────────
+
+    @Test
+    public void testIndependenceDay2024DiffersBetweenJoAndJod() {
+        HolidayCalendar joCalendar = new HolidayCalendarServiceJO().getHolidayCalendar();
+        Optional<HolidayDate> jodDate = findFirst("Independence Day", 2024);
+        Optional<HolidayDate> joDate  = joCalendar.calculate(2024).stream()
+                .filter(hd -> "Independence Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(jodDate.isPresent());
+        assertTrue(joDate.isPresent());
+        assertNotEquals(jodDate.get().date(), joDate.get().date(),
+                "JOD Independence Day 2024 must differ from JO (no-roll vs roll-to-Sunday)");
+        assertEquals(jodDate.get().date(), LocalDate.of(2024, Month.MAY, 25));
+        assertEquals(joDate.get().date(),  LocalDate.of(2024, Month.MAY, 26));
+    }
+
+    @Test
+    public void testLabourDay2026DiffersBetweenJoAndJod() {
+        HolidayCalendar joCalendar = new HolidayCalendarServiceJO().getHolidayCalendar();
+        Optional<HolidayDate> jodDate = findFirst("Labour Day", 2026);
+        Optional<HolidayDate> joDate  = joCalendar.calculate(2026).stream()
+                .filter(hd -> "Labour Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(jodDate.isPresent());
+        assertTrue(joDate.isPresent());
+        assertNotEquals(jodDate.get().date(), joDate.get().date(),
+                "JOD Labour Day 2026 must differ from JO (no-roll vs roll-to-Sunday)");
+        assertEquals(jodDate.get().date(), LocalDate.of(2026, Month.MAY, 1));
+        assertEquals(joDate.get().date(),  LocalDate.of(2026, Month.MAY, 3));
+    }
+
+    // ── Islamic dates match JO (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testJodIslamicDatesMatchJo() {
+        HolidayCalendarServiceJO joService = new HolidayCalendarServiceJO();
+        for (String name : new String[]{
+                "Eid al-Fitr", "Eid al-Fitr (2nd Day)", "Eid al-Fitr (3rd Day)", "Eid al-Fitr (4th Day)",
+                "Arafat Day",
+                "Eid al-Adha", "Eid al-Adha (2nd Day)", "Eid al-Adha (3rd Day)", "Eid al-Adha (4th Day)",
+                "Islamic New Year", "Prophet's Birthday"}) {
+            for (int year : new int[]{2024, 2025}) {
+                Optional<HolidayDate> jod = findFirst(name, year);
+                Optional<HolidayDate> jo  = joService.getHolidayCalendar().calculate(year).stream()
+                        .filter(hd -> name.equals(hd.holiday().getName()))
+                        .findFirst();
+                assertTrue(jod.isPresent(), year + " JOD must contain " + name);
+                assertTrue(jo.isPresent(),  year + " JO must contain " + name);
+                assertEquals(jod.get().date(), jo.get().date(),
+                        year + " JOD and JO must share the same " + name + " date (same CSV source)");
+            }
+        }
+    }
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 9),
+                "JOD Eid al-Fitr 2024 must match CBJ official date");
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "JOD Eid al-Adha 2024 must match CBJ official date");
+    }
+
+    // ── JOD holiday count equals JO (same holiday set, only rolling differs) ──
+
+    @Test
+    public void testJodHolidayCountEqualsJo() {
+        HolidayCalendarServiceJO joService = new HolidayCalendarServiceJO();
+        for (int year : new int[]{2024, 2025, 2026}) {
+            int joCount  = joService.getHolidayCalendar().calculate(year).size();
+            int jodCount = service.getHolidayCalendar().calculate(year).size();
+            assertEquals(jodCount, joCount,
+                    year + ": JOD holiday count must equal JO count");
+        }
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "JOD calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("JOD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"JOD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), JOD_HOLIDAY_COUNT,
+                "Expected all " + JOD_HOLIDAY_COUNT + " JOD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted)");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), JOD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + JOD_FIXED_HOLIDAY_COUNT +
+                " fixed JOD holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Fitr (4th Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Independence Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Eid al-Adha (4th Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Christmas Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "JOD calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJOTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJOTest.java
@@ -1,0 +1,544 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceJOTest {
+
+    // 4 fixed (New Year's Day, Labour Day, Independence Day, Christmas Day)
+    // + 4 Eid al-Fitr + Arafat Day + 4 Eid al-Adha
+    // + Islamic New Year + Prophet's Birthday = 15
+    private static final int JO_HOLIDAY_COUNT = 15;
+
+    // Beyond CSV ceiling: 4 fixed Gregorian holidays survive
+    private static final int JO_FIXED_HOLIDAY_COUNT = 4;
+
+    private final HolidayCalendarServiceJO service = new HolidayCalendarServiceJO();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("JO"));
+        assertFalse(service.isProvided("JOD"));
+        assertFalse(service.isProvided("BH"));
+        assertFalse(service.isProvided("EG"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "JO");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Jordan (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("JO");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "JO");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Jordan weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must not be a weekend day in Jordan");
+    }
+
+    // ── total count (S5976-compliant parameterized test) ──────────────────────
+
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), JO_HOLIDAY_COUNT,
+                "Expected " + JO_HOLIDAY_COUNT + " holidays for " + year +
+                ", got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday or Sunday ─────────────────────────
+    //
+    // In Jordan, Sunday is the first business day; it must NEVER trigger a roll.
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // May 25, 2025 is Sunday — must NOT roll (Sunday is the first business day in Jordan)
+    @Test
+    public void testIndependenceDayOnSundayNotRolled2025() {
+        assertEquals(LocalDate.of(2025, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2025);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2025, Month.MAY, 25),
+                "Independence Day 2025 (Sunday) must not roll — Sunday is first business day in Jordan");
+    }
+
+    // Jun 10, 2025 is Tuesday — unused (Army Day not in Jordan calendar; verifies no such holiday exists)
+    @Test
+    public void testNoArmyDayHoliday() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> h.getName().contains("Army Day"));
+        assertFalse(found, "Jordan calendar must not contain Army Day — not a gazetted public holiday");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // May 25, 2024 is Saturday → rolls to Sunday May 26
+    @Test
+    public void testIndependenceDayRollFromSaturday2024() {
+        assertEquals(LocalDate.of(2024, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2024);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2024, Month.MAY, 26),
+                "Independence Day 2024 (Saturday) must roll to Sunday May 26");
+    }
+
+    // May 1, 2026 is Friday → rolls to Sunday May 3
+    @Test
+    public void testLabourDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.MAY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2026);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2026, Month.MAY, 3),
+                "Labour Day 2026 (Friday) must roll to Sunday May 3");
+    }
+
+    // Dec 25, 2026 is Friday → rolls to Sunday Dec 27
+    @Test
+    public void testChristmasDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> cd = findFirst("Christmas Day", 2026);
+        assertTrue(cd.isPresent());
+        assertEquals(cd.get().date(), LocalDate.of(2026, Month.DECEMBER, 27),
+                "Christmas Day 2026 (Friday) must roll to Sunday Dec 27");
+    }
+
+    // Jan 1, 2027 is Friday → rolls to Sunday Jan 3
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 3),
+                "New Year's Day 2027 (Friday) must roll to Sunday Jan 3");
+    }
+
+    // May 1, 2027 is Saturday → rolls to Sunday May 2
+    @Test
+    public void testLabourDayRollFromSaturday2027() {
+        assertEquals(LocalDate.of(2027, Month.MAY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2027);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2027, Month.MAY, 2),
+                "Labour Day 2027 (Saturday) must roll to Sunday May 2");
+    }
+
+    // Dec 25, 2027 is Saturday → rolls to Sunday Dec 26
+    @Test
+    public void testChristmasDayRollFromSaturday2027() {
+        assertEquals(LocalDate.of(2027, Month.DECEMBER, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> cd = findFirst("Christmas Day", 2027);
+        assertTrue(cd.isPresent());
+        assertEquals(cd.get().date(), LocalDate.of(2027, Month.DECEMBER, 26),
+                "Christmas Day 2027 (Saturday) must roll to Sunday Dec 26");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // May 25, 2029 is Friday → rolls to Sunday May 27
+    @Test
+    public void testIndependenceDayRollFromFriday2029() {
+        assertEquals(LocalDate.of(2029, Month.MAY, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2029);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2029, Month.MAY, 27),
+                "Independence Day 2029 (Friday) must roll to Sunday May 27");
+    }
+
+    // May 25, 2030 is Saturday → rolls to Sunday May 26
+    @Test
+    public void testIndependenceDayRollFromSaturday2030() {
+        assertEquals(LocalDate.of(2030, Month.MAY, 25).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2030);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2030, Month.MAY, 26),
+                "Independence Day 2030 (Saturday) must roll to Sunday May 26");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+    //
+    // 2024: sourced from CBJ / ASE official announcements.
+    // 2025–2026: sourced from ASE official announcements.
+    // Jordan determines Islamic holiday dates by moon sighting (Ministry of Awqaf /
+    // Higher Judiciary Council) and may differ from Saudi Arabia by ±1 day.
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 9),
+                "Eid al-Fitr 2024 must be 2024-04-09 per CBJ official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 10));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay4_2024() {
+        Optional<HolidayDate> eid4 = findFirst("Eid al-Fitr (4th Day)", 2024);
+        assertTrue(eid4.isPresent());
+        assertEquals(eid4.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per ASE official");
+    }
+
+    @Test
+    public void testEidAlFitr2026() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2026);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2026, Month.MARCH, 20),
+                "Eid al-Fitr 2026 must be 2026-03-20 per ASE official");
+    }
+
+    @Test
+    public void testEidAlFitrConsecutiveDays() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Fitr", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Fitr (2nd Day)", year);
+            Optional<HolidayDate> day3 = findFirst("Eid al-Fitr (3rd Day)", year);
+            Optional<HolidayDate> day4 = findFirst("Eid al-Fitr (4th Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Fitr must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Fitr (2nd Day) must be present");
+            assertTrue(day3.isPresent(), year + ": Eid al-Fitr (3rd Day) must be present");
+            assertTrue(day4.isPresent(), year + ": Eid al-Fitr (4th Day) must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Fitr (2nd Day) must be Day 1 + 1");
+            assertEquals(day3.get().date(), day1.get().date().plusDays(2),
+                    year + ": Eid al-Fitr (3rd Day) must be Day 1 + 2");
+            assertEquals(day4.get().date(), day1.get().date().plusDays(3),
+                    year + ": Eid al-Fitr (4th Day) must be Day 1 + 3");
+        }
+    }
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 per ASE official (falls on Saturday)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 per ASE official");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBJ official");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per ASE official");
+    }
+
+    @Test
+    public void testEidAlAdha2026() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2026);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2026, Month.MAY, 27),
+                "Eid al-Adha 2026 must be 2026-05-27 per ASE official");
+    }
+
+    @Test
+    public void testEidAlAdhaConsecutiveDays() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Adha", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Adha (2nd Day)", year);
+            Optional<HolidayDate> day3 = findFirst("Eid al-Adha (3rd Day)", year);
+            Optional<HolidayDate> day4 = findFirst("Eid al-Adha (4th Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Adha must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Adha (2nd Day) must be present");
+            assertTrue(day3.isPresent(), year + ": Eid al-Adha (3rd Day) must be present");
+            assertTrue(day4.isPresent(), year + ": Eid al-Adha (4th Day) must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Adha (2nd Day) must be Day 1 + 1");
+            assertEquals(day3.get().date(), day1.get().date().plusDays(2),
+                    year + ": Eid al-Adha (3rd Day) must be Day 1 + 2");
+            assertEquals(day4.get().date(), day1.get().date().plusDays(3),
+                    year + ": Eid al-Adha (4th Day) must be Day 1 + 3");
+        }
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBJ official");
+    }
+
+    @Test
+    public void testIslamicNewYear2025() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 26),
+                "Islamic New Year 2025 must be 2025-06-26 per ASE official");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 16),
+                "Prophet's Birthday 2024 must be 2024-09-16 per CBJ official");
+    }
+
+    @Test
+    public void testProphetsBirthday2025() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2025);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 4),
+                "Prophet's Birthday 2025 must be 2025-09-04 per ASE official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "JO calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("JO");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"JO\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), JO_HOLIDAY_COUNT,
+                "Expected all " + JO_HOLIDAY_COUNT + " JO holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted)");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), JO_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + JO_FIXED_HOLIDAY_COUNT +
+                " fixed Jordan holidays must remain");
+    }
+
+    // ── 2033 dual Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Fitr (4th Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Independence Day"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Eid al-Adha (4th Day)"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Christmas Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWDTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWDTest.java
@@ -1,0 +1,275 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceKWDTest {
+
+    // Same 13 holidays as KW — exchange uses the national holiday set, no-roll only
+    private static final int KWD_HOLIDAY_COUNT = 13;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int KWD_FIXED_HOLIDAY_COUNT = 3;
+
+    private final HolidayCalendarServiceKWD service = new HolidayCalendarServiceKWD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("KWD"));
+        assertFalse(service.isProvided("KW"));
+        assertFalse(service.isProvided("QAR"));
+        assertFalse(service.isProvided("SAR"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "KWD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Kuwait (Boursa Kuwait/CBK) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("KWD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "KWD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Kuwait weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KWD_HOLIDAY_COUNT,
+                "Expected " + KWD_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KWD_HOLIDAY_COUNT,
+                "Expected " + KWD_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── no-roll: Liberation Day stays on natural date (Friday 2027) ───────────
+
+    // Feb 26, 2027 is Friday — KWD must NOT roll (noRoll convention)
+    // KW rolls this to Sunday Feb 28; KWD stays on Feb 26
+    @Test
+    public void testLiberationDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2027);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2027, Month.FEBRUARY, 26),
+                "KWD must not roll Liberation Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── no-roll: National Day stays on natural date (Friday 2028) ────────────
+
+    // Feb 25, 2028 is Friday — KWD must NOT roll
+    @Test
+    public void testNationalDayOnFridayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.FEBRUARY, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.FEBRUARY, 25),
+                "KWD must not roll National Day 2028 (Friday) — settlement uses no-roll convention");
+    }
+
+    // Feb 26, 2028 is Saturday — KWD must NOT roll
+    @Test
+    public void testLiberationDayOnSaturdayNotRolled2028() {
+        assertEquals(LocalDate.of(2028, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2028);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2028, Month.FEBRUARY, 26),
+                "KWD must not roll Liberation Day 2028 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Jan 1, 2027 is Friday — KWD must NOT roll
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "KWD must not roll New Year's Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── Islamic dates match KW (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testEidAlFitr2025MatchesKW() {
+        HolidayCalendar kwCalendar = new HolidayCalendarServiceKW().getHolidayCalendar();
+        Optional<HolidayDate> kwdEid = findFirst("Eid al-Fitr", 2025);
+        Optional<HolidayDate> kwEid  = kwCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(kwdEid.isPresent());
+        assertTrue(kwEid.isPresent());
+        assertEquals(kwdEid.get().date(), kwEid.get().date(),
+                "KWD Eid al-Fitr 2025 must match KW (same CSV source)");
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesKW() {
+        HolidayCalendar kwCalendar = new HolidayCalendarServiceKW().getHolidayCalendar();
+        Optional<HolidayDate> kwdAdha = findFirst("Eid al-Adha", 2025);
+        Optional<HolidayDate> kwAdha  = kwCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(kwdAdha.isPresent());
+        assertTrue(kwAdha.isPresent());
+        assertEquals(kwdAdha.get().date(), kwAdha.get().date(),
+                "KWD Eid al-Adha 2025 must match KW (same CSV source)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "KWD calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("KWD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"KWD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), KWD_HOLIDAY_COUNT,
+                "Expected all " + KWD_HOLIDAY_COUNT + " KWD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), KWD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + KWD_FIXED_HOLIDAY_COUNT +
+                " fixed KWD holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"National Day"},
+            new Object[]{"Liberation Day"},
+            new Object[]{"Isra and Mi'raj"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceKWTest.java
@@ -1,0 +1,473 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceKWTest {
+
+    // 3 fixed (New Year's, National Day, Liberation Day)
+    // + Isra and Mi'raj + 3 Eid al-Fitr + 3 Eid al-Adha + Arafat Day
+    // + Islamic New Year + Prophet's Birthday = 13
+    private static final int KW_HOLIDAY_COUNT = 13;
+
+    // Fixed holidays survive beyond the CSV ceiling (New Year's, National Day, Liberation Day)
+    private static final int KW_FIXED_HOLIDAY_COUNT = 3;
+
+    private final HolidayCalendarServiceKW service = new HolidayCalendarServiceKW();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("KW"));
+        assertFalse(service.isProvided("KWD"));
+        assertFalse(service.isProvided("QA"));
+        assertFalse(service.isProvided("SA"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "KW");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Kuwait (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("KW");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "KW");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Kuwait weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "Expected " + KW_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "Expected " + KW_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ──────────────────────────────────
+
+    // Feb 25, 2024 is Sunday — must not roll
+    @Test
+    public void testNationalDay2024NoRoll() {
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 25).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2024);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2024, Month.FEBRUARY, 25),
+                "National Day 2024 (Sunday) must not roll");
+    }
+
+    // Feb 26, 2024 is Monday — must not roll
+    @Test
+    public void testLiberationDay2024NoRoll() {
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.MONDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2024);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2024, Month.FEBRUARY, 26),
+                "Liberation Day 2024 (Monday) must not roll");
+    }
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // ── fixed holidays — Friday/Saturday roll to following Sunday ─────────────
+
+    // Feb 25, 2028 is Friday → rolls to Sunday Feb 27
+    @Test
+    public void testNationalDayRollFromFriday2028() {
+        assertEquals(LocalDate.of(2028, Month.FEBRUARY, 25).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.FEBRUARY, 27),
+                "National Day 2028 (Friday) must roll to Sunday Feb 27");
+    }
+
+    // Feb 26, 2028 is Saturday → rolls to Sunday Feb 27; combined with National Day roll,
+    // both fixed holidays land on the same Sunday — assert total count is unchanged
+    @Test
+    public void testNoDuplicateDatesWhenNationalAndLiberationDayBothRoll2028() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2028);
+        // Rolling does not deduplicate — all 11 holidays must still be returned even when
+        // multiple land on the same date (Eid al-Fitr Day 2 also falls on 2028-02-27)
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "2028 must still return " + KW_HOLIDAY_COUNT + " holidays even when multiple holidays share a date");
+        // Both fixed holidays must resolve to the same Sunday
+        Optional<HolidayDate> nd = findFirst("National Day", 2028);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2028);
+        assertTrue(nd.isPresent());
+        assertTrue(ld.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2028, Month.FEBRUARY, 27),
+                "National Day 2028 (Friday) must roll to Sunday Feb 27");
+        assertEquals(ld.get().date(), LocalDate.of(2028, Month.FEBRUARY, 27),
+                "Liberation Day 2028 (Saturday) must roll to Sunday Feb 27");
+    }
+
+    // Feb 26, 2027 is Friday → rolls to Sunday Feb 28
+    @Test
+    public void testLiberationDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.FEBRUARY, 26).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ld = findFirst("Liberation Day", 2027);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2027, Month.FEBRUARY, 28),
+                "Liberation Day 2027 (Friday) must roll to Sunday Feb 28");
+    }
+
+    // Jan 1, 2027 is Friday → rolls to Sunday Jan 3
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 3),
+                "New Year's Day 2027 (Friday) must roll to Sunday Jan 3");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per CBK official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per CBK official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per CBK official");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per CBK official");
+    }
+
+    // ── Isra and Mi'raj spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testIsraMiraj2024() {
+        Optional<HolidayDate> im = findFirst("Isra and Mi'raj", 2024);
+        assertTrue(im.isPresent());
+        assertEquals(im.get().date(), LocalDate.of(2024, Month.FEBRUARY, 8),
+                "Isra and Mi'raj 2024 must be 2024-02-08 per CBK official");
+    }
+
+    @Test
+    public void testIsraMiraj2025() {
+        Optional<HolidayDate> im = findFirst("Isra and Mi'raj", 2025);
+        assertTrue(im.isPresent());
+        assertEquals(im.get().date(), LocalDate.of(2025, Month.JANUARY, 27),
+                "Isra and Mi'raj 2025 must be 2025-01-27 per CBK official");
+    }
+
+    // ── Arafat Day spot-checks ────────────────────────────────────────────────
+
+    @Test
+    public void testArafatDay2024() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2024);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2024, Month.JUNE, 15),
+                "Arafat Day 2024 must be 2024-06-15 (one day before Eid al-Adha June 16)");
+    }
+
+    @Test
+    public void testArafatDay2025() {
+        Optional<HolidayDate> ad = findFirst("Arafat Day", 2025);
+        assertTrue(ad.isPresent());
+        assertEquals(ad.get().date(), LocalDate.of(2025, Month.JUNE, 5),
+                "Arafat Day 2025 must be 2025-06-05 (one day before Eid al-Adha June 6)");
+    }
+
+    @Test
+    public void testArafatDayPrecedesEidAlAdha() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> ad  = findFirst("Arafat Day", year);
+            Optional<HolidayDate> eid = findFirst("Eid al-Adha", year);
+            assertTrue(ad.isPresent(),  year + ": Arafat Day must be present");
+            assertTrue(eid.isPresent(), year + ": Eid al-Adha must be present");
+            assertEquals(ad.get().date(), eid.get().date().minusDays(1),
+                    year + ": Arafat Day must be exactly one day before Eid al-Adha");
+        }
+    }
+
+    // ── Islamic New Year and Prophet's Birthday are gazetted in Kuwait ────────
+
+    @Test
+    public void testIslamicNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Islamic New Year".equals(h.getName()));
+        assertTrue(found, "Islamic New Year is a gazetted Kuwait public holiday and must be included");
+    }
+
+    @Test
+    public void testProphetsBirthdayIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Prophet's Birthday".equals(h.getName()));
+        assertTrue(found, "Prophet's Birthday is a gazetted Kuwait public holiday and must be included");
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per CBK official");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per CBK official");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "KW calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("KW");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"KW\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), KW_HOLIDAY_COUNT,
+                "Expected all " + KW_HOLIDAY_COUNT + " KW holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), KW_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + KW_FIXED_HOLIDAY_COUNT +
+                " fixed Kuwait holidays must remain");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"National Day"},
+            new Object[]{"Liberation Day"},
+            new Object[]{"Isra and Mi'raj"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"Arafat Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Prophet's Birthday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMADTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMADTest.java
@@ -1,0 +1,382 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceMADTest {
+
+    // Same 17 holidays as MA — settlement calendar uses the full national holiday set, no-roll
+    private static final int MAD_HOLIDAY_COUNT = 17;
+
+    // Fixed holidays survive beyond the CSV ceiling
+    private static final int MAD_FIXED_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceMAD service = new HolidayCalendarServiceMAD();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("MAD"));
+        assertFalse(service.isProvided("MA"));
+        assertFalse(service.isProvided("EGP"));
+        assertFalse(service.isProvided("BHD"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "MAD");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Morocco (CSE/BAM) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("MAD");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "MAD");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysSaturdayAndSunday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Morocco weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must NOT be a weekend day — Morocco uses Sat/Sun weekend");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), MAD_HOLIDAY_COUNT,
+                "Expected " + MAD_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), MAD_HOLIDAY_COUNT,
+                "Expected " + MAD_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── no-roll: fixed holidays stay on natural dates ─────────────────────────
+
+    // Jan 11, 2025 is Saturday — MAD must NOT roll; MA rolls this to Monday Jan 13
+    @Test
+    public void testManifestoDayOnSaturdayNotRolled2025() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 11).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> md = findFirst("Manifesto of Independence Day", 2025);
+        assertTrue(md.isPresent());
+        assertEquals(md.get().date(), LocalDate.of(2025, Month.JANUARY, 11),
+                "MAD must not roll Manifesto of Independence Day 2025 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Jan 14, 2024 is Sunday — MAD must NOT roll; MA rolls this to Monday Jan 15
+    @Test
+    public void testAmazighNewYear2024OnSundayNotRolled() {
+        assertEquals(LocalDate.of(2024, Month.JANUARY, 14).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2024);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2024, Month.JANUARY, 14),
+                "MAD must not roll Amazigh New Year 2024 (Sunday) — settlement uses no-roll convention");
+    }
+
+    // Jan 1, 2028 is Saturday — MAD must NOT roll; MA rolls this to Monday Jan 3
+    @Test
+    public void testNewYearsDay2028OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 1),
+                "MAD must not roll New Year's Day 2028 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // Aug 14, 2027 is Saturday — MAD must NOT roll; MA rolls this to Monday Aug 16
+    @Test
+    public void testOuedEdDahab2027OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2027, Month.AUGUST, 14).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> odd = findFirst("Oued Ed-Dahab Allegiance Day", 2027);
+        assertTrue(odd.isPresent());
+        assertEquals(odd.get().date(), LocalDate.of(2027, Month.AUGUST, 14),
+                "MAD must not roll Oued Ed-Dahab Allegiance Day 2027 (Saturday)");
+    }
+
+    // Nov 18, 2028 is Saturday — MAD must NOT roll; MA rolls this to Monday Nov 20
+    @Test
+    public void testIndependenceDay2028OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2028, Month.NOVEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2028);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2028, Month.NOVEMBER, 18),
+                "MAD must not roll Independence Day 2028 (Saturday)");
+    }
+
+    // ── MAD differs from MA on fixed holidays that fall on weekends ───────────
+
+    @Test
+    public void testManifestoDayDiffersBetweenMaAndMad2025() {
+        // MA rolls Jan 11 (Saturday) to Jan 13 (Monday); MAD stays Jan 11
+        HolidayCalendar maCalendar = new HolidayCalendarServiceMA().getHolidayCalendar();
+        Optional<HolidayDate> madMd = findFirst("Manifesto of Independence Day", 2025);
+        Optional<HolidayDate> maMd  = maCalendar.calculate(2025).stream()
+                .filter(hd -> "Manifesto of Independence Day".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(madMd.isPresent());
+        assertTrue(maMd.isPresent());
+        assertNotEquals(madMd.get().date(), maMd.get().date(),
+                "MAD Manifesto of Independence Day 2025 must differ from MA (no-roll vs followingMonday)");
+        assertEquals(madMd.get().date(), LocalDate.of(2025, Month.JANUARY, 11));
+        assertEquals(maMd.get().date(), LocalDate.of(2025, Month.JANUARY, 13));
+    }
+
+    @Test
+    public void testAmazighNewYearDiffersBetweenMaAndMad2024() {
+        // MA rolls Jan 14, 2024 (Sunday) to Jan 15; MAD stays Jan 14
+        HolidayCalendar maCalendar = new HolidayCalendarServiceMA().getHolidayCalendar();
+        Optional<HolidayDate> madAny = findFirst("Amazigh New Year", 2024);
+        Optional<HolidayDate> maAny  = maCalendar.calculate(2024).stream()
+                .filter(hd -> "Amazigh New Year".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(madAny.isPresent());
+        assertTrue(maAny.isPresent());
+        assertNotEquals(madAny.get().date(), maAny.get().date(),
+                "MAD Amazigh New Year 2024 must differ from MA (no-roll vs followingMonday)");
+        assertEquals(madAny.get().date(), LocalDate.of(2024, Month.JANUARY, 14));
+        assertEquals(maAny.get().date(), LocalDate.of(2024, Month.JANUARY, 15));
+    }
+
+    // ── KEY EDGE CASE: Islamic holidays on weekend must not roll in MAD ───────
+
+    // Eid al-Adha 2025 = Saturday Jun 7 — must stay Jun 7
+    @Test
+    public void testEidAlAdha2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 7).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: June 7, 2025 must be a Saturday");
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "MAD Eid al-Adha 2025 must be 2025-06-07 per CSE AV-2025-078 — no-roll preserves Saturday date");
+    }
+
+    // Eid al-Adha Day 2, 2025 = Sunday Jun 8 — must stay Jun 8
+    @Test
+    public void testEidAlAdhaDay2_2025OnSundayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 8).getDayOfWeek(), DayOfWeek.SUNDAY,
+                "Pre-condition: June 8, 2025 must be a Sunday");
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2025);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2025, Month.JUNE, 8),
+                "MAD Eid al-Adha (2nd Day) 2025 must be 2025-06-08 (Sunday) — no-roll preserves date");
+    }
+
+    // Mawlid Day 2, 2025 = Saturday Sep 6 — must stay Sep 6
+    @Test
+    public void testProphetsBirthdayDay2_2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: September 6, 2025 must be a Saturday");
+        Optional<HolidayDate> pb2 = findFirst("Prophet's Birthday (2nd Day)", 2025);
+        assertTrue(pb2.isPresent());
+        assertEquals(pb2.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 6),
+                "MAD Prophet's Birthday (2nd Day) 2025 must be 2025-09-06 (Saturday) — no-roll preserves date");
+    }
+
+    // ── Islamic dates match MA (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testMadIslamicDatesMatchMa() {
+        HolidayCalendarServiceMA maService = new HolidayCalendarServiceMA();
+        for (String name : new String[]{
+                "Eid al-Fitr", "Eid al-Fitr (2nd Day)",
+                "Eid al-Adha", "Eid al-Adha (2nd Day)",
+                "Islamic New Year",
+                "Prophet's Birthday", "Prophet's Birthday (2nd Day)"}) {
+            for (int year : new int[]{2024, 2025}) {
+                Optional<HolidayDate> mad = findFirst(name, year);
+                Optional<HolidayDate> ma  = maService.getHolidayCalendar().calculate(year).stream()
+                        .filter(hd -> name.equals(hd.holiday().getName()))
+                        .findFirst();
+                assertTrue(mad.isPresent(), year + " MAD must contain " + name);
+                assertTrue(ma.isPresent(),  year + " MA must contain " + name);
+                assertEquals(mad.get().date(), ma.get().date(),
+                        year + " MAD and MA must share the same " + name + " date (same CSV source, both rollable=false)");
+            }
+        }
+    }
+
+    // ── Amazigh New Year ──────────────────────────────────────────────────────
+
+    @Test
+    public void testAmazighNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Amazigh New Year".equals(h.getName()));
+        assertTrue(found, "Amazigh New Year must be included in the MAD calendar");
+    }
+
+    @Test
+    public void testAmazighNewYear2025() {
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2025);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2025, Month.JANUARY, 14),
+                "MAD Amazigh New Year 2025 must be Jan 14 (Tuesday, no roll needed)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "MAD calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("MAD");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"MAD\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), MAD_HOLIDAY_COUNT,
+                "Expected all " + MAD_HOLIDAY_COUNT + " MAD holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), MAD_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + MAD_FIXED_HOLIDAY_COUNT +
+                " fixed Morocco holidays must remain (10 Gregorian)");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Manifesto of Independence Day"},
+            new Object[]{"Amazigh New Year"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Throne Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Oued Ed-Dahab Allegiance Day"},
+            new Object[]{"Revolution of the King and the People"},
+            new Object[]{"Youth Day"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Prophet's Birthday (2nd Day)"},
+            new Object[]{"Green March Anniversary"},
+            new Object[]{"Independence Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "MAD calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMATest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceMATest.java
@@ -1,0 +1,515 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceMATest {
+
+    // 10 fixed Gregorian + 2 Eid al-Fitr + 2 Eid al-Adha
+    // + Islamic New Year + Prophet's Birthday × 2 = 17
+    private static final int MA_HOLIDAY_COUNT = 17;
+
+    // Beyond CSV ceiling: 10 fixed Gregorian holidays survive
+    private static final int MA_FIXED_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceMA service = new HolidayCalendarServiceMA();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("MA"));
+        assertFalse(service.isProvided("MAD"));
+        assertFalse(service.isProvided("EG"));
+        assertFalse(service.isProvided("BH"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "MA");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Morocco (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("MA");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "MA");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysSaturdayAndSunday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2,
+                "Morocco weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY),
+                "Saturday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY),
+                "Sunday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY),
+                "Friday must NOT be a weekend day — Morocco uses Sat/Sun weekend");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> years() {
+        return Arrays.asList(
+            new Object[]{2024},
+            new Object[]{2025},
+            new Object[]{2026}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "years")
+    public void testCalculate(int year) {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), MA_HOLIDAY_COUNT,
+                "Expected " + MA_HOLIDAY_COUNT + " holidays for " + year +
+                ", got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── fixed holidays — no roll on weekday ───────────────────────────────────
+
+    // Jan 1, 2025 is Wednesday — must not roll
+    @Test
+    public void testNewYearsDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2025);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2025, Month.JANUARY, 1),
+                "New Year's Day 2025 (Wednesday) must not roll");
+    }
+
+    // May 1, 2025 is Thursday — must not roll
+    @Test
+    public void testLabourDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.MAY, 1).getDayOfWeek(), DayOfWeek.THURSDAY);
+        Optional<HolidayDate> ld = findFirst("Labour Day", 2025);
+        assertTrue(ld.isPresent());
+        assertEquals(ld.get().date(), LocalDate.of(2025, Month.MAY, 1),
+                "Labour Day 2025 (Thursday) must not roll");
+    }
+
+    // Jul 30, 2025 is Wednesday — must not roll
+    @Test
+    public void testThroneDay2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JULY, 30).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> td = findFirst("Throne Day", 2025);
+        assertTrue(td.isPresent());
+        assertEquals(td.get().date(), LocalDate.of(2025, Month.JULY, 30),
+                "Throne Day 2025 (Wednesday) must not roll");
+    }
+
+    // ── fixed holidays — Saturday/Sunday roll to following Monday ─────────────
+
+    // Jan 11, 2025 is Saturday → rolls to Monday Jan 13
+    @Test
+    public void testManifestoDay2025OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 11).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> md = findFirst("Manifesto of Independence Day", 2025);
+        assertTrue(md.isPresent());
+        assertEquals(md.get().date(), LocalDate.of(2025, Month.JANUARY, 13),
+                "Manifesto of Independence Day 2025 (Saturday) must roll to Monday Jan 13");
+    }
+
+    // Jan 14, 2024 is Sunday → rolls to Monday Jan 15
+    @Test
+    public void testAmazighNewYear2024OnSundayRollsToMonday() {
+        assertEquals(LocalDate.of(2024, Month.JANUARY, 14).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2024);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2024, Month.JANUARY, 15),
+                "Amazigh New Year 2024 (Sunday) must roll to Monday Jan 15");
+    }
+
+    // Jan 14, 2025 is Tuesday — must not roll
+    @Test
+    public void testAmazighNewYear2025NoRoll() {
+        assertEquals(LocalDate.of(2025, Month.JANUARY, 14).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> any = findFirst("Amazigh New Year", 2025);
+        assertTrue(any.isPresent());
+        assertEquals(any.get().date(), LocalDate.of(2025, Month.JANUARY, 14),
+                "Amazigh New Year 2025 (Tuesday) must not roll");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Monday Jan 3
+    @Test
+    public void testNewYearsDay2028OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 3),
+                "New Year's Day 2028 (Saturday) must roll to Monday Jan 3");
+    }
+
+    // Aug 14, 2027 is Saturday → rolls to Monday Aug 16
+    @Test
+    public void testOuedEdDahab2027OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2027, Month.AUGUST, 14).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> odd = findFirst("Oued Ed-Dahab Allegiance Day", 2027);
+        assertTrue(odd.isPresent());
+        assertEquals(odd.get().date(), LocalDate.of(2027, Month.AUGUST, 16),
+                "Oued Ed-Dahab Allegiance Day 2027 (Saturday) must roll to Monday Aug 16");
+    }
+
+    // Nov 18, 2028 is Saturday → rolls to Monday Nov 20
+    @Test
+    public void testIndependenceDay2028OnSaturdayRollsToMonday() {
+        assertEquals(LocalDate.of(2028, Month.NOVEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> id = findFirst("Independence Day", 2028);
+        assertTrue(id.isPresent());
+        assertEquals(id.get().date(), LocalDate.of(2028, Month.NOVEMBER, 20),
+                "Independence Day 2028 (Saturday) must roll to Monday Nov 20");
+    }
+
+    // ── Islamic holidays — rollable(false): never roll even on weekend ─────────
+
+    // KEY EDGE CASE: Eid al-Adha 2025 = Saturday Jun 7 — must NOT roll despite MA using followingMonday
+    @Test
+    public void testEidAlAdha2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 7).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: June 7, 2025 must be a Saturday");
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "Eid al-Adha 2025 (Saturday) must stay Jun 7 — Islamic holidays are rollable(false) in MA");
+    }
+
+    // Eid al-Adha Day 2, 2025 = Sunday Jun 8 — must NOT roll
+    @Test
+    public void testEidAlAdhaDay2_2025OnSundayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 8).getDayOfWeek(), DayOfWeek.SUNDAY,
+                "Pre-condition: June 8, 2025 must be a Sunday");
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2025);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2025, Month.JUNE, 8),
+                "Eid al-Adha (2nd Day) 2025 (Sunday) must stay Jun 8 — rollable(false)");
+    }
+
+    // Islamic New Year 2025 = Friday Jun 27 — must NOT roll (Friday is not a Morocco weekend)
+    @Test
+    public void testIslamicNewYear2025OnFriday() {
+        assertEquals(LocalDate.of(2025, Month.JUNE, 27).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 27),
+                "Islamic New Year 2025 must be 2025-06-27 per CSE AV-2025-078");
+    }
+
+    // ── Islamic holiday spot-checks (official 2024–2025 dates) ───────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per official announcement");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11),
+                "Eid al-Fitr (2nd Day) 2024 must be 2024-04-11");
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 31),
+                "Eid al-Fitr 2025 must be 2025-03-31 per CSE AV-2025-078 (one day after GCC consensus)");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2025() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2025);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2025, Month.APRIL, 1),
+                "Eid al-Fitr (2nd Day) 2025 must be 2025-04-01");
+    }
+
+    @Test
+    public void testEidAlFitrDay2IsOneDayAfterDay1() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Fitr", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Fitr (2nd Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Fitr Day 1 must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Fitr Day 2 must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Fitr (2nd Day) must be exactly one day after Day 1");
+        }
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per official announcement");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 7),
+                "Eid al-Adha 2025 must be 2025-06-07 per CSE AV-2025-078 (one day after GCC consensus)");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2IsOneDayAfterDay1() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Eid al-Adha", year);
+            Optional<HolidayDate> day2 = findFirst("Eid al-Adha (2nd Day)", year);
+            assertTrue(day1.isPresent(), year + ": Eid al-Adha Day 1 must be present");
+            assertTrue(day2.isPresent(), year + ": Eid al-Adha Day 2 must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Eid al-Adha (2nd Day) must be exactly one day after Day 1");
+        }
+    }
+
+    @Test
+    public void testIslamicNewYear2024() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2024);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2024, Month.JULY, 7),
+                "Islamic New Year 2024 must be 2024-07-07 per official announcement");
+    }
+
+    @Test
+    public void testIslamicNewYear2025() {
+        Optional<HolidayDate> iny = findFirst("Islamic New Year", 2025);
+        assertTrue(iny.isPresent());
+        assertEquals(iny.get().date(), LocalDate.of(2025, Month.JUNE, 27),
+                "Islamic New Year 2025 must be 2025-06-27 per CSE AV-2025-078");
+    }
+
+    @Test
+    public void testProphetsBirthday2024() {
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2024);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2024, Month.SEPTEMBER, 15),
+                "Prophet's Birthday 2024 must be 2024-09-15 per official announcement");
+    }
+
+    // Mawlid 2025: Day 1 = Fri Sep 5 (natural date, observed as-is)
+    @Test
+    public void testProphetsBirthday2025OnFriday() {
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 5).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> pb = findFirst("Prophet's Birthday", 2025);
+        assertTrue(pb.isPresent());
+        assertEquals(pb.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 5),
+                "Prophet's Birthday 2025 must be 2025-09-05 per CSE AV-2025-078");
+    }
+
+    // Mawlid Day 2, 2025 = Sat Sep 6 — must NOT roll (Islamic rollable=false)
+    @Test
+    public void testProphetsBirthdayDay2_2025OnSaturdayNotRolled() {
+        assertEquals(LocalDate.of(2025, Month.SEPTEMBER, 6).getDayOfWeek(), DayOfWeek.SATURDAY,
+                "Pre-condition: September 6, 2025 must be a Saturday");
+        Optional<HolidayDate> pb2 = findFirst("Prophet's Birthday (2nd Day)", 2025);
+        assertTrue(pb2.isPresent());
+        assertEquals(pb2.get().date(), LocalDate.of(2025, Month.SEPTEMBER, 6),
+                "Prophet's Birthday (2nd Day) 2025 (Saturday) must stay Sep 6 — rollable(false)");
+    }
+
+    @Test
+    public void testProphetsBirthdayDay2IsOneDayAfterDay1() {
+        for (int year : new int[]{2024, 2025, 2026}) {
+            Optional<HolidayDate> day1 = findFirst("Prophet's Birthday", year);
+            Optional<HolidayDate> day2 = findFirst("Prophet's Birthday (2nd Day)", year);
+            assertTrue(day1.isPresent(), year + ": Prophet's Birthday Day 1 must be present");
+            assertTrue(day2.isPresent(), year + ": Prophet's Birthday (2nd Day) must be present");
+            assertEquals(day2.get().date(), day1.get().date().plusDays(1),
+                    year + ": Prophet's Birthday (2nd Day) must be exactly one day after Day 1");
+        }
+    }
+
+    // ── Amazigh New Year presence ─────────────────────────────────────────────
+
+    @Test
+    public void testAmazighNewYearIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Amazigh New Year".equals(h.getName()));
+        assertTrue(found,
+                "Amazigh New Year (Jan 14, added 2024) must be included in the MA calendar");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "MA calendar has CSV-backed Islamic holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("MA");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"MA\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), MA_HOLIDAY_COUNT,
+                "Expected all " + MA_HOLIDAY_COUNT + " MA holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), MA_FIXED_HOLIDAY_COUNT,
+                "Beyond CSV ceiling only the " + MA_FIXED_HOLIDAY_COUNT +
+                " fixed Morocco holidays must remain (10 Gregorian)");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date().getMonth(), Month.JANUARY,
+                "The single 2033 Eid al-Fitr occurrence must be in January");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Manifesto of Independence Day"},
+            new Object[]{"Amazigh New Year"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Labour Day"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Throne Day"},
+            new Object[]{"Islamic New Year"},
+            new Object[]{"Oued Ed-Dahab Allegiance Day"},
+            new Object[]{"Revolution of the King and the People"},
+            new Object[]{"Youth Day"},
+            new Object[]{"Prophet's Birthday"},
+            new Object[]{"Prophet's Birthday (2nd Day)"},
+            new Object[]{"Green March Anniversary"},
+            new Object[]{"Independence Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQARTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQARTest.java
@@ -1,0 +1,287 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceQARTest {
+
+    // 9 national holidays shared with QA + Qatar Banks Holiday (first Sunday of March) = 10
+    private static final int QAR_HOLIDAY_COUNT = 10;
+
+    private final HolidayCalendarServiceQAR service = new HolidayCalendarServiceQAR();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("QAR"));
+        assertFalse(service.isProvided("QA"));
+        assertFalse(service.isProvided("SAR"));
+        assertFalse(service.isProvided("USD"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "QAR");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Qatar (QSE/QCB) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("QAR");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "QAR");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Qatar weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QAR_HOLIDAY_COUNT,
+                "Expected " + QAR_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QAR_HOLIDAY_COUNT,
+                "Expected " + QAR_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── no-roll: National Day stays on natural date ───────────────────────────
+
+    // Dec 18, 2026 is Friday — QAR must NOT roll (noRoll convention)
+    @Test
+    public void testNationalDayOnFridayNotRolled2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2026);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2026, Month.DECEMBER, 18),
+                "QAR must not roll National Day 2026 (Friday) — settlement uses no-roll convention");
+    }
+
+    // Dec 18, 2027 is Saturday — QAR must NOT roll
+    @Test
+    public void testNationalDayOnSaturdayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2027);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2027, Month.DECEMBER, 18),
+                "QAR must not roll National Day 2027 (Saturday) — settlement uses no-roll convention");
+    }
+
+    // ── no-roll: New Year's Day stays on natural date ─────────────────────────
+
+    // Jan 1, 2027 is Friday — QAR must NOT roll
+    @Test
+    public void testNewYearsDayOnFridayNotRolled2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2027, Month.JANUARY, 1),
+                "QAR must not roll New Year's Day 2027 (Friday) — settlement uses no-roll convention");
+    }
+
+    // ── Qatar Banks Holiday (first Sunday of March, QAR-only) ────────────────
+
+    // Mar 3, 2024 is the first Sunday of March — confirmed QCB announcement
+    @Test
+    public void testQatarBanksHoliday2024() {
+        assertEquals(LocalDate.of(2024, Month.MARCH, 3).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> bh = findFirst("Qatar Banks Holiday", 2024);
+        assertTrue(bh.isPresent());
+        assertEquals(bh.get().date(), LocalDate.of(2024, Month.MARCH, 3),
+                "Qatar Banks Holiday 2024 must be 2024-03-03 per QCB announcement");
+    }
+
+    @Test
+    public void testQatarBanksHoliday2025() {
+        assertEquals(LocalDate.of(2025, Month.MARCH, 2).getDayOfWeek(), DayOfWeek.SUNDAY);
+        Optional<HolidayDate> bh = findFirst("Qatar Banks Holiday", 2025);
+        assertTrue(bh.isPresent());
+        assertEquals(bh.get().date(), LocalDate.of(2025, Month.MARCH, 2),
+                "Qatar Banks Holiday 2025 must be 2025-03-02");
+    }
+
+    @Test
+    public void testQatarBanksHolidayNotInQA() {
+        boolean inQA = new HolidayCalendarServiceQA().getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Qatar Banks Holiday".equals(h.getName()));
+        assertFalse(inQA, "Qatar Banks Holiday is QAR-only — not a national public holiday");
+    }
+
+    // ── Islamic dates match QA (same CSV source) ──────────────────────────────
+
+    @Test
+    public void testEidAlFitr2025MatchesQA() {
+        HolidayCalendar qaCalendar  = new HolidayCalendarServiceQA().getHolidayCalendar();
+        Optional<HolidayDate> qarEid = findFirst("Eid al-Fitr", 2025);
+        Optional<HolidayDate> qaEid  = qaCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(qarEid.isPresent());
+        assertTrue(qaEid.isPresent());
+        assertEquals(qarEid.get().date(), qaEid.get().date(),
+                "QAR Eid al-Fitr 2025 must match QA (same CSV source)");
+    }
+
+    @Test
+    public void testEidAlAdha2025MatchesQA() {
+        HolidayCalendar qaCalendar  = new HolidayCalendarServiceQA().getHolidayCalendar();
+        Optional<HolidayDate> qarAdha = findFirst("Eid al-Adha", 2025);
+        Optional<HolidayDate> qaAdha  = qaCalendar.calculate(2025).stream()
+                .filter(hd -> "Eid al-Adha".equals(hd.holiday().getName()))
+                .findFirst();
+        assertTrue(qarAdha.isPresent());
+        assertTrue(qaAdha.isPresent());
+        assertEquals(qarAdha.get().date(), qaAdha.get().date(),
+                "QAR Eid al-Adha 2025 must match QA (same CSV source)");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "QAR calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("QAR");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"QAR\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), QAR_HOLIDAY_COUNT,
+                "Expected all " + QAR_HOLIDAY_COUNT + " QAR holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        // New Year's Day, Sports Day, National Day, and Qatar Banks Holiday are all
+        // algorithmic/fixed — they remain after the Eid CSV data is exhausted
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), 4,
+                "Beyond CSV ceiling the 4 fixed/computed QAR holidays must remain");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Qatar National Sports Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"National Day"},
+            new Object[]{"Qatar Banks Holiday"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQATest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceQATest.java
@@ -1,0 +1,394 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.OptionalInt;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceQATest {
+
+    // 2 fixed (New Year's, National Day) + 1 floating Gregorian (Sports Day)
+    // + 3 Eid al-Fitr + 3 Eid al-Adha = 9
+    private static final int QA_HOLIDAY_COUNT = 9;
+
+    private final HolidayCalendarServiceQA service = new HolidayCalendarServiceQA();
+    private HolidayCalendarFactory factory;
+
+    @BeforeClass
+    public void setupFactory() {
+        this.factory = new HolidayCalendarFactory();
+    }
+
+    // ── service identity ──────────────────────────────────────────────────────
+
+    @Test
+    public void testIsProvided() {
+        assertTrue(service.isProvided("QA"));
+        assertFalse(service.isProvided("QAR"));
+        assertFalse(service.isProvided("SA"));
+        assertFalse(service.isProvided("US"));
+    }
+
+    @Test
+    public void testGetCode() {
+        assertEquals(service.getCode(), "QA");
+    }
+
+    @Test
+    public void testGetRegion() {
+        assertEquals(service.getRegion(), "Qatar (National) Holidays");
+    }
+
+    // ── factory integration ───────────────────────────────────────────────────
+
+    @Test
+    public void testHolidayCalendarFactoryCreate() {
+        HolidayCalendar calendar = factory.create("QA");
+        assertNotNull(calendar);
+        assertEquals(calendar.getCode(), "QA");
+    }
+
+    // ── weekend configuration ─────────────────────────────────────────────────
+
+    @Test
+    public void testWeekendDaysFridayAndSaturday() {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertEquals(calendar.getWeekendDays().size(), 2, "Qatar weekend must be exactly 2 days");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.FRIDAY), "Friday must be a weekend day");
+        assertTrue(calendar.getWeekendDays().contains(DayOfWeek.SATURDAY), "Saturday must be a weekend day");
+        assertFalse(calendar.getWeekendDays().contains(DayOfWeek.SUNDAY), "Sunday must not be a weekend day");
+    }
+
+    // ── total count ───────────────────────────────────────────────────────────
+
+    @Test
+    public void testCalculate2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QA_HOLIDAY_COUNT,
+                "Expected " + QA_HOLIDAY_COUNT + " holidays for 2024, got: " + holidays.size());
+    }
+
+    @Test
+    public void testCalculate2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), QA_HOLIDAY_COUNT,
+                "Expected " + QA_HOLIDAY_COUNT + " holidays for 2025, got: " + holidays.size());
+    }
+
+    // ── chronological order ───────────────────────────────────────────────────
+
+    @Test
+    public void testChronologicalOrder2024() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    @Test
+    public void testChronologicalOrder2025() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        for (int i = 1; i < holidays.size(); i++) {
+            assertFalse(holidays.get(i).date().isBefore(holidays.get(i - 1).date()),
+                    "Holidays must be in chronological order");
+        }
+    }
+
+    // ── Sports Day (second Tuesday of February) ───────────────────────────────
+
+    @Test
+    public void testSportsDay2024() {
+        assertEquals(LocalDate.of(2024, Month.FEBRUARY, 13).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> sd = findFirst("Qatar National Sports Day", 2024);
+        assertTrue(sd.isPresent());
+        assertEquals(sd.get().date(), LocalDate.of(2024, Month.FEBRUARY, 13),
+                "Sports Day 2024 must be 2024-02-13");
+    }
+
+    @Test
+    public void testSportsDay2025() {
+        assertEquals(LocalDate.of(2025, Month.FEBRUARY, 11).getDayOfWeek(), DayOfWeek.TUESDAY);
+        Optional<HolidayDate> sd = findFirst("Qatar National Sports Day", 2025);
+        assertTrue(sd.isPresent());
+        assertEquals(sd.get().date(), LocalDate.of(2025, Month.FEBRUARY, 11),
+                "Sports Day 2025 must be 2025-02-11");
+    }
+
+    // ── National Day (Dec 18) — no roll when weekday ──────────────────────────
+
+    // Dec 18, 2024 is Wednesday — must not roll
+    @Test
+    public void testNationalDay2024NoRoll() {
+        assertEquals(LocalDate.of(2024, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.WEDNESDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2024);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2024, Month.DECEMBER, 18),
+                "National Day 2024 (Wednesday) must not roll");
+    }
+
+    // ── National Day — Friday rolls to preceding Thursday ─────────────────────
+
+    // Dec 18, 2026 is Friday → rolls to Thursday Dec 17 (Amiri Diwan rule; confirmed 2020)
+    @Test
+    public void testNationalDayRollFromFriday2026() {
+        assertEquals(LocalDate.of(2026, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2026);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2026, Month.DECEMBER, 17),
+                "National Day 2026 (Friday) must roll to Thursday Dec 17");
+    }
+
+    // ── National Day — Saturday rolls to following Sunday ─────────────────────
+
+    // Dec 18, 2027 is Saturday → rolls to Sunday Dec 19 (Amiri Diwan rule; confirmed 2021)
+    @Test
+    public void testNationalDayRollFromSaturday2027() {
+        assertEquals(LocalDate.of(2027, Month.DECEMBER, 18).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> nd = findFirst("National Day", 2027);
+        assertTrue(nd.isPresent());
+        assertEquals(nd.get().date(), LocalDate.of(2027, Month.DECEMBER, 19),
+                "National Day 2027 (Saturday) must roll to Sunday Dec 19");
+    }
+
+    // ── New Year's Day rolls ──────────────────────────────────────────────────
+
+    // Jan 1, 2027 is Friday → rolls to Thursday Dec 31, 2026
+    @Test
+    public void testNewYearsDayRollFromFriday2027() {
+        assertEquals(LocalDate.of(2027, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.FRIDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2027);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2026, Month.DECEMBER, 31),
+                "New Year's Day 2027 (Friday) must roll to Thursday Dec 31, 2026");
+    }
+
+    // Jan 1, 2028 is Saturday → rolls to Sunday Jan 2
+    @Test
+    public void testNewYearsDayRollFromSaturday2028() {
+        assertEquals(LocalDate.of(2028, Month.JANUARY, 1).getDayOfWeek(), DayOfWeek.SATURDAY);
+        Optional<HolidayDate> ny = findFirst("New Year's Day", 2028);
+        assertTrue(ny.isPresent());
+        assertEquals(ny.get().date(), LocalDate.of(2028, Month.JANUARY, 2),
+                "New Year's Day 2028 (Saturday) must roll to Sunday Jan 2");
+    }
+
+    // ── Islamic holiday spot-checks ───────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2024() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2024);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2024, Month.APRIL, 10),
+                "Eid al-Fitr 2024 must be 2024-04-10 per QCB official");
+    }
+
+    @Test
+    public void testEidAlFitrDay2_2024() {
+        Optional<HolidayDate> eid2 = findFirst("Eid al-Fitr (2nd Day)", 2024);
+        assertTrue(eid2.isPresent());
+        assertEquals(eid2.get().date(), LocalDate.of(2024, Month.APRIL, 11));
+    }
+
+    @Test
+    public void testEidAlFitrDay3_2024() {
+        Optional<HolidayDate> eid3 = findFirst("Eid al-Fitr (3rd Day)", 2024);
+        assertTrue(eid3.isPresent());
+        assertEquals(eid3.get().date(), LocalDate.of(2024, Month.APRIL, 12));
+    }
+
+    @Test
+    public void testEidAlAdha2024() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2024);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2024, Month.JUNE, 16),
+                "Eid al-Adha 2024 must be 2024-06-16 per QCB official");
+    }
+
+    @Test
+    public void testEidAlAdhaDay2_2024() {
+        Optional<HolidayDate> adha2 = findFirst("Eid al-Adha (2nd Day)", 2024);
+        assertTrue(adha2.isPresent());
+        assertEquals(adha2.get().date(), LocalDate.of(2024, Month.JUNE, 17));
+    }
+
+    @Test
+    public void testEidAlAdhaDay3_2024() {
+        Optional<HolidayDate> adha3 = findFirst("Eid al-Adha (3rd Day)", 2024);
+        assertTrue(adha3.isPresent());
+        assertEquals(adha3.get().date(), LocalDate.of(2024, Month.JUNE, 18));
+    }
+
+    @Test
+    public void testEidAlFitr2025() {
+        Optional<HolidayDate> eid = findFirst("Eid al-Fitr", 2025);
+        assertTrue(eid.isPresent());
+        assertEquals(eid.get().date(), LocalDate.of(2025, Month.MARCH, 30),
+                "Eid al-Fitr 2025 must be 2025-03-30 per QCB official");
+    }
+
+    @Test
+    public void testEidAlAdha2025() {
+        Optional<HolidayDate> adha = findFirst("Eid al-Adha", 2025);
+        assertTrue(adha.isPresent());
+        assertEquals(adha.get().date(), LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per QCB official");
+    }
+
+    // ── Islamic holidays not included ─────────────────────────────────────────
+
+    @Test
+    public void testIslamicNewYearNotIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Islamic New Year".equals(h.getName()));
+        assertFalse(found, "Islamic New Year is not a gazetted Qatar public holiday");
+    }
+
+    @Test
+    public void testProphetsBirthdayNotIncluded() {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> "Prophet's Birthday".equals(h.getName()));
+        assertFalse(found, "Prophet's Birthday is not a gazetted Qatar public holiday");
+    }
+
+    // ── dataValidThrough ──────────────────────────────────────────────────────
+
+    @Test
+    public void testDataValidThroughReturnsPresent() {
+        assertTrue(service.dataValidThrough().isPresent(),
+                "QA calendar has CSV-backed holidays; dataValidThrough() must be present");
+    }
+
+    @Test
+    public void testDataValidThroughReturnedYear() {
+        assertEquals(service.dataValidThrough().orElseThrow(), 2055,
+                "dataValidThrough() must return 2055");
+    }
+
+    @Test
+    public void testDataValidThroughViaFactory() {
+        OptionalInt result = factory.dataValidThrough("QA");
+        assertTrue(result.isPresent());
+        assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(),
+                "factory.dataValidThrough(\"QA\") must delegate to the service");
+    }
+
+    // ── CSV boundary behaviour ────────────────────────────────────────────────
+
+    @Test
+    public void testCalculateAtDataValidThroughReturnsAllHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(boundary);
+        assertFalse(holidays.isEmpty(),
+                "calculate(" + boundary + ") must return holidays — within covered range");
+        assertEquals(holidays.size(), QA_HOLIDAY_COUNT,
+                "Expected all " + QA_HOLIDAY_COUNT + " QA holidays for boundary year " + boundary);
+    }
+
+    @Test
+    public void testCalculateBeyondDataValidThroughDropsIslamicHolidays() {
+        int boundary = service.dataValidThrough().orElseThrow();
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> atBoundary     = calendar.calculate(boundary);
+        List<HolidayDate> beyondBoundary = calendar.calculate(boundary + 1);
+        assertTrue(beyondBoundary.size() < atBoundary.size(),
+                "Year beyond dataValidThrough must produce fewer holidays (Islamic tables exhausted); " +
+                "at boundary: " + atBoundary.size() + ", beyond: " + beyondBoundary.size());
+    }
+
+    @Test
+    public void testEidAlFitr2056AbsentSilently() {
+        Optional<HolidayDate> eid = service.getHolidayCalendar().calculate(2056).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .findFirst();
+        assertFalse(eid.isPresent(),
+                "Eid al-Fitr must be silently absent for 2056 — beyond the table ceiling");
+    }
+
+    @Test
+    public void testFixedHolidaysPresentBeyondCeiling() {
+        // New Year's Day, Sports Day, and National Day remain after CSV data is exhausted
+        List<HolidayDate> holidays2056 = service.getHolidayCalendar().calculate(2056);
+        assertEquals(holidays2056.size(), 3,
+                "Beyond CSV ceiling only the 3 fixed/computed Qatar holidays must remain");
+    }
+
+    // ── 2033 dual-Eid al-Fitr ────────────────────────────────────────────────
+
+    @Test
+    public void testEidAlFitr2033OnlyJanuaryOccurrence() {
+        List<HolidayDate> eidOccurrences = service.getHolidayCalendar().calculate(2033).stream()
+                .filter(hd -> "Eid al-Fitr".equals(hd.holiday().getName()))
+                .toList();
+        assertEquals(eidOccurrences.size(), 1,
+                "2033 has two Eid al-Fitr occurrences but only January is recorded in the CSV");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
+                "The single 2033 Eid al-Fitr occurrence must be January 3");
+    }
+
+    // ── holiday name registry ─────────────────────────────────────────────────
+
+    @DataProvider
+    Iterator<Object[]> expectedHolidayNames() {
+        return Arrays.asList(
+            new Object[]{"New Year's Day"},
+            new Object[]{"Qatar National Sports Day"},
+            new Object[]{"Eid al-Fitr"},
+            new Object[]{"Eid al-Fitr (2nd Day)"},
+            new Object[]{"Eid al-Fitr (3rd Day)"},
+            new Object[]{"Eid al-Adha"},
+            new Object[]{"Eid al-Adha (2nd Day)"},
+            new Object[]{"Eid al-Adha (3rd Day)"},
+            new Object[]{"National Day"}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "expectedHolidayNames")
+    public void testHolidayCalendarContains(String holidayName) {
+        boolean found = service.getHolidayCalendar().getHolidays().stream()
+                .anyMatch(h -> holidayName.equals(h.getName()));
+        assertTrue(found, "Calendar must contain holiday: " + holidayName);
+    }
+
+    // ── helper ────────────────────────────────────────────────────────────────
+
+    private Optional<HolidayDate> findFirst(String name, int year) {
+        return service.getHolidayCalendar().calculate(year).stream()
+                .filter(hd -> name.equals(hd.holiday().getName()))
+                .findFirst();
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -128,4 +128,30 @@ public class EidAlAdhaTest {
         assertNotEquals(trDate, aeDate,
                 "Diyanet and Umm al-Qura Eid al-Adha 2025 must differ by one day");
     }
+
+    // -------------------------------------------------------------------------
+    // Known dates — QA (Qatar Central Bank official)
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDatesQA() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 6, 16)},
+            new Object[]{2025, LocalDate.of(2025, 6, 6)},
+            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesQA")
+    public void testKnownDatesQA(int year, LocalDate expected) {
+        assertEquals(new EidAlAdha("QA").apply(year), expected,
+                "Eid al-Adha " + year + " per QCB must be " + expected);
+    }
+
+    // QA 2025 matches AE: Qatar and UAE both use Umm al-Qura; Jun 6 confirmed QCB official
+    @Test
+    public void testQA2025MatchesAE() {
+        assertEquals(new EidAlAdha("QA").apply(2025), new EidAlAdha("AE").apply(2025),
+                "Eid al-Adha 2025: Qatar (QCB) and UAE (SCA) must agree on June 6");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -175,4 +175,30 @@ public class EidAlFitrTest {
         assertEquals(new EidAlFitr("TR").apply(2025), new EidAlFitr("AE").apply(2025),
                 "Eid al-Fitr 2025: Diyanet (TR) and UAE SCA (AE) must agree on March 30");
     }
+
+    // -------------------------------------------------------------------------
+    // Known dates — QA (Qatar Central Bank official)
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> knownDatesQA() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 4, 10)},
+            new Object[]{2025, LocalDate.of(2025, 3, 30)},
+            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDatesQA")
+    public void testKnownDatesQA(int year, LocalDate expected) {
+        assertEquals(new EidAlFitr("QA").apply(year), expected,
+                "Eid al-Fitr " + year + " per QCB must be " + expected);
+    }
+
+    // QA 2025 matches AE: both Qatar and UAE arrive at same date via Umm al-Qura
+    @Test
+    public void testQA2025MatchesAE() {
+        assertEquals(new EidAlFitr("QA").apply(2025), new EidAlFitr("AE").apply(2025),
+                "Eid al-Fitr 2025: Qatar (QCB) and UAE (SCA) must agree on March 30");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarBanksHolidayTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarBanksHolidayTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class QatarBanksHolidayTest {
+
+    private final QatarBanksHoliday banksHoliday = new QatarBanksHoliday();
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        return List.of(
+            // 2024-03-03 confirmed via QCB official announcement (Gulf Times)
+            new Object[]{2024, LocalDate.of(2024, Month.MARCH, 3)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 2)},
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 1)},
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 7)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testFirstSundayOfMarch(int year, LocalDate expected) {
+        assertEquals(banksHoliday.apply(year), expected,
+                "Qatar Banks Holiday " + year + " must be " + expected);
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testAlwaysFallsOnSunday(int year, LocalDate expected) {
+        assertEquals(banksHoliday.apply(year).getDayOfWeek(), DayOfWeek.SUNDAY,
+                "Qatar Banks Holiday must always fall on Sunday");
+    }
+
+    @Test
+    public void testValidFrom2009() {
+        assertNotNull(banksHoliday.apply(2009),
+                "Qatar Banks Holiday must be computable from 2009 (Cabinet Decision No. (33) of 2009)");
+        assertEquals(banksHoliday.apply(2009).getDayOfWeek(), DayOfWeek.SUNDAY);
+    }
+
+    @Test
+    public void testInvalidBefore2009ReturnsNull() {
+        assertNull(banksHoliday.apply(2008),
+                "Qatar Banks Holiday before 2009 must return null — Cabinet Decision not yet in force");
+    }
+
+    @Test
+    public void testTestReturnsFalseBeforeInception() {
+        assertFalse(banksHoliday.test(2008));
+    }
+
+    @Test
+    public void testTestReturnsTrueFrom2009() {
+        assertTrue(banksHoliday.test(2024));
+    }
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarNationalSportsDayTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/qa/QatarNationalSportsDayTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.qa;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class QatarNationalSportsDayTest {
+
+    private final QatarNationalSportsDay sportsDay = new QatarNationalSportsDay();
+
+    @DataProvider
+    Iterator<Object[]> knownDates() {
+        return List.of(
+            // Amiri Diwan confirmed dates
+            new Object[]{2023, LocalDate.of(2023, Month.FEBRUARY, 14)},
+            new Object[]{2024, LocalDate.of(2024, Month.FEBRUARY, 13)},
+            new Object[]{2025, LocalDate.of(2025, Month.FEBRUARY, 11)},
+            new Object[]{2026, LocalDate.of(2026, Month.FEBRUARY, 10)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testSecondTuesdayOfFebruary(int year, LocalDate expected) {
+        assertEquals(sportsDay.apply(year), expected,
+                "Qatar National Sports Day " + year + " must be " + expected);
+    }
+
+    @Test(dataProvider = "knownDates")
+    public void testAlwaysFallsOnTuesday(int year, LocalDate expected) {
+        assertEquals(sportsDay.apply(year).getDayOfWeek(), DayOfWeek.TUESDAY,
+                "Qatar National Sports Day must always fall on Tuesday");
+    }
+
+    @Test
+    public void testValidFrom2012() {
+        assertNotNull(sportsDay.apply(2012),
+                "First Sports Day (2012) must be computable");
+        assertEquals(sportsDay.apply(2012).getDayOfWeek(), DayOfWeek.TUESDAY);
+    }
+
+    @Test
+    public void testInvalidBefore2012ReturnsNull() {
+        assertNull(sportsDay.apply(2011),
+                "Sports Day before 2012 must return null — Decree enacted 2011, first observed 2012");
+    }
+
+    @Test
+    public void testTestReturnsFalseBeforeInception() {
+        assertFalse(sportsDay.test(2011));
+    }
+
+    @Test
+    public void testTestReturnsTrueFrom2012() {
+        assertTrue(sportsDay.test(2025));
+    }
+}

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0-SNAPSHOT</version>
+    <version>1.4.0</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>1.3.1</version>
+    <version>1.4.0-SNAPSHOT</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -31,7 +31,7 @@
       {@link org.holiday.calendar.HolidayCalendarService}.</p>
 
   <h1>Modules</h1>
-  <p>This API is divided into three modules to enable client software to depend
+  <p>This API is divided into four modules to enable client software to depend
       only on the regions it requires.</p>
   <dl>
     <dt><strong>holiday-calendar-core</strong></dt>
@@ -55,6 +55,14 @@
         Tokyo Stock Exchange (JP), Bank of Japan (JPY), and
         People's Bank of China (CNY). Uses Time4J for accurate
         non-Gregorian date calculations such as Chinese New Year.</dd>
+    <dt><strong>holiday-calendar-mena</strong></dt>
+    <dd>Holiday calendars for Middle East and North Africa markets:
+        UAE national (AE), UAE DFM / CBUAE (AED),
+        Saudi Arabia national (SA), Saudi Exchange / SAMA (SAR),
+        Israel national (IL), Tel Aviv Stock Exchange / Bank of Israel (ILS),
+        Turkey national (TR), Borsa İstanbul / TCMB (TRY),
+        Qatar national (QA), and Qatar Stock Exchange / QCB (QAR).
+        Uses CSV lookup tables for Islamic lunar holidays.</dd>
   </dl>
 </body>
 </html>

--- a/src/main/javadoc/overview.html
+++ b/src/main/javadoc/overview.html
@@ -61,7 +61,8 @@
         Saudi Arabia national (SA), Saudi Exchange / SAMA (SAR),
         Israel national (IL), Tel Aviv Stock Exchange / Bank of Israel (ILS),
         Turkey national (TR), Borsa İstanbul / TCMB (TRY),
-        Qatar national (QA), and Qatar Stock Exchange / QCB (QAR).
+        Qatar national (QA), Qatar Stock Exchange / QCB (QAR),
+        Kuwait national (KW), and Boursa Kuwait / CBK (KWD).
         Uses CSV lookup tables for Islamic lunar holidays.</dd>
   </dl>
 </body>

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -18,43 +18,45 @@ Key design goals:
 
 ### Supported Calendars
 
-| Code | Region |
-|------|--------|
-| `AE` | UAE (National) Holidays |
-| `AED` | UAE (CBUAE/DFM/ADX) Holidays |
+| Code | Region                                        |
+|------|-----------------------------------------------|
+| `AE` | United Arab Emirates (National) Holidays      |
+| `AED` | United Arab Emirates (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
-| `AUD` | Australia (RBA) Holidays |
-| `BH` | Bahrain (National) Holidays |
-| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
-| `CA` | Canada National Holidays |
-| `CAD` | Bank of Canada (Lynx) Holiday Schedule |
-| `CH` | Switzerland (SIX) Holidays |
-| `CHF` | Switzerland (SIC/SNB) Holidays |
-| `CN` | China National Holidays |
-| `CNY` | China (PBOC) Holidays |
-| `DE` | Germany (Xetra) Holidays |
-| `EG` | Egypt (National) Holidays |
-| `EGP` | Egypt (EGX/CBE) Holidays |
-| `EUR` | Euro (TARGET2) Holidays |
-| `FR` | France (Euronext Paris) Holidays |
-| `GBP` | United Kingdom (CHAPS) Holidays |
-| `IL` | Israel (National) Holidays |
-| `ILS` | Israel (TASE/Bank of Israel) Holidays |
-| `KW` | Kuwait (National) Holidays |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
-| `JP` | Japan (TSE) Holidays |
-| `JPY` | Japan (BOJ) Holidays |
-| `QA` | Qatar (National) Holidays |
-| `QAR` | Qatar (QSE/QCB) Holidays |
-| `SA` | Saudi Arabia (National) Holidays |
-| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
-| `SG` | Singapore (SGX) Holidays |
-| `SGD` | Singapore (MAS/MEPS+) Holidays |
-| `TR`  | Turkey (National) Holidays |
-| `TRY` | Turkey (BIST/TCMB) Holidays |
-| `UK` | United Kingdom National Holidays |
-| `US` | United States National Holidays |
-| `USD` | United States (Federal Reserve) Holidays |
+| `AUD` | Australia (RBA) Holidays                      |
+| `BH` | Bahrain (National) Holidays                   |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays         |
+| `CA` | Canada National Holidays                      |
+| `CAD` | Bank of Canada (Lynx) Holiday Schedule        |
+| `CH` | Switzerland (SIX) Holidays                    |
+| `CHF` | Switzerland (SIC/SNB) Holidays                |
+| `CN` | China National Holidays                       |
+| `CNY` | China (PBOC) Holidays                         |
+| `DE` | Germany (Xetra) Holidays                      |
+| `EG` | Egypt (National) Holidays                     |
+| `EGP` | Egypt (EGX/CBE) Holidays                      |
+| `EUR` | Euro (TARGET2) Holidays                       |
+| `FR` | France (Euronext Paris) Holidays              |
+| `GBP` | United Kingdom (CHAPS) Holidays               |
+| `IL` | Israel (National) Holidays                    |
+| `ILS` | Israel (TASE/Bank of Israel) Holidays         |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
+| `JP` | Japan (TSE) Holidays                          |
+| `JPY` | Japan (BOJ) Holidays                          |
+| `MA` | Morocco (National) Holidays                   |
+| `MAD` | Morocco (CSE/BAM) Holidays                    |
+| `QA` | Qatar (National) Holidays                     |
+| `QAR` | Qatar (QSE/QCB) Holidays                      |
+| `SA` | Saudi Arabia (National) Holidays              |
+| `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays          |
+| `SG` | Singapore (SGX) Holidays                      |
+| `SGD` | Singapore (MAS/MEPS+) Holidays                |
+| `TR`  | Turkey (National) Holidays                    |
+| `TRY` | Turkey (BIST/TCMB) Holidays                   |
+| `UK` | United Kingdom National Holidays              |
+| `US` | United States National Holidays               |
+| `USD` | United States (Federal Reserve) Holidays      |
 
 For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
 
@@ -98,7 +100,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -145,7 +147,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -31,6 +31,8 @@ Key design goals:
 | `CN` | China National Holidays |
 | `CNY` | China (PBOC) Holidays |
 | `DE` | Germany (Xetra) Holidays |
+| `EG` | Egypt (National) Holidays |
+| `EGP` | Egypt (EGX/CBE) Holidays |
 | `EUR` | Euro (TARGET2) Holidays |
 | `FR` | France (Euronext Paris) Holidays |
 | `GBP` | United Kingdom (CHAPS) Holidays |
@@ -94,7 +96,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -40,10 +40,12 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays               |
 | `IL` | Israel (National) Holidays                    |
 | `ILS` | Israel (TASE/Bank of Israel) Holidays         |
-| `KW` | Kuwait (National) Holidays                    |
-| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
+| `JO` | Jordan (National) Holidays |
+| `JOD` | Jordan (ASE/CBJ) Holidays |
 | `JP` | Japan (TSE) Holidays                          |
 | `JPY` | Japan (BOJ) Holidays                          |
+| `KW` | Kuwait (National) Holidays                    |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays           |
 | `MA` | Morocco (National) Holidays                   |
 | `MAD` | Morocco (CSE/BAM) Holidays                    |
 | `QA` | Qatar (National) Holidays                     |
@@ -100,7 +102,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -147,7 +149,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JO", "JOD", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -38,6 +38,8 @@ Key design goals:
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
+| `QA` | Qatar (National) Holidays |
+| `QAR` | Qatar (QSE/QCB) Holidays |
 | `SA` | Saudi Arabia (National) Holidays |
 | `SAR` | Saudi Arabia (Tadawul/SAMA) Holidays |
 | `SG` | Singapore (SGX) Holidays |
@@ -90,7 +92,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -137,7 +139,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -36,6 +36,8 @@ Key design goals:
 | `GBP` | United Kingdom (CHAPS) Holidays |
 | `IL` | Israel (National) Holidays |
 | `ILS` | Israel (TASE/Bank of Israel) Holidays |
+| `KW` | Kuwait (National) Holidays |
+| `KWD` | Kuwait (Boursa Kuwait/CBK) Holidays |
 | `JP` | Japan (TSE) Holidays |
 | `JPY` | Japan (BOJ) Holidays |
 | `QA` | Qatar (National) Holidays |
@@ -92,7 +94,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, IL, ILS, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -139,7 +141,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -24,6 +24,8 @@ Key design goals:
 | `AED` | UAE (CBUAE/DFM/ADX) Holidays |
 | `AU` | Australian Securities Exchange (ASX) Holidays |
 | `AUD` | Australia (RBA) Holidays |
+| `BH` | Bahrain (National) Holidays |
+| `BHD` | Bahrain (Boursa Bahrain/CBB) Holidays |
 | `CA` | Canada National Holidays |
 | `CAD` | Bank of Canada (Lynx) Holiday Schedule |
 | `CH` | Switzerland (SIX) Holidays |
@@ -96,7 +98,7 @@ Then add the modules you need:
   <version>@project.version@</version>
 </dependency>
 
-<!-- MENA calendars: AE, AED, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
+<!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, KW, KWD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
@@ -143,7 +145,7 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 
 ```java
 List<String> codes = factory.listAvailableCodes();
-// ["AE", "AED", "AU", "AUD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+// ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JP", "JPY", "KW", "KWD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
 ```
 
 ### Define a custom holiday calendar

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0-SNAPSHOT</version>
+        <version>1.4.0</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.3.1</version>
+        <version>1.4.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 29 implemented holiday calendars
+ * 30-year integration test suite validating all 31 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -73,6 +73,8 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"ILS"},
                 new Object[]{"JP"},
                 new Object[]{"JPY"},
+                new Object[]{"KW"},
+                new Object[]{"KWD"},
                 new Object[]{"QA"},
                 new Object[]{"QAR"},
                 new Object[]{"SA"},

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -29,7 +29,7 @@ import java.util.Map;
 import static org.testng.Assert.*;
 
 /**
- * 30-year integration test suite validating all 27 implemented holiday calendars
+ * 30-year integration test suite validating all 29 implemented holiday calendars
  * over the 2026–2055 target range (issue #117).
  *
  * <p>For every calendar code the suite verifies:
@@ -73,6 +73,8 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"ILS"},
                 new Object[]{"JP"},
                 new Object[]{"JPY"},
+                new Object[]{"QA"},
+                new Object[]{"QAR"},
                 new Object[]{"SA"},
                 new Object[]{"SAR"},
                 new Object[]{"SG"},


### PR DESCRIPTION
## Release v1.4.0 — MENA Financial Market Calendars (Continued)

This PR releases v1.4.0, which expands the `holiday-calendar-mena` module with six additional MENA financial market holiday calendars.

### What's included

**New calendars (12 calendar codes):**
- 🇶🇦 QA (Qatar National) + QAR (QSE/Qatar Central Bank) (#162)
- 🇰🇼 KW (Kuwait National) + KWD (Boursa Kuwait/CBK) (#163)
- 🇪🇬 EG (Egypt National) + EGP (EGX/Central Bank of Egypt) (#164)
- 🇧🇭 BH (Bahrain National) + BHD (Boursa Bahrain/CBB) (#165)
- 🇲🇦 MA (Morocco National) + MAD (Casablanca SE/Bank Al-Maghrib) (#166)
- 🇯🇴 JO (Jordan National) + JOD (ASE/Central Bank of Jordan) (#167)

**Changed:**
- Upgraded GitHub Actions to Node.js 24-compatible versions (#185)

### Changelog

See [CHANGELOG.md](CHANGELOG.md) for the full entry.

### Milestone

Closes [GA Release 1.4.0](https://github.com/holiday-calendar/holiday-calendar-java/milestone/8)