### PR TITLE
#180 Replace Umm al-Qura projections with Diyanet ilmi takvim data/calculator for TR

### DIFF
--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -41,10 +41,11 @@ import java.util.OptionalInt;
  * ilmi takvim (scientific calendar) via {@code eid-al-fitr-tr.csv} and
  * {@code eid-al-adha-tr.csv}. Dates for 2024–2035 are official Diyanet-published
  * dates (confirmed against BIST announcements for 2024–2026); 2036–2055 are
- * projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's own
- * publication of those years. Diyanet uses ilmi takvim, which is confirmed to
- * differ from the Umm al-Qura calendar by ±1–2 days in some years — verify
- * projected 2036–2055 dates against official announcements as each year is
+ * computed via an ilmi takvim calculator (true lunar conjunction + Ankara sunset
+ * visibility rule) pending Diyanet's own publication of those years. Diyanet's
+ * method is confirmed to differ from the Umm al-Qura calendar used by other MENA
+ * countries by ±1–2 days in some years — verify projected 2036–2055 dates
+ * against official announcements as each year is
  * published. Corrections require a new JAR release.
  *
  * <p><strong>Half-day closure not modelled:</strong>

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -39,11 +39,13 @@ import java.util.OptionalInt;
  * <p>Islamic holidays (Ramazan Bayramı / Eid al-Fitr × 3 days; Kurban Bayramı /
  * Eid al-Adha × 4 days) are sourced from Diyanet (Presidency of Religious Affairs)
  * ilmi takvim (scientific calendar) via {@code eid-al-fitr-tr.csv} and
- * {@code eid-al-adha-tr.csv}. Dates for 2024–2026 are official Diyanet / BIST
- * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
- * calendar. Diyanet uses ilmi takvim, which may differ from the Umm al-Qura
- * calendar by ±1 day — verify projected dates against official announcements as
- * each year is published. Corrections require a new JAR release.
+ * {@code eid-al-adha-tr.csv}. Dates for 2024–2035 are official Diyanet-published
+ * dates (confirmed against BIST announcements for 2024–2026); 2036–2055 are
+ * projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's own
+ * publication of those years. Diyanet uses ilmi takvim, which is confirmed to
+ * differ from the Umm al-Qura calendar by ±1–2 days in some years — verify
+ * projected 2036–2055 dates against official announcements as each year is
+ * published. Corrections require a new JAR release.
  *
  * <p><strong>Half-day closure not modelled:</strong>
  * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -38,11 +38,15 @@ import java.util.List;
  *
  * <p>All seven Islamic holidays are populated through {@value DATA_VALID_THROUGH}
  * via Diyanet-sourced CSV lookup tables (country code {@code tr}).
- * Dates for 2024–2026 are official Diyanet (Presidency of Religious Affairs) /
- * BIST market calendar announcements; dates for 2027–2055 are projected from
- * the Umm al-Qura tabular Islamic calendar. Diyanet uses ilmi takvim (scientific
- * method), which may differ from the Umm al-Qura calendar by ±1 day — verify
- * projected dates against Diyanet announcements as each year is published.
+ * Dates for 2024–2035 are official Diyanet (Presidency of Religious Affairs)
+ * published dates (Diyanet publishes several years ahead of the current year,
+ * not just 1–2 years as originally assumed — see GitHub issue #180), confirmed
+ * against BIST market calendar announcements for 2024–2026; dates for 2036–2055
+ * are projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's
+ * own publication of those years. Diyanet uses ilmi takvim (scientific method),
+ * which is confirmed to differ from the Umm al-Qura calendar by ±1–2 days in some
+ * years (e.g. 2026 Eid al-Adha: Diyanet 27 May vs. UAE/Umm al-Qura 26 May) — verify
+ * projected 2036–2055 dates against Diyanet announcements as each year is published.
  * Corrections require a new JAR release; no runtime update mechanism exists.
  *
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -42,11 +42,14 @@ import java.util.List;
  * published dates (Diyanet publishes several years ahead of the current year,
  * not just 1–2 years as originally assumed — see GitHub issue #180), confirmed
  * against BIST market calendar announcements for 2024–2026; dates for 2036–2055
- * are projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's
- * own publication of those years. Diyanet uses ilmi takvim (scientific method),
- * which is confirmed to differ from the Umm al-Qura calendar by ±1–2 days in some
- * years (e.g. 2026 Eid al-Adha: Diyanet 27 May vs. UAE/Umm al-Qura 26 May) — verify
- * projected 2036–2055 dates against Diyanet announcements as each year is published.
+ * are computed via {@code IlmiTakvimCalculator} (true lunar conjunction + Ankara
+ * sunset visibility rule, calibrated against and exactly reproducing all 24
+ * Diyanet-published dates 2024–2035) pending Diyanet's own publication of those
+ * years. Diyanet's ilmi takvim (scientific method) is confirmed to differ from
+ * the Umm al-Qura calendar used by other MENA countries in this package by
+ * ±1–2 days in some years (e.g. 2026 Eid al-Adha: Diyanet 27 May vs.
+ * UAE/Umm al-Qura 26 May) — verify projected 2036–2055 dates against Diyanet
+ * announcements as each year is published.
  * Corrections require a new JAR release; no runtime update mechanism exists.
  *
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.islamic.mena;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator;
 import org.holiday.calendar.util.CsvObservanceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,20 +53,44 @@ public class EidAlAdha extends AbstractObservance {
     static final int DATA_VALID_FROM = 2024;
     static final int DATA_VALID_THROUGH = 2055;
 
+    /**
+     * Country code for which a live {@link IlmiTakvimCalculator} fallback applies
+     * when the CSV table is missing a row for an in-range year (e.g. a future
+     * {@code DATA_VALID_THROUGH} extension made before the CSV is regenerated).
+     * All CSV rows for {@code tr} are currently populated through
+     * {@value #DATA_VALID_THROUGH}, so this fallback is a defensive safety net,
+     * not part of the normal lookup path.
+     */
+    private static final String ILMI_TAKVIM_COUNTRY_CODE = "tr";
+
     private static final Logger log = LoggerFactory.getLogger(EidAlAdha.class);
     private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
             new ConcurrentHashMap<>();
 
+    private final String countryCode;
     private final Map<Integer, LocalDate> dates;
 
     public EidAlAdha(String countryCode) {
-        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+        this.countryCode = countryCode.toLowerCase();
+        this.dates = CACHE.computeIfAbsent(this.countryCode,
                 cc -> CsvObservanceLoader.loadSingle(EidAlAdha.class, "eid-al-adha-" + cc + ".csv"));
     }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return dates.get(year);
+        LocalDate csvDate = dates.get(year);
+        if (csvDate != null) {
+            return csvDate;
+        }
+        if (ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode)) {
+            try {
+                return IlmiTakvimCalculator.eidAlAdha(year);
+            } catch (RuntimeException e) {
+                log.warn("Ilmi takvim calculation failed for Eid al-Adha {}; no fallback data available", year, e);
+                return null;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -74,7 +99,8 @@ public class EidAlAdha extends AbstractObservance {
             log.warn("Year {} exceeds data ceiling {}; Eid al-Adha date unavailable", year, DATA_VALID_THROUGH);
             return false;
         }
-        return dates.containsKey(year);
+        return year >= DATA_VALID_FROM
+                && (dates.containsKey(year) || ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode));
     }
 
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
@@ -36,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * Dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar;
  * verify against official announcements as each year is published.</p>
  *
+ * <p>For Turkey ({@code tr}), 2024–2035 are official Diyanet (Presidency of
+ * Religious Affairs) published dates rather than Umm al-Qura projections — Diyanet
+ * publishes several years ahead of the current year. See {@code eid-al-adha-tr.csv}
+ * for the confirmed 2026 divergence between Diyanet's ilmi takvim and Umm al-Qura.</p>
+ *
  * <p>Date data is loaded at runtime from {@code eid-al-adha-{countryCode}.csv}
  * in this package, where {@code countryCode} is the ISO 3166-1 alpha-2 country
  * code in lower case (e.g. {@code ae}, {@code sa}).</p>

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.islamic.mena;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator;
 import org.holiday.calendar.util.CsvObservanceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,20 +57,44 @@ public class EidAlFitr extends AbstractObservance {
     static final int DATA_VALID_FROM = 2024;
     static final int DATA_VALID_THROUGH = 2055;
 
+    /**
+     * Country code for which a live {@link IlmiTakvimCalculator} fallback applies
+     * when the CSV table is missing a row for an in-range year (e.g. a future
+     * {@code DATA_VALID_THROUGH} extension made before the CSV is regenerated).
+     * All CSV rows for {@code tr} are currently populated through
+     * {@value #DATA_VALID_THROUGH}, so this fallback is a defensive safety net,
+     * not part of the normal lookup path.
+     */
+    private static final String ILMI_TAKVIM_COUNTRY_CODE = "tr";
+
     private static final Logger log = LoggerFactory.getLogger(EidAlFitr.class);
     private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
             new ConcurrentHashMap<>();
 
+    private final String countryCode;
     private final Map<Integer, LocalDate> dates;
 
     public EidAlFitr(String countryCode) {
-        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+        this.countryCode = countryCode.toLowerCase();
+        this.dates = CACHE.computeIfAbsent(this.countryCode,
                 cc -> CsvObservanceLoader.loadSingle(EidAlFitr.class, "eid-al-fitr-" + cc + ".csv"));
     }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return dates.get(year);
+        LocalDate csvDate = dates.get(year);
+        if (csvDate != null) {
+            return csvDate;
+        }
+        if (ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode)) {
+            try {
+                return IlmiTakvimCalculator.eidAlFitr(year);
+            } catch (RuntimeException e) {
+                log.warn("Ilmi takvim calculation failed for Eid al-Fitr {}; no fallback data available", year, e);
+                return null;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -78,7 +103,8 @@ public class EidAlFitr extends AbstractObservance {
             log.warn("Year {} exceeds data ceiling {}; Eid al-Fitr date unavailable", year, DATA_VALID_THROUGH);
             return false;
         }
-        return dates.containsKey(year);
+        return year >= DATA_VALID_FROM
+                && (dates.containsKey(year) || ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode));
     }
 
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
@@ -36,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * Dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar;
  * verify against official announcements as each year is published.</p>
  *
+ * <p>For Turkey ({@code tr}), 2024–2035 are official Diyanet (Presidency of
+ * Religious Affairs) published dates rather than Umm al-Qura projections — Diyanet
+ * publishes several years ahead of the current year. See {@code eid-al-fitr-tr.csv}
+ * for details.</p>
+ *
  * <p>Note: Gregorian year 2033 contains two Eid al-Fitr occurrences (~January 4 and
  * ~December 24). Only the first (January) occurrence is recorded; the December
  * occurrence cannot be represented under the single-date-per-year-key design.</p>

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
@@ -25,6 +25,7 @@ import net.time4j.calendar.astro.SolarTime;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.ZoneId;
 
 /**
@@ -78,13 +79,13 @@ public final class IlmiTakvimCalculator {
      * Verified anchor: 1 Shawwal 1456 AH, per Diyanet's own published "Dini
      * Günler" table (confirmed 2035-12-01).
      */
-    private static final LocalDate FITR_MONTH_START_ANCHOR = LocalDate.of(2035, 12, 1);
+    private static final LocalDate FITR_MONTH_START_ANCHOR = LocalDate.of(2035, Month.DECEMBER, 1);
 
     /**
      * Verified anchor: 1 Dhu al-Hijjah 1456 AH, derived from Diyanet's published
      * Eid al-Adha 2035 date (2035-02-18) minus {@value ADHA_DAY_OFFSET} days.
      */
-    private static final LocalDate ADHA_MONTH_START_ANCHOR = LocalDate.of(2035, 2, 9);
+    private static final LocalDate ADHA_MONTH_START_ANCHOR = LocalDate.of(2035, Month.FEBRUARY, 9);
 
     private IlmiTakvimCalculator() {}
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena.ilmitakvim;
+
+import net.time4j.Moment;
+import net.time4j.PlainDate;
+import net.time4j.calendar.astro.MoonPhase;
+import net.time4j.calendar.astro.SolarTime;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+/**
+ * Computes Turkish Diyanet ilmi takvim (scientific calendar) dates for Eid al-Fitr
+ * (1 Shawwal AH) and Eid al-Adha (10 Dhu al-Hijjah AH), for years beyond Diyanet's
+ * own published range.
+ *
+ * <p><strong>Methodology</strong>: a Hijri month begins the day after the true
+ * (perturbed, not mean-motion) astronomical lunar conjunction, computed via
+ * {@link MoonPhase#NEW_MOON} (Meeus Ch. 49) — unless the conjunction occurs after
+ * local sunset at Ankara (39.93°N, 32.85°E, via {@link SolarTime}), in which case
+ * the month begins two days after the conjunction's civil date
+ * ({@code Europe/Istanbul}, fixed UTC+3 since Turkey's 2016 DST abolition). Each
+ * Hijri year always advances by exactly 12 lunations (no intercalation), so a
+ * target year's relevant month start is located by walking forward one Hijri
+ * year at a time from a verified anchor date and re-snapping to the true
+ * conjunction at each step, rather than by independently computing each year.</p>
+ *
+ * <p>This rule was calibrated against, and exactly reproduces, all 24 Diyanet
+ * officially-published dates (Eid al-Fitr and Eid al-Adha, 2024–2035) fetched
+ * directly from {@code vakithesaplama.diyanet.gov.tr} — see
+ * {@code IlmiTakvimCalculatorTest} for the full verification dataset. It is used
+ * here only for years beyond Diyanet's own published range (2036 onward, as of
+ * this writing); for years Diyanet has already published, the CSV lookup tables
+ * in {@code eid-al-fitr-tr.csv}/{@code eid-al-adha-tr.csv} are the source of
+ * truth and take precedence.</p>
+ *
+ * <p><strong>Caveat</strong>: this remains a best-effort approximation, not a
+ * guarantee of Diyanet's future published dates — Diyanet's actual process may
+ * involve committee judgment beyond a pure astronomical rule. Projected dates
+ * should be verified against Diyanet's own publications as they become
+ * available (Diyanet has historically published several years ahead of the
+ * current year).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public final class IlmiTakvimCalculator {
+
+    static final double ANKARA_LATITUDE_DEG = 39.93;
+    static final double ANKARA_LONGITUDE_DEG = 32.85;
+
+    private static final ZoneId ANKARA_ZONE = ZoneId.of("Europe/Istanbul");
+    private static final SolarTime ANKARA_SOLAR_TIME = SolarTime.ofLocation(ANKARA_LATITUDE_DEG, ANKARA_LONGITUDE_DEG);
+    private static final double MEAN_SYNODIC_MONTH_DAYS = 29.530588861;
+    private static final int LUNATIONS_PER_HIJRI_YEAR = 12;
+
+    /** Days after 1 Dhu al-Hijjah that Eid al-Adha (10 Dhu al-Hijjah) falls on. */
+    private static final int ADHA_DAY_OFFSET = 9;
+
+    /**
+     * Verified anchor: 1 Shawwal 1456 AH, per Diyanet's own published "Dini
+     * Günler" table (confirmed 2035-12-01).
+     */
+    private static final LocalDate FITR_MONTH_START_ANCHOR = LocalDate.of(2035, 12, 1);
+
+    /**
+     * Verified anchor: 1 Dhu al-Hijjah 1456 AH, derived from Diyanet's published
+     * Eid al-Adha 2035 date (2035-02-18) minus {@value ADHA_DAY_OFFSET} days.
+     */
+    private static final LocalDate ADHA_MONTH_START_ANCHOR = LocalDate.of(2035, 2, 9);
+
+    private IlmiTakvimCalculator() {}
+
+    /**
+     * @param gregorianYear the Gregorian year in which Eid al-Fitr's first day falls
+     * @return the computed Gregorian date of 1 Shawwal AH (Eid al-Fitr, 1st day)
+     */
+    public static LocalDate eidAlFitr(int gregorianYear) {
+        return monthStartForYear(FITR_MONTH_START_ANCHOR, gregorianYear, 0);
+    }
+
+    /**
+     * @param gregorianYear the Gregorian year in which Eid al-Adha's first day falls
+     * @return the computed Gregorian date of 10 Dhu al-Hijjah AH (Eid al-Adha, 1st day)
+     */
+    public static LocalDate eidAlAdha(int gregorianYear) {
+        return monthStartForYear(ADHA_MONTH_START_ANCHOR, gregorianYear, ADHA_DAY_OFFSET)
+                .plusDays(ADHA_DAY_OFFSET);
+    }
+
+    /**
+     * Walks one Hijri year (12 lunations) at a time from the anchor month start,
+     * re-snapping to the true conjunction at each step, until the bucketed
+     * occurrence (month start + {@code dayOffsetForBucketing}) falls in
+     * {@code targetGregorianYear}. Walks forward for years after the anchor's own
+     * year, backward for years before it. When a Gregorian year contains two
+     * occurrences of the same Hijri anniversary, the earlier (chronologically
+     * first) one is returned regardless of walk direction, matching the
+     * convention already documented on {@code EidAlFitr}/{@code EidAlAdha} for
+     * CSV-sourced years.
+     */
+    private static LocalDate monthStartForYear(LocalDate anchorMonthStart, int targetGregorianYear, int dayOffsetForBucketing) {
+        int anchorBucketYear = anchorMonthStart.plusDays(dayOffsetForBucketing).getYear();
+        long approxLunarYearDays = Math.round(MEAN_SYNODIC_MONTH_DAYS * LUNATIONS_PER_HIJRI_YEAR);
+        boolean forward = targetGregorianYear >= anchorBucketYear;
+
+        LocalDate monthStart = anchorMonthStart;
+        LocalDate earliestMatch = null;
+        while (true) {
+            int bucketYear = monthStart.plusDays(dayOffsetForBucketing).getYear();
+            if (bucketYear == targetGregorianYear) {
+                if (earliestMatch == null || monthStart.isBefore(earliestMatch)) {
+                    earliestMatch = monthStart;
+                }
+            } else if (earliestMatch != null) {
+                // Walked past the target year's occurrence(s); the earliest one recorded wins.
+                return earliestMatch;
+            } else if ((forward && bucketYear > targetGregorianYear) || (!forward && bucketYear < targetGregorianYear)) {
+                throw new IllegalArgumentException(
+                        "No ilmi takvim occurrence found for year " + targetGregorianYear
+                                + " (anchor " + anchorMonthStart + " does not reach it)");
+            }
+            LocalDate approxNext = forward
+                    ? monthStart.plusDays(approxLunarYearDays)
+                    : monthStart.minusDays(approxLunarYearDays);
+            monthStart = nextConjunctionMonthStart(approxNext);
+        }
+    }
+
+    /**
+     * Finds the true conjunction nearest (on or after 3 days before)
+     * {@code approxTarget}, then applies the Ankara-sunset visibility rule to
+     * determine the resulting Hijri month's start date.
+     */
+    private static LocalDate nextConjunctionMonthStart(LocalDate approxTarget) {
+        Instant seed = approxTarget.minusDays(3).atStartOfDay(ANKARA_ZONE).toInstant();
+        Moment conjunction = MoonPhase.NEW_MOON.after(Moment.from(seed));
+        LocalDate conjunctionCivilDate = toAnkaraCivilDate(conjunction);
+        Moment sunset = sunsetAt(conjunctionCivilDate);
+        return conjunction.isBefore(sunset) ? conjunctionCivilDate.plusDays(1) : conjunctionCivilDate.plusDays(2);
+    }
+
+    private static LocalDate toAnkaraCivilDate(Moment moment) {
+        long epochMillis = moment.getPosixTime() * 1000L + moment.getNanosecond() / 1_000_000L;
+        return Instant.ofEpochMilli(epochMillis).atZone(ANKARA_ZONE).toLocalDate();
+    }
+
+    private static Moment sunsetAt(LocalDate date) {
+        PlainDate plainDate = PlainDate.of(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        return plainDate.get(ANKARA_SOLAR_TIME.sunset())
+                .orElseThrow(() -> new IllegalStateException("No sunset computed for Ankara on " + date));
+    }
+
+}

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
@@ -8,13 +8,14 @@
 #              of the current year, not just 1–2 years as previously assumed (see
 #              GitHub issue #180 for background). Confirmed against BIST market
 #              calendar publications for 2024–2026.
-#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
-#              Küçük 30-year cycle), used as a best-available approximation because Diyanet
-#              has not yet published religious-day tables this far ahead. Actual Diyanet
-#              dates may differ by ±1–2 days from these Umm al-Qura values — the confirmed
-#              2026 divergence below (both tiers "official") illustrates the magnitude of
-#              this risk. Replace with real Diyanet-published dates or an ilmi takvim
-#              calculation as they become available (see GitHub issue #180).
+#   2036–2055: Computed via IlmiTakvimCalculator (true lunar conjunction + Ankara
+#              sunset visibility rule, calibrated against and exactly reproducing
+#              all 24 Diyanet-published dates 2024–2035 — see
+#              IlmiTakvimCalculatorTest), used as a best-available projection
+#              because Diyanet has not yet published religious-day tables this far
+#              ahead. This remains a best-effort approximation, not a guarantee of
+#              Diyanet's actual future announcements — Diyanet's real process may
+#              involve committee judgment beyond a pure astronomical rule.
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
@@ -42,26 +43,28 @@
 2033,2033-03-11,Diyanet official
 2034,2034-03-01,Diyanet official
 2035,2035-02-18,Diyanet official
-# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
-2036,2036-02-06,Umm al-Qura projection
-2037,2037-01-25,Umm al-Qura projection
-2038,2038-01-15,Umm al-Qura projection
-# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
-2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
-# 2040: falls in December because January slot was consumed by 2039 double-occurrence
-2040,2040-12-13,Umm al-Qura projection
-2041,2041-12-02,Umm al-Qura projection
-2042,2042-11-21,Umm al-Qura projection
-2043,2043-11-11,Umm al-Qura projection
-2044,2044-10-30,Umm al-Qura projection
-2045,2045-10-20,Umm al-Qura projection
-2046,2046-10-09,Umm al-Qura projection
-2047,2047-09-28,Umm al-Qura projection
-2048,2048-09-17,Umm al-Qura projection
-2049,2049-09-06,Umm al-Qura projection
-2050,2050-08-26,Umm al-Qura projection
-2051,2051-08-16,Umm al-Qura projection
-2052,2052-08-04,Umm al-Qura projection
-2053,2053-07-24,Umm al-Qura projection
-2054,2054-07-14,Umm al-Qura projection
-2055,2055-07-03,Umm al-Qura projection
+# 2036–2055: ilmi takvim calculation; verify against Diyanet announcements as published
+2036,2036-02-07,ilmi takvim calculation
+2037,2037-01-26,ilmi takvim calculation
+2038,2038-01-15,ilmi takvim calculation
+# 2039: two 10 Dhu al-Hijjah occurrences in one Gregorian year (per the underlying
+# astronomical model); only the earlier (January) occurrence is recorded, consistent
+# with the 2033/2034 Eid al-Fitr convention documented in eid-al-fitr-tr.csv
+2039,2039-01-05,ilmi takvim calculation (January occurrence only; December occurrence omitted)
+# 2040: falls in December because the January slot was consumed by 2039's double-occurrence
+2040,2040-12-14,ilmi takvim calculation
+2041,2041-12-04,ilmi takvim calculation
+2042,2042-11-23,ilmi takvim calculation
+2043,2043-11-12,ilmi takvim calculation
+2044,2044-10-31,ilmi takvim calculation
+2045,2045-10-20,ilmi takvim calculation
+2046,2046-10-10,ilmi takvim calculation
+2047,2047-09-30,ilmi takvim calculation
+2048,2048-09-18,ilmi takvim calculation
+2049,2049-09-07,ilmi takvim calculation
+2050,2050-08-27,ilmi takvim calculation
+2051,2051-08-16,ilmi takvim calculation
+2052,2052-08-05,ilmi takvim calculation
+2053,2053-07-26,ilmi takvim calculation
+2054,2054-07-15,ilmi takvim calculation
+2055,2055-07-05,ilmi takvim calculation

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
@@ -2,20 +2,28 @@
 # The Feast of Sacrifice.
 #
 # SOURCE TIERS:
-#   2024–2026: Diyanet (Presidency of Religious Affairs) official announcements,
-#              confirmed against BIST market calendar publications.
-#   2027–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
+#   2024–2035: Diyanet (Presidency of Religious Affairs) official published dates,
+#              sourced directly from vakithesaplama.diyanet.gov.tr's "Dini Günler"
+#              (religious days) tables — Diyanet publishes these several years ahead
+#              of the current year, not just 1–2 years as previously assumed (see
+#              GitHub issue #180 for background). Confirmed against BIST market
+#              calendar publications for 2024–2026.
+#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
 #              Küçük 30-year cycle), used as a best-available approximation because Diyanet
-#              does not publish ilmi takvim (scientific calendar) projections beyond 1–2 years
-#              in advance. Actual Diyanet dates may differ by ±1 day from these Umm al-Qura
-#              values — the 2025 divergence below is the canonical confirmed example.
-#              Replace with ilmi takvim calculations when available (see GitHub issue #180).
+#              has not yet published religious-day tables this far ahead. Actual Diyanet
+#              dates may differ by ±1–2 days from these Umm al-Qura values — the confirmed
+#              2026 divergence below (both tiers "official") illustrates the magnitude of
+#              this risk. Replace with real Diyanet-published dates or an ilmi takvim
+#              calculation as they become available (see GitHub issue #180).
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
-# KNOWN DIVERGENCE — 2025: Diyanet declared 10 Dhu al-Hijjah 1446 as 5 June 2025,
-# one day earlier than the Saudi/UAE Umm al-Qura date of 6 June 2025. This is the
-# canonical confirmed example of ilmi takvim vs. Umm al-Qura divergence.
+# KNOWN DIVERGENCE — 2026: Diyanet declared 10 Dhu al-Hijjah 1447 as 27 May 2026,
+# one day later than the UAE SCA-confirmed date of 26 May 2026 (see eid-al-adha-ae.csv).
+# Both tiers are officially confirmed (not projections) — this is the canonical example
+# of ilmi takvim vs. Umm al-Qura / moon-sighting divergence. (A previously-recorded 2025
+# divergence in this file was found to be a data error — 2025-06-05 is Arefe, the eve of
+# Bayram, not the 1st day; Diyanet's own published 1st day is 2025-06-06, matching AE.)
 #
 # NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
 # (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
@@ -23,19 +31,18 @@
 #
 # Format: year,YYYY-MM-DD,source
 2024,2024-06-16,Diyanet official
-# 2025: Diyanet = June 5 (1446 AH); differs from Saudi/UAE Umm al-Qura date of June 6
-2025,2025-06-05,Diyanet official
-2026,2026-05-26,Diyanet official
-# 2027–2055: Umm al-Qura tabular projection; verify against Diyanet announcements (±1 day risk)
-2027,2027-05-15,Umm al-Qura projection
-2028,2028-05-04,Umm al-Qura projection
-2029,2029-04-23,Umm al-Qura projection
-2030,2030-04-12,Umm al-Qura projection
-2031,2031-04-01,Umm al-Qura projection
-2032,2032-03-20,Umm al-Qura projection
-2033,2033-03-10,Umm al-Qura projection
-2034,2034-02-27,Umm al-Qura projection
-2035,2035-02-16,Umm al-Qura projection
+2025,2025-06-06,Diyanet official
+2026,2026-05-27,Diyanet official
+2027,2027-05-16,Diyanet official
+2028,2028-05-05,Diyanet official
+2029,2029-04-24,Diyanet official
+2030,2030-04-13,Diyanet official
+2031,2031-04-02,Diyanet official
+2032,2032-03-22,Diyanet official
+2033,2033-03-11,Diyanet official
+2034,2034-03-01,Diyanet official
+2035,2035-02-18,Diyanet official
+# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
 2036,2036-02-06,Umm al-Qura projection
 2037,2037-01-25,Umm al-Qura projection
 2038,2038-01-15,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
@@ -2,36 +2,42 @@
 # Marks the end of Ramadan.
 #
 # SOURCE TIERS:
-#   2024–2026: Diyanet (Presidency of Religious Affairs) official announcements,
-#              confirmed against BIST market calendar publications.
-#   2027–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
-#              used as a best-available approximation because Diyanet does not publish
-#              ilmi takvim (scientific calendar) projections beyond 1–2 years in advance.
-#              Actual Diyanet dates may differ by ±1 day from these Umm al-Qura values.
-#              Replace with ilmi takvim calculations when available (see GitHub issue #180).
+#   2024–2035: Diyanet (Presidency of Religious Affairs) official published dates,
+#              sourced directly from vakithesaplama.diyanet.gov.tr's "Dini Günler"
+#              (religious days) tables — Diyanet publishes these several years ahead
+#              of the current year, not just 1–2 years as previously assumed (see
+#              GitHub issue #180 for background). Confirmed against BIST market
+#              calendar publications for 2024–2026.
+#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
+#              used as a best-available approximation because Diyanet has not yet
+#              published religious-day tables this far ahead. Actual Diyanet dates may
+#              differ from these Umm al-Qura values (see eid-al-adha-tr.csv's 2026
+#              divergence note for a confirmed example of the magnitude of this risk).
+#              Replace with real Diyanet-published dates or an ilmi takvim calculation
+#              as they become available (see GitHub issue #180).
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
-# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
-# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
-# here. The December occurrence cannot be represented under the single-date-per-
-# year-key design.
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences, per Diyanet's
+# own published table: 2 January 2033 and 23 December 2033. Only the first (January)
+# occurrence is recorded here. The December occurrence cannot be represented under the
+# single-date-per-year-key design.
 #
 # Format: year,YYYY-MM-DD,source
 2024,2024-04-10,Diyanet official
 2025,2025-03-30,Diyanet official
-2026,2026-03-19,Diyanet official
-# 2027–2055: Umm al-Qura tabular projection; verify against Diyanet announcements (±1 day risk)
-2027,2027-03-09,Umm al-Qura projection
-2028,2028-02-26,Umm al-Qura projection
-2029,2029-02-15,Umm al-Qura projection
-2030,2030-02-04,Umm al-Qura projection
-2031,2031-01-24,Umm al-Qura projection
-2032,2032-01-14,Umm al-Qura projection
-# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
-2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
-2034,2034-12-12,Umm al-Qura projection
-2035,2035-12-01,Umm al-Qura projection
+2026,2026-03-20,Diyanet official
+2027,2027-03-09,Diyanet official
+2028,2028-02-26,Diyanet official
+2029,2029-02-14,Diyanet official
+2030,2030-02-04,Diyanet official
+2031,2031-01-24,Diyanet official
+2032,2032-01-14,Diyanet official
+# 2033: two Eid al-Fitr occurrences (2 January and 23 December); only January recorded
+2033,2033-01-02,Diyanet official (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Diyanet official
+2035,2035-12-01,Diyanet official
+# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
 2036,2036-11-19,Umm al-Qura projection
 2037,2037-11-09,Umm al-Qura projection
 2038,2038-10-29,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
@@ -8,13 +8,14 @@
 #              of the current year, not just 1–2 years as previously assumed (see
 #              GitHub issue #180 for background). Confirmed against BIST market
 #              calendar publications for 2024–2026.
-#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
-#              used as a best-available approximation because Diyanet has not yet
-#              published religious-day tables this far ahead. Actual Diyanet dates may
-#              differ from these Umm al-Qura values (see eid-al-adha-tr.csv's 2026
-#              divergence note for a confirmed example of the magnitude of this risk).
-#              Replace with real Diyanet-published dates or an ilmi takvim calculation
-#              as they become available (see GitHub issue #180).
+#   2036–2055: Computed via IlmiTakvimCalculator (true lunar conjunction + Ankara
+#              sunset visibility rule, calibrated against and exactly reproducing
+#              all 24 Diyanet-published dates 2024–2035 — see
+#              IlmiTakvimCalculatorTest), used as a best-available projection
+#              because Diyanet has not yet published religious-day tables this far
+#              ahead. This remains a best-effort approximation, not a guarantee of
+#              Diyanet's actual future announcements — Diyanet's real process may
+#              involve committee judgment beyond a pure astronomical rule.
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
@@ -37,24 +38,24 @@
 2033,2033-01-02,Diyanet official (January occurrence only; December occurrence omitted)
 2034,2034-12-12,Diyanet official
 2035,2035-12-01,Diyanet official
-# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
-2036,2036-11-19,Umm al-Qura projection
-2037,2037-11-09,Umm al-Qura projection
-2038,2038-10-29,Umm al-Qura projection
-2039,2039-10-19,Umm al-Qura projection
-2040,2040-10-08,Umm al-Qura projection
-2041,2041-09-27,Umm al-Qura projection
-2042,2042-09-16,Umm al-Qura projection
-2043,2043-09-05,Umm al-Qura projection
-2044,2044-08-24,Umm al-Qura projection
-2045,2045-08-14,Umm al-Qura projection
-2046,2046-08-04,Umm al-Qura projection
-2047,2047-07-24,Umm al-Qura projection
-2048,2048-07-13,Umm al-Qura projection
-2049,2049-07-02,Umm al-Qura projection
-2050,2050-06-21,Umm al-Qura projection
-2051,2051-06-10,Umm al-Qura projection
-2052,2052-05-30,Umm al-Qura projection
-2053,2053-05-19,Umm al-Qura projection
-2054,2054-05-09,Umm al-Qura projection
-2055,2055-04-28,Umm al-Qura projection
+# 2036–2055: ilmi takvim calculation; verify against Diyanet announcements as published
+2036,2036-11-19,ilmi takvim calculation
+2037,2037-11-08,ilmi takvim calculation
+2038,2038-10-29,ilmi takvim calculation
+2039,2039-10-19,ilmi takvim calculation
+2040,2040-10-07,ilmi takvim calculation
+2041,2041-09-26,ilmi takvim calculation
+2042,2042-09-15,ilmi takvim calculation
+2043,2043-09-04,ilmi takvim calculation
+2044,2044-08-24,ilmi takvim calculation
+2045,2045-08-14,ilmi takvim calculation
+2046,2046-08-03,ilmi takvim calculation
+2047,2047-07-24,ilmi takvim calculation
+2048,2048-07-12,ilmi takvim calculation
+2049,2049-07-01,ilmi takvim calculation
+2050,2050-06-20,ilmi takvim calculation
+2051,2051-06-10,ilmi takvim calculation
+2052,2052-05-29,ilmi takvim calculation
+2053,2053-05-19,ilmi takvim calculation
+2054,2054-05-09,ilmi takvim calculation
+2055,2055-04-28,ilmi takvim calculation

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -314,20 +314,20 @@ public class HolidayCalendarServiceTRTest {
     @Test
     public void testEidAlFitr2026() {
         assertEquals(findFirst("Eid al-Fitr", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MARCH, 19),
-                "Eid al-Fitr 2026 must be 2026-03-19 per Diyanet");
+                LocalDate.of(2026, Month.MARCH, 20),
+                "Eid al-Fitr 2026 must be 2026-03-20 per Diyanet");
     }
 
     @Test
     public void testEidAlFitrDay2_2026() {
         assertEquals(findFirst("Eid al-Fitr (2nd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MARCH, 20));
+                LocalDate.of(2026, Month.MARCH, 21));
     }
 
     @Test
     public void testEidAlFitrDay3_2026() {
         assertEquals(findFirst("Eid al-Fitr (3rd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MARCH, 21));
+                LocalDate.of(2026, Month.MARCH, 22));
     }
 
     // =========================================================================
@@ -361,53 +361,54 @@ public class HolidayCalendarServiceTRTest {
 
     @Test
     public void testEidAlAdha2025() {
-        // Turkey Diyanet = June 5; one day earlier than Saudi/UAE (June 6)
+        // Diyanet's 1st day of Bayram is June 6, matching Saudi/UAE; June 5 is Arefe (the eve)
         assertEquals(findFirst("Eid al-Adha", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 5),
-                "Eid al-Adha 2025 must be 2025-06-05 per Diyanet (one day earlier than Saudi/UAE)");
+                LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per Diyanet");
     }
 
     @Test
     public void testEidAlAdhaDay2_2025() {
         assertEquals(findFirst("Eid al-Adha (2nd Day)", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 6));
+                LocalDate.of(2025, Month.JUNE, 7));
     }
 
     @Test
     public void testEidAlAdhaDay3_2025() {
         assertEquals(findFirst("Eid al-Adha (3rd Day)", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 7));
+                LocalDate.of(2025, Month.JUNE, 8));
     }
 
     @Test
     public void testEidAlAdhaDay4_2025() {
         assertEquals(findFirst("Eid al-Adha (4th Day)", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 8));
+                LocalDate.of(2025, Month.JUNE, 9));
     }
 
     @Test
     public void testEidAlAdha2026() {
+        // Turkey Diyanet = May 27; one day later than Saudi/UAE (May 26) — confirmed divergence
         assertEquals(findFirst("Eid al-Adha", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 26),
-                "Eid al-Adha 2026 must be 2026-05-26 per Diyanet");
+                LocalDate.of(2026, Month.MAY, 27),
+                "Eid al-Adha 2026 must be 2026-05-27 per Diyanet");
     }
 
     @Test
     public void testEidAlAdhaDay2_2026() {
         assertEquals(findFirst("Eid al-Adha (2nd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 27));
+                LocalDate.of(2026, Month.MAY, 28));
     }
 
     @Test
     public void testEidAlAdhaDay3_2026() {
         assertEquals(findFirst("Eid al-Adha (3rd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 28));
+                LocalDate.of(2026, Month.MAY, 29));
     }
 
     @Test
     public void testEidAlAdhaDay4_2026() {
         assertEquals(findFirst("Eid al-Adha (4th Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 29));
+                LocalDate.of(2026, Month.MAY, 30));
     }
 
     // =========================================================================
@@ -554,8 +555,8 @@ public class HolidayCalendarServiceTRTest {
                 .toList();
         assertEquals(eidOccurrences.size(), 1,
                 "2033 has two Eid al-Fitr occurrences but only the first is recorded in the CSV");
-        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
-                "The single 2033 Eid al-Fitr occurrence must be January 3");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 2),
+                "The single 2033 Eid al-Fitr occurrence must be January 2");
     }
 
     // =========================================================================

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -33,8 +33,8 @@ public class EidAlAdhaDay4Test {
     Iterator<Object[]> knownDatesTR() {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, 6, 19)},
-            new Object[]{2025, LocalDate.of(2025, 6, 8)},
-            new Object[]{2026, LocalDate.of(2026, 5, 29)},
+            new Object[]{2025, LocalDate.of(2025, 6, 9)},
+            new Object[]{2026, LocalDate.of(2026, 5, 30)},
             new Object[]{2055, LocalDate.of(2055, 7, 6)}
         ).iterator();
     }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -35,7 +35,7 @@ public class EidAlAdhaDay4Test {
             new Object[]{2024, LocalDate.of(2024, 6, 19)},
             new Object[]{2025, LocalDate.of(2025, 6, 9)},
             new Object[]{2026, LocalDate.of(2026, 5, 30)},
-            new Object[]{2055, LocalDate.of(2055, 7, 6)}
+            new Object[]{2055, LocalDate.of(2055, 7, 8)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -32,10 +33,10 @@ public class EidAlAdhaDay4Test {
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 19)},
-            new Object[]{2025, LocalDate.of(2025, 6, 9)},
-            new Object[]{2026, LocalDate.of(2026, 5, 30)},
-            new Object[]{2055, LocalDate.of(2055, 7, 8)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 19)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 9)},
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 8)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -55,9 +56,9 @@ public class EidAlAdhaTest {
     @DataProvider
     Iterator<Object[]> knownDatesAE() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 3)}
         ).iterator();
     }
 
@@ -102,17 +103,17 @@ public class EidAlAdhaTest {
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2026, LocalDate.of(2026, 5, 27)},  // one day later than AE/SA — see below
-            new Object[]{2027, LocalDate.of(2027, 5, 16)},
-            new Object[]{2035, LocalDate.of(2035, 2, 18)},
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 27)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, Month.MAY, 16)},
+            new Object[]{2035, LocalDate.of(2035, Month.FEBRUARY, 18)},
             // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
             // published this far ahead) — not independently verified against a
             // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
-            new Object[]{2040, LocalDate.of(2040, 12, 14)},
-            new Object[]{2050, LocalDate.of(2050, 8, 27)},
-            new Object[]{2055, LocalDate.of(2055, 7, 5)}
+            new Object[]{2040, LocalDate.of(2040, Month.DECEMBER, 14)},
+            new Object[]{2050, LocalDate.of(2050, Month.AUGUST, 27)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 5)}
         ).iterator();
     }
 
@@ -130,9 +131,9 @@ public class EidAlAdhaTest {
     public void testTR2026DiffersFromAE() {
         LocalDate trDate = new EidAlAdha("TR").apply(2026);
         LocalDate aeDate = new EidAlAdha("AE").apply(2026);
-        assertEquals(trDate, LocalDate.of(2026, 5, 27),
+        assertEquals(trDate, LocalDate.of(2026, Month.MAY, 27),
                 "Diyanet Eid al-Adha 2026 must be May 27");
-        assertEquals(aeDate, LocalDate.of(2026, 5, 26),
+        assertEquals(aeDate, LocalDate.of(2026, Month.MAY, 26),
                 "UAE SCA Eid al-Adha 2026 must be May 26");
         assertNotEquals(trDate, aeDate,
                 "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
@@ -152,9 +153,9 @@ public class EidAlAdhaTest {
     @DataProvider
     Iterator<Object[]> knownDatesQA() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 3)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -107,9 +107,12 @@ public class EidAlAdhaTest {
             new Object[]{2026, LocalDate.of(2026, 5, 27)},  // one day later than AE/SA — see below
             new Object[]{2027, LocalDate.of(2027, 5, 16)},
             new Object[]{2035, LocalDate.of(2035, 2, 18)},
-            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
-            // far ahead) — not independently verified against a Diyanet source.
-            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+            // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
+            // published this far ahead) — not independently verified against a
+            // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
+            new Object[]{2040, LocalDate.of(2040, 12, 14)},
+            new Object[]{2050, LocalDate.of(2050, 8, 27)},
+            new Object[]{2055, LocalDate.of(2055, 7, 5)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -96,16 +96,19 @@ public class EidAlAdhaTest {
     }
 
     // -------------------------------------------------------------------------
-    // Known dates — TR (Diyanet ilmi takvim)
-    // 2025 divergence: Diyanet = June 5; Saudi/UAE Umm al-Qura = June 6
+    // Known dates — TR (Diyanet ilmi takvim, official published dates 2024-2035)
     // -------------------------------------------------------------------------
 
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 5)},   // one day earlier than AE/SA
-            new Object[]{2026, LocalDate.of(2026, 5, 26)},
+            new Object[]{2025, LocalDate.of(2025, 6, 6)},
+            new Object[]{2026, LocalDate.of(2026, 5, 27)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, 5, 16)},
+            new Object[]{2035, LocalDate.of(2035, 2, 18)},
+            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
+            // far ahead) — not independently verified against a Diyanet source.
             new Object[]{2055, LocalDate.of(2055, 7, 3)}
         ).iterator();
     }
@@ -116,17 +119,27 @@ public class EidAlAdhaTest {
                 "Eid al-Adha " + year + " per Diyanet must be " + expected);
     }
 
-    // Canonical Diyanet vs. Umm al-Qura divergence: 2025 Eid al-Adha
+    // Canonical Diyanet vs. Umm al-Qura/UAE divergence: 2026 Eid al-Adha.
+    // (A previously-recorded 2025 divergence was a data error: 2025-06-05 is Arefe,
+    // the eve of Bayram, not the actual 1st day — Diyanet's published 1st day is
+    // 2025-06-06, matching AE/SA. No divergence exists in 2025.)
     @Test
-    public void testTR2025DiffersFromAE() {
-        LocalDate trDate = new EidAlAdha("TR").apply(2025);
-        LocalDate aeDate = new EidAlAdha("AE").apply(2025);
-        assertEquals(trDate, LocalDate.of(2025, 6, 5),
-                "Diyanet Eid al-Adha 2025 must be June 5");
-        assertEquals(aeDate, LocalDate.of(2025, 6, 6),
-                "UAE SCA Eid al-Adha 2025 must be June 6");
+    public void testTR2026DiffersFromAE() {
+        LocalDate trDate = new EidAlAdha("TR").apply(2026);
+        LocalDate aeDate = new EidAlAdha("AE").apply(2026);
+        assertEquals(trDate, LocalDate.of(2026, 5, 27),
+                "Diyanet Eid al-Adha 2026 must be May 27");
+        assertEquals(aeDate, LocalDate.of(2026, 5, 26),
+                "UAE SCA Eid al-Adha 2026 must be May 26");
         assertNotEquals(trDate, aeDate,
-                "Diyanet and Umm al-Qura Eid al-Adha 2025 must differ by one day");
+                "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
+    }
+
+    // 2025 no longer diverges once the Arefe/Bayram-day data error is corrected
+    @Test
+    public void testTR2025MatchesAE() {
+        assertEquals(new EidAlAdha("TR").apply(2025), new EidAlAdha("AE").apply(2025),
+                "Eid al-Adha 2025: Diyanet (TR) and UAE SCA (AE) must agree on June 6");
     }
 
     // -------------------------------------------------------------------------

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -170,4 +170,37 @@ public class EidAlAdhaTest {
         assertEquals(new EidAlAdha("QA").apply(2025), new EidAlAdha("AE").apply(2025),
                 "Eid al-Adha 2025: Qatar (QCB) and UAE (SCA) must agree on June 6");
     }
+
+    // -------------------------------------------------------------------------
+    // Runtime fallback to IlmiTakvimCalculator (TR only, when the CSV has no row
+    // for an in-range year — all tr CSV rows are currently populated through
+    // DATA_VALID_THROUGH, so these tests exercise computeDate() directly for years
+    // outside the CSV's own range to prove the fallback path itself is correct.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void computeDateFallsBackToCalculatorForTrWhenCsvHasNoRow() {
+        int year = 2100; // beyond DATA_VALID_THROUGH; no CSV row for any country
+        EidAlAdha tr = new EidAlAdha("tr");
+        assertEquals(tr.computeDate(year),
+                org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator.eidAlAdha(year),
+                "computeDate must fall back to IlmiTakvimCalculator for tr when the CSV lacks a row");
+    }
+
+    @Test
+    public void computeDateReturnsNullWhenCalculatorFailsForTr() {
+        // Year 3050 is beyond Time4J's supported astronomical range, forcing
+        // IlmiTakvimCalculator to throw; computeDate must catch it and return null.
+        assertNull(new EidAlAdha("tr").computeDate(3050),
+                "computeDate must return null when the ilmi takvim calculation itself fails");
+        assertTrue(listAppender.list.stream().anyMatch(e -> e.getLevel() == Level.WARN),
+                "Expected a WARN log when the ilmi takvim calculation fails");
+    }
+
+    @Test
+    public void computeDateReturnsNullForNonTrCountryWhenCsvHasNoRow() {
+        assertNull(new EidAlAdha("ae").computeDate(2100),
+                "computeDate must return null for non-tr countries when the CSV lacks a row "
+                        + "(no calculator fallback exists for them)");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -59,9 +60,9 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesAE() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 
@@ -77,9 +78,9 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesSA() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 
@@ -156,17 +157,17 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2026, LocalDate.of(2026, 3, 20)},  // one day later than AE/SA — see below
-            new Object[]{2027, LocalDate.of(2027, 3, 9)},
-            new Object[]{2035, LocalDate.of(2035, 12, 1)},
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 20)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 9)},
+            new Object[]{2035, LocalDate.of(2035, Month.DECEMBER, 1)},
             // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
             // published this far ahead) — not independently verified against a
             // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
-            new Object[]{2040, LocalDate.of(2040, 10, 7)},
-            new Object[]{2050, LocalDate.of(2050, 6, 20)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2040, LocalDate.of(2040, Month.OCTOBER, 7)},
+            new Object[]{2050, LocalDate.of(2050, Month.JUNE, 20)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 
@@ -188,9 +189,9 @@ public class EidAlFitrTest {
     public void testTR2026DiffersFromAE() {
         LocalDate trDate = new EidAlFitr("TR").apply(2026);
         LocalDate aeDate = new EidAlFitr("AE").apply(2026);
-        assertEquals(trDate, LocalDate.of(2026, 3, 20),
+        assertEquals(trDate, LocalDate.of(2026, Month.MARCH, 20),
                 "Diyanet Eid al-Fitr 2026 must be March 20");
-        assertEquals(aeDate, LocalDate.of(2026, 3, 19),
+        assertEquals(aeDate, LocalDate.of(2026, Month.MARCH, 19),
                 "UAE SCA Eid al-Fitr 2026 must be March 19");
         assertNotEquals(trDate, aeDate,
                 "Diyanet and UAE SCA Eid al-Fitr 2026 must differ by one day");
@@ -203,9 +204,9 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesQA() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -161,8 +161,11 @@ public class EidAlFitrTest {
             new Object[]{2026, LocalDate.of(2026, 3, 20)},  // one day later than AE/SA — see below
             new Object[]{2027, LocalDate.of(2027, 3, 9)},
             new Object[]{2035, LocalDate.of(2035, 12, 1)},
-            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
-            // far ahead) — not independently verified against a Diyanet source.
+            // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
+            // published this far ahead) — not independently verified against a
+            // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
+            new Object[]{2040, LocalDate.of(2040, 10, 7)},
+            new Object[]{2050, LocalDate.of(2050, 6, 20)},
             new Object[]{2055, LocalDate.of(2055, 4, 28)}
         ).iterator();
     }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -221,4 +221,37 @@ public class EidAlFitrTest {
         assertEquals(new EidAlFitr("QA").apply(2025), new EidAlFitr("AE").apply(2025),
                 "Eid al-Fitr 2025: Qatar (QCB) and UAE (SCA) must agree on March 30");
     }
+
+    // -------------------------------------------------------------------------
+    // Runtime fallback to IlmiTakvimCalculator (TR only, when the CSV has no row
+    // for an in-range year — all tr CSV rows are currently populated through
+    // DATA_VALID_THROUGH, so these tests exercise computeDate() directly for years
+    // outside the CSV's own range to prove the fallback path itself is correct.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void computeDateFallsBackToCalculatorForTrWhenCsvHasNoRow() {
+        int year = 2100; // beyond DATA_VALID_THROUGH; no CSV row for any country
+        EidAlFitr tr = new EidAlFitr("tr");
+        assertEquals(tr.computeDate(year),
+                org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator.eidAlFitr(year),
+                "computeDate must fall back to IlmiTakvimCalculator for tr when the CSV lacks a row");
+    }
+
+    @Test
+    public void computeDateReturnsNullWhenCalculatorFailsForTr() {
+        // Year 3050 is beyond Time4J's supported astronomical range, forcing
+        // IlmiTakvimCalculator to throw; computeDate must catch it and return null.
+        assertNull(new EidAlFitr("tr").computeDate(3050),
+                "computeDate must return null when the ilmi takvim calculation itself fails");
+        assertTrue(listAppender.list.stream().anyMatch(e -> e.getLevel() == Level.WARN),
+                "Expected a WARN log when the ilmi takvim calculation fails");
+    }
+
+    @Test
+    public void computeDateReturnsNullForNonTrCountryWhenCsvHasNoRow() {
+        assertNull(new EidAlFitr("ae").computeDate(2100),
+                "computeDate must return null for non-tr countries when the CSV lacks a row "
+                        + "(no calculator fallback exists for them)");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -150,7 +150,7 @@ public class EidAlFitrTest {
     }
 
     // -------------------------------------------------------------------------
-    // Known dates — TR (Diyanet ilmi takvim)
+    // Known dates — TR (Diyanet ilmi takvim, official published dates 2024-2035)
     // -------------------------------------------------------------------------
 
     @DataProvider
@@ -158,7 +158,11 @@ public class EidAlFitrTest {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, 4, 10)},
             new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2026, LocalDate.of(2026, 3, 19)},
+            new Object[]{2026, LocalDate.of(2026, 3, 20)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, 3, 9)},
+            new Object[]{2035, LocalDate.of(2035, 12, 1)},
+            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
+            // far ahead) — not independently verified against a Diyanet source.
             new Object[]{2055, LocalDate.of(2055, 4, 28)}
         ).iterator();
     }
@@ -174,6 +178,19 @@ public class EidAlFitrTest {
     public void testTR2025MatchesAE() {
         assertEquals(new EidAlFitr("TR").apply(2025), new EidAlFitr("AE").apply(2025),
                 "Eid al-Fitr 2025: Diyanet (TR) and UAE SCA (AE) must agree on March 30");
+    }
+
+    // TR 2026 diverges from AE by one day: Diyanet (ilmi takvim) vs UAE SCA
+    @Test
+    public void testTR2026DiffersFromAE() {
+        LocalDate trDate = new EidAlFitr("TR").apply(2026);
+        LocalDate aeDate = new EidAlFitr("AE").apply(2026);
+        assertEquals(trDate, LocalDate.of(2026, 3, 20),
+                "Diyanet Eid al-Fitr 2026 must be March 20");
+        assertEquals(aeDate, LocalDate.of(2026, 3, 19),
+                "UAE SCA Eid al-Fitr 2026 must be March 19");
+        assertNotEquals(trDate, aeDate,
+                "Diyanet and UAE SCA Eid al-Fitr 2026 must differ by one day");
     }
 
     // -------------------------------------------------------------------------

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/CsvCalculatorParityTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/CsvCalculatorParityTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena.ilmitakvim;
+
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Guards against drift between the checked-in {@code eid-al-fitr-tr.csv} /
+ * {@code eid-al-adha-tr.csv} rows for 2036-2055 and {@link IlmiTakvimCalculator}'s
+ * own live output — both currently encode the same values (the CSV rows were
+ * generated from the calculator), but nothing prevents them from silently
+ * diverging if either is edited independently in the future.
+ */
+public class CsvCalculatorParityTest {
+
+    // 2039 has a documented double-occurrence in Gregorian terms (see
+    // eid-al-adha-tr.csv comments); the CSV records only the earlier occurrence,
+    // exactly as the calculator does, so no exclusion is actually needed — but
+    // years with day1 exactly on 31 December / 1 January carry a small extra risk
+    // of calendar-boundary edge cases, so this suite does not special-case any
+    // year and instead lets a real mismatch fail loudly.
+
+    @DataProvider
+    Object[][] projectedYears() {
+        Object[][] years = new Object[20][1];
+        for (int i = 0; i < 20; i++) {
+            years[i][0] = 2036 + i;
+        }
+        return years;
+    }
+
+    @Test(dataProvider = "projectedYears")
+    public void fitrCsvRowMatchesCalculatorOutput(int year) {
+        Map<Integer, LocalDate> csv = CsvObservanceLoader.loadSingle(EidAlFitr.class, "eid-al-fitr-tr.csv");
+        assertEquals(csv.get(year), IlmiTakvimCalculator.eidAlFitr(year),
+                "eid-al-fitr-tr.csv row for " + year + " has drifted from IlmiTakvimCalculator's own output");
+    }
+
+    @Test(dataProvider = "projectedYears")
+    public void adhaCsvRowMatchesCalculatorOutput(int year) {
+        Map<Integer, LocalDate> csv = CsvObservanceLoader.loadSingle(EidAlAdha.class, "eid-al-adha-tr.csv");
+        assertEquals(csv.get(year), IlmiTakvimCalculator.eidAlAdha(year),
+                "eid-al-adha-tr.csv row for " + year + " has drifted from IlmiTakvimCalculator's own output");
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,18 +47,18 @@ public class IlmiTakvimCalculatorTest {
     @DataProvider
     Iterator<Object[]> verifiedEidAlFitrDates() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2026, LocalDate.of(2026, 3, 20)},
-            new Object[]{2027, LocalDate.of(2027, 3, 9)},
-            new Object[]{2028, LocalDate.of(2028, 2, 26)},
-            new Object[]{2029, LocalDate.of(2029, 2, 14)},
-            new Object[]{2030, LocalDate.of(2030, 2, 4)},
-            new Object[]{2031, LocalDate.of(2031, 1, 24)},
-            new Object[]{2032, LocalDate.of(2032, 1, 14)},
-            new Object[]{2033, LocalDate.of(2033, 1, 2)}, // double-occurrence year; January recorded
-            new Object[]{2034, LocalDate.of(2034, 12, 12)},
-            new Object[]{2035, LocalDate.of(2035, 12, 1)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 20)},
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 9)},
+            new Object[]{2028, LocalDate.of(2028, Month.FEBRUARY, 26)},
+            new Object[]{2029, LocalDate.of(2029, Month.FEBRUARY, 14)},
+            new Object[]{2030, LocalDate.of(2030, Month.FEBRUARY, 4)},
+            new Object[]{2031, LocalDate.of(2031, Month.JANUARY, 24)},
+            new Object[]{2032, LocalDate.of(2032, Month.JANUARY, 14)},
+            new Object[]{2033, LocalDate.of(2033, Month.JANUARY, 2)}, // double-occurrence year; January recorded
+            new Object[]{2034, LocalDate.of(2034, Month.DECEMBER, 12)},
+            new Object[]{2035, LocalDate.of(2035, Month.DECEMBER, 1)}
         ).iterator();
     }
 
@@ -74,18 +75,18 @@ public class IlmiTakvimCalculatorTest {
     @DataProvider
     Iterator<Object[]> verifiedEidAlAdhaDates() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2026, LocalDate.of(2026, 5, 27)},
-            new Object[]{2027, LocalDate.of(2027, 5, 16)},
-            new Object[]{2028, LocalDate.of(2028, 5, 5)},
-            new Object[]{2029, LocalDate.of(2029, 4, 24)},
-            new Object[]{2030, LocalDate.of(2030, 4, 13)},
-            new Object[]{2031, LocalDate.of(2031, 4, 2)},
-            new Object[]{2032, LocalDate.of(2032, 3, 22)},
-            new Object[]{2033, LocalDate.of(2033, 3, 11)},
-            new Object[]{2034, LocalDate.of(2034, 3, 1)},
-            new Object[]{2035, LocalDate.of(2035, 2, 18)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 27)},
+            new Object[]{2027, LocalDate.of(2027, Month.MAY, 16)},
+            new Object[]{2028, LocalDate.of(2028, Month.MAY, 5)},
+            new Object[]{2029, LocalDate.of(2029, Month.APRIL, 24)},
+            new Object[]{2030, LocalDate.of(2030, Month.APRIL, 13)},
+            new Object[]{2031, LocalDate.of(2031, Month.APRIL, 2)},
+            new Object[]{2032, LocalDate.of(2032, Month.MARCH, 22)},
+            new Object[]{2033, LocalDate.of(2033, Month.MARCH, 11)},
+            new Object[]{2034, LocalDate.of(2034, Month.MARCH, 1)},
+            new Object[]{2035, LocalDate.of(2035, Month.FEBRUARY, 18)}
         ).iterator();
     }
 
@@ -98,8 +99,8 @@ public class IlmiTakvimCalculatorTest {
     // Canonical divergence: Diyanet vs UAE SCA / Umm al-Qura, 2026 Eid al-Adha
     @Test
     public void reproducesCanonical2026AdhaDivergence() {
-        assertEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 27));
-        assertNotEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 26),
+        assertEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, Month.MAY, 27));
+        assertNotEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, Month.MAY, 26),
                 "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena.ilmitakvim;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies {@link IlmiTakvimCalculator} against all 24 dates (2024-2035, Eid
+ * al-Fitr and Eid al-Adha) fetched directly from Diyanet's own published
+ * "Dini Günler" tables at vakithesaplama.diyanet.gov.tr (icerik.php?icerik=N /
+ * dinigunler.php?yil=N for the respective years) — not the CSV files, so this
+ * is an independent check of the calculator's logic in isolation.
+ */
+public class IlmiTakvimCalculatorTest {
+
+    // -------------------------------------------------------------------------
+    // Verified Eid al-Fitr dates (1 Shawwal), 2024-2035, Diyanet official
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> verifiedEidAlFitrDates() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 4, 10)},
+            new Object[]{2025, LocalDate.of(2025, 3, 30)},
+            new Object[]{2026, LocalDate.of(2026, 3, 20)},
+            new Object[]{2027, LocalDate.of(2027, 3, 9)},
+            new Object[]{2028, LocalDate.of(2028, 2, 26)},
+            new Object[]{2029, LocalDate.of(2029, 2, 14)},
+            new Object[]{2030, LocalDate.of(2030, 2, 4)},
+            new Object[]{2031, LocalDate.of(2031, 1, 24)},
+            new Object[]{2032, LocalDate.of(2032, 1, 14)},
+            new Object[]{2033, LocalDate.of(2033, 1, 2)}, // double-occurrence year; January recorded
+            new Object[]{2034, LocalDate.of(2034, 12, 12)},
+            new Object[]{2035, LocalDate.of(2035, 12, 1)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "verifiedEidAlFitrDates")
+    public void computesEidAlFitrAgainstDiyanetPublishedDate(int year, LocalDate expected) {
+        assertEquals(IlmiTakvimCalculator.eidAlFitr(year), expected,
+                "Eid al-Fitr " + year + " must match Diyanet's published ilmi takvim date");
+    }
+
+    // -------------------------------------------------------------------------
+    // Verified Eid al-Adha dates (10 Dhu al-Hijjah), 2024-2035, Diyanet official
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> verifiedEidAlAdhaDates() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 6, 16)},
+            new Object[]{2025, LocalDate.of(2025, 6, 6)},
+            new Object[]{2026, LocalDate.of(2026, 5, 27)},
+            new Object[]{2027, LocalDate.of(2027, 5, 16)},
+            new Object[]{2028, LocalDate.of(2028, 5, 5)},
+            new Object[]{2029, LocalDate.of(2029, 4, 24)},
+            new Object[]{2030, LocalDate.of(2030, 4, 13)},
+            new Object[]{2031, LocalDate.of(2031, 4, 2)},
+            new Object[]{2032, LocalDate.of(2032, 3, 22)},
+            new Object[]{2033, LocalDate.of(2033, 3, 11)},
+            new Object[]{2034, LocalDate.of(2034, 3, 1)},
+            new Object[]{2035, LocalDate.of(2035, 2, 18)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "verifiedEidAlAdhaDates")
+    public void computesEidAlAdhaAgainstDiyanetPublishedDate(int year, LocalDate expected) {
+        assertEquals(IlmiTakvimCalculator.eidAlAdha(year), expected,
+                "Eid al-Adha " + year + " must match Diyanet's published ilmi takvim date");
+    }
+
+    // Canonical divergence: Diyanet vs UAE SCA / Umm al-Qura, 2026 Eid al-Adha
+    @Test
+    public void reproducesCanonical2026AdhaDivergence() {
+        assertEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 27));
+        assertNotEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 26),
+                "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
+    }
+
+    // -------------------------------------------------------------------------
+    // Residual projection range (2036-2055) — internal consistency checks only;
+    // Diyanet has not yet published these, so there is no independent source to
+    // verify against. These checks guard against gross errors (wrong direction,
+    // duplicate dates, out-of-range results), not exact-date correctness.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void projectedFitrDatesRegressPlausibly() {
+        for (int year = 2036; year <= 2054; year++) {
+            LocalDate current = IlmiTakvimCalculator.eidAlFitr(year);
+            LocalDate next = IlmiTakvimCalculator.eidAlFitr(year + 1);
+            assertPlausibleGap("Eid al-Fitr", year, current, next);
+        }
+    }
+
+    @Test
+    public void projectedAdhaDatesRegressPlausibly() {
+        for (int year = 2036; year <= 2054; year++) {
+            LocalDate current = IlmiTakvimCalculator.eidAlAdha(year);
+            LocalDate next = IlmiTakvimCalculator.eidAlAdha(year + 1);
+            assertPlausibleGap("Eid al-Adha", year, current, next);
+        }
+    }
+
+    /**
+     * A Hijri year is ~354-355 days; against a ~365-366 day Gregorian year, the
+     * anniversary regresses by ~10-12 days most years. When a double-occurrence
+     * year (two anniversaries in one Gregorian year, only the first recorded per
+     * the documented convention) is involved, the recorded gap to the following
+     * year can look like roughly two lunar years instead of one.
+     */
+    private static void assertPlausibleGap(String label, int year, LocalDate current, LocalDate next) {
+        long daysBetween = java.time.temporal.ChronoUnit.DAYS.between(current, next);
+        boolean oneLunarYear = daysBetween >= 353 && daysBetween <= 357;
+        boolean twoLunarYears = daysBetween >= 700 && daysBetween <= 712;
+        assertTrue(oneLunarYear || twoLunarYears,
+                label + " " + year + "->" + (year + 1) + " gap of " + daysBetween
+                        + " days is outside the plausible range");
+    }
+
+    @Test
+    public void adhaIsAlwaysComputableAcrossTheResidualProjectionRange() {
+        for (int year = 2036; year <= 2055; year++) {
+            assertNotNull(IlmiTakvimCalculator.eidAlAdha(year), "Eid al-Adha " + year + " must resolve to a date");
+        }
+    }
+
+}


### PR DESCRIPTION
## Summary
- Fixes a pre-existing data bug where three Turkey CSV rows recorded Arefe (the eve of Bayram) instead of the actual 1st day of Bayram (Eid al-Adha 2025/2026, Eid al-Fitr 2026), verified against Diyanet's own published calendar at `vakithesaplama.diyanet.gov.tr`. This also invalidated the "canonical 2025 divergence" test cited by #180 — Diyanet's real 2025 Eid al-Adha date (June 6) actually matches Saudi/UAE, with no divergence that year.
- Replaces the 2027–2035 Umm al-Qura placeholder rows in `eid-al-fitr-tr.csv`/`eid-al-adha-tr.csv` with genuine Diyanet-published dates (Diyanet publishes ~9 years ahead, not 1–2 years as originally assumed).
- Adds a new `IlmiTakvimCalculator` modeling Diyanet's ilmi takvim methodology (true/perturbed lunar conjunction via Time4J's `MoonPhase.NEW_MOON`, with the Hijri month starting the day after conjunction, or two days after if the conjunction falls after local sunset at Ankara via Time4J's `SolarTime`). This rule was calibrated against, and exactly reproduces, all 24 Diyanet-published dates (Eid al-Fitr and Eid al-Adha, 2024–2035).
- Uses the calculator to replace the remaining 2036–2055 Umm al-Qura placeholders with computed ilmi takvim projections.
- Adds a minimal live fallback in `EidAlAdha`/`EidAlFitr` to the calculator for country code `tr` when a CSV row is missing for an in-range year, as a defensive safety net (all `tr` CSV rows are currently populated, so this path isn't exercised in normal operation).
- Replaces the disproven "2025 divergence" test with a real, doubly-confirmed 2026 divergence (Diyanet Eid al-Adha May 27 vs. UAE SCA May 26) and an analogous Eid al-Fitr 2026 divergence test.
- Updates Javadoc on `EidAlAdha`, `EidAlFitr`, `TurkeyHolidays`, and `HolidayCalendarServiceTR` to describe the corrected source tiers and methodology.

Closes #180

## Test plan
- [x] New `IlmiTakvimCalculatorTest`: verifies the calculator in isolation against all 24 Diyanet-published dates (2024–2035, Eid al-Fitr and Eid al-Adha), the canonical 2026 divergence, and plausibility checks (gap regression, double-occurrence consequences) across the projected 2036–2055 range
- [x] New `CsvCalculatorParityTest`: asserts every 2036–2055 CSV row for both holidays matches the calculator's own live output, guarding against future drift
- [x] `EidAlAdhaTest`/`EidAlFitrTest`: corrected `knownDatesTR` data (2025/2026 Arefe fix, added 2027/2040/2050/2055), replaced `testTR2025DiffersFromAE` with `testTR2026DiffersFromAE` (Adha) and `testTR2026DiffersFromAE` (Fitr)
- [x] `HolidayCalendarServiceTRTest`: fixed stale assertions built on the old Arefe-based values (Fitr/Adha 2025/2026, 2033 double-occurrence)
- [x] `EidAlAdhaDay4Test`: updated 2025/2026/2055 offsets to match corrected base dates
- [x] Full suite green: `mvn test` (root reactor) — 128 tests; `mvn -pl holiday-calendar-mena test` — 1152 tests, 0 failures, 0 errors
- [x] `mvn -pl holiday-calendar-mena compile` confirms no `module-info.java` changes were needed (Time4J's single automatic module already covers `calendar.astro`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)