### PR TITLE
CH: Add Christmas Eve / New Year's Eve market holidays

### DIFF
--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCH.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCH.java
@@ -100,6 +100,13 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.AUGUST, 1)
                 .build();
+        final Holiday christmasEve = Holiday.builder()
+                .name("Christmas Eve")
+                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 24)
+                .build();
         final Holiday christmasDay = Holiday.builder()
                 .name("Christmas Day")
                 .description("Celebration of traditional Christmas holiday")
@@ -114,6 +121,13 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday newYearsEve = Holiday.builder()
+                .name("New Year's Eve")
+                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 31)
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -127,8 +141,10 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
                 .holiday(ascensionDay)
                 .holiday(whitMonday)
                 .holiday(swissNationalDay)
+                .holiday(christmasEve)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(newYearsEve)
                 .build();
     }
 

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHTest.java
@@ -18,12 +18,20 @@
 
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.*;
 
 public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarServiceTest {
 
@@ -37,8 +45,10 @@ public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarService
     @Override
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
+        final Object[] christmasEve = new Object[]{"Christmas Eve"};
         final Object[] boxingDay = new Object[]{"Boxing Day"};
-        return Arrays.asList(swissNationalDay, boxingDay).listIterator();
+        final Object[] newYearsEve = new Object[]{"New Year's Eve"};
+        return Arrays.asList(swissNationalDay, christmasEve, boxingDay, newYearsEve).listIterator();
     }
 
     @DataProvider
@@ -57,8 +67,72 @@ public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarService
         final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // Christmas Day 2023: Dec 25 is Monday -> no roll
         final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // Christmas Eve: Dec 24
+        // 2021: Dec 24 is Friday -> no roll
+        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
+        // 2022: Dec 24 is Saturday -> rolls to Friday Dec 23
+        final Object[] christmasEve22 = {2022, "Christmas Eve", LocalDate.of(2022, Month.DECEMBER, 23)};
+        // 2023: Dec 24 is Sunday -> rolls to Monday Dec 25
+        final Object[] christmasEve23 = {2023, "Christmas Eve", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // New Year's Eve: Dec 31
+        // 2021: Dec 31 is Friday -> no roll
+        final Object[] newYearsEve21 = {2021, "New Year's Eve", LocalDate.of(2021, Month.DECEMBER, 31)};
+        // 2022: Dec 31 is Saturday -> rolls to Friday Dec 30
+        final Object[] newYearsEve22 = {2022, "New Year's Eve", LocalDate.of(2022, Month.DECEMBER, 30)};
+        // 2023: Dec 31 is Sunday -> rolls to Monday Jan 1, 2024
+        final Object[] newYearsEve23 = {2023, "New Year's Eve", LocalDate.of(2024, Month.JANUARY, 1)};
         return Arrays.asList(swissNationalDay21, swissNationalDay22, swissNationalDay23,
-                             christmas21, christmas22, christmas23).listIterator();
+                             christmas21, christmas22, christmas23,
+                             christmasEve21, christmasEve22, christmasEve23,
+                             newYearsEve21, newYearsEve22, newYearsEve23).listIterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Same-resolved-date collisions between independently-rolled fixed holidays
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCollision_ChristmasDayRollAndChristmasEveShareDec24_2021() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        List<HolidayDate> holidays2021 = calendar.calculate(2021);
+
+        Optional<HolidayDate> christmasDay = holidays2021.stream()
+                .filter(hd -> "Christmas Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        Optional<HolidayDate> christmasEve = holidays2021.stream()
+                .filter(hd -> "Christmas Eve".equals(hd.getHoliday().getName()))
+                .findFirst();
+
+        assertTrue(christmasDay.isPresent());
+        assertTrue(christmasEve.isPresent());
+        assertEquals(christmasDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+        assertEquals(christmasEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+    }
+
+    @Test
+    public void testCollision_NewYearsDayRollAndNewYearsEveShareDec31_2021() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        // 2022: Jan 1 is Saturday -> New Year's Day rolls back to Friday Dec 31, 2021
+        List<HolidayDate> holidays2022 = calendar.calculate(2022);
+        Optional<HolidayDate> newYearsDay = holidays2022.stream()
+                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(newYearsDay.isPresent());
+        assertEquals(newYearsDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
+
+        // 2021: Dec 31 is Friday -> New Year's Eve stays on Dec 31, 2021
+        List<HolidayDate> holidays2021 = calendar.calculate(2021);
+        Optional<HolidayDate> newYearsEve = holidays2021.stream()
+                .filter(hd -> "New Year's Eve".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(newYearsEve.isPresent());
+        assertEquals(newYearsEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
     }
 
 }


### PR DESCRIPTION
### Title of the PR

CH: Add Christmas Eve / New Year's Eve market holidays

**Description**

- Adds "Christmas Eve" (Dec 24) and "New Year's Eve" (Dec 31) as `FIXED`, rollable holidays to `HolidayCalendarServiceCH`, matching the existing style used for Christmas Day/Boxing Day/Swiss National Day.
- Extends `HolidayCalendarServiceCHTest` with occurrence coverage (no-roll / Saturday-roll / Sunday-roll cases for both new dates) plus two dedicated tests for the case where an independently-rolled fixed holiday and a new one resolve to the same calendar date in the same year (Christmas Day rolling onto Dec 24 in 2021; New Year's Day rolling onto Dec 31 in 2022) — confirming both coexist correctly as distinct entries.

**Deviation from issue #208**

Issue #208 asked for these two dates to be modeled as `EARLY_CLOSE` (half-day) holidays, following the `IsraelHolidays.earlyCloseHolidays()` pattern, and explicitly asked for close times to be verified against SIX's official trading calendar before finalizing.

Doing that verification changed the outcome: SIX Group's own published **Trading Calendar** PDFs, checked independently for **2026** and **2027** (two different years, different weekdays for Dec 24/31 in each), show both dates as full **"Market Holiday" / Market Closed** — the identical category used for Saturdays and Sundays. Neither document's legend has a half-day/early-close category at all.

A separate SIX document (the Currency Holiday Calendar, covering CHF/EUR settlement — closer to `HolidayCalendarServiceCHF`'s domain than `HolidayCalendarServiceCH`'s) omits Dec 24/31 entirely, which is a different calendar for a different purpose and doesn't change the equities Trading Calendar's classification.

Given that, this PR models both dates as ordinary `FIXED` full-closure holidays rather than `EARLY_CLOSE`, since that's what the primary source actually documents for the SIX Swiss Exchange (equities) calendar. `HolidayCalendarServiceCHF` is left untouched — out of scope here, though the Currency Holiday Calendar finding may be worth a separate follow-up investigation for that calendar.

**Related Issue**

- #208

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed