### PR TITLE
chore: regenerate README.md for 1.5.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,28 +85,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 ```
 


### PR DESCRIPTION
## Summary
- The `Build and analyze` job on `develop` was failing its README.md drift check ([run 26318889193](https://github.com/holiday-calendar/holiday-calendar-java/actions/runs/26318889193))
- Commit `63aa13a` bumped all module versions to `1.5.0-SNAPSHOT` but didn't regenerate `README.md` (templated from `src/readme/README.md` via `mvn validate -N`)
- This regenerates `README.md`, updating the four dependency version examples from `1.4.0` to `1.5.0-SNAPSHOT`

## Test plan
- [x] Ran `mvn validate -N` locally and confirmed the diff matches CI's reported diff exactly
- [ ] Confirm `Build and analyze` job passes on this PR / after merge to `develop`