### PR TITLE
#204 TR: Model BIST Republic Day Eve half-day close

### DIFF
--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -48,12 +48,12 @@ import java.util.OptionalInt;
  * against official announcements as each year is
  * published. Corrections require a new JAR release.
  *
- * <p><strong>Half-day closure not modelled:</strong>
- * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
- * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
- * settlement from midday. This calendar does not include 28 October as a holiday.
- * Callers relying on afternoon liquidity or same-day settlement on this date must
- * apply their own adjustment.
+ * <p>Borsa Istanbul (BIST) observes a half-day closure on 28 October (Republic
+ * Day Eve), closing at 12:30 {@code Europe/Istanbul}. This is modelled as an
+ * {@code EARLY_CLOSE} holiday, non-rollable, and reported separately via
+ * {@link HolidayCalendar#calculateEarlyCloses(int)} rather than {@link
+ * HolidayCalendar#calculate(int)}. It does not shift when 28 October falls on
+ * a Saturday or Sunday.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -79,6 +79,7 @@ public class HolidayCalendarServiceTR extends AbstractHolidayCalendarService {
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(TurkeyHolidays.STANDARD_WEEKEND)
                 .holidays(TurkeyHolidays.baseHolidays(true, List.of()))
+                .holidays(TurkeyHolidays.earlyCloseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -26,9 +26,12 @@ import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay4;
 import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
 import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
 import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.tr.RepublicDayEveEarlyClose;
 
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,12 +58,12 @@ import java.util.List;
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days
  * of Eid al-Adha (Kurban Bayramı), consistent with BIST market closure announcements.
  *
- * <p><strong>Half-day closure not modelled:</strong>
- * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
- * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
- * settlement from midday. This calendar does not include 28 October as a holiday.
- * Callers relying on afternoon liquidity or same-day settlement on this date must
- * apply their own adjustment.
+ * <p>Borsa Istanbul (BIST) observes a half-day closure on 28 October (Republic
+ * Day Eve), closing at 12:30 {@code Europe/Istanbul}. This is modelled as an
+ * {@link Holiday.Type#EARLY_CLOSE} holiday via {@link #earlyCloseHolidays()},
+ * consumed by {@link HolidayCalendarServiceTR}. It does not shift when
+ * 28 October falls on a Saturday or Sunday — see {@link RepublicDayEveEarlyClose}.
+ * {@link HolidayCalendarServiceTRY} does not yet include this half-day closure.
  *
  * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
  * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
@@ -188,5 +191,26 @@ class TurkeyHolidays {
                 .build());
         holidays.addAll(additional);
         return List.copyOf(holidays);
+    }
+
+    /**
+     * Returns the single {@code EARLY_CLOSE} holiday representing BIST's
+     * Republic Day Eve half-day close (28 October, closing at 12:30
+     * {@code Europe/Istanbul}). Does not shift when 28 October falls on a
+     * Saturday or Sunday; see {@link RepublicDayEveEarlyClose}.
+     */
+    static List<Holiday> earlyCloseHolidays() {
+        return List.of(
+            Holiday.builder()
+                    .name("Republic Day Eve")
+                    .description("BIST half-day close ahead of Republic Day; no adjustment when "
+                            + "28 October falls on a Saturday or Sunday")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new RepublicDayEveEarlyClose())
+                    .closeTime(LocalTime.of(12, 30))
+                    .zoneId(ZoneId.of("Europe/Istanbul"))
+                    .build()
+        );
     }
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.tr;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Borsa İstanbul's (BIST) Republic Day Eve half-day close
+ * (October 28). Unlike the LSE's Christmas Eve convention, BIST does not
+ * shift this session to the preceding Friday when October 28 falls on a
+ * Saturday or Sunday — the market is simply closed for the weekend as usual,
+ * with no early-close adjustment that year (confirmed against BIST's 2023
+ * holiday schedule, where 28-29 October fell on Saturday-Sunday with no
+ * preceding half-day session).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class RepublicDayEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.OCTOBER, 28);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek dayOfWeek = LocalDate.of(year, Month.OCTOBER, 28).getDayOfWeek();
+        return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
@@ -45,7 +45,7 @@ public class RepublicDayEveEarlyClose extends AbstractObservance {
     @Override
     protected boolean isValidYear(int year) {
         DayOfWeek dayOfWeek = LocalDate.of(year, Month.OCTOBER, 28).getDayOfWeek();
-        return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
+        return !dayOfWeek.equals(DayOfWeek.SATURDAY) && !dayOfWeek.equals(DayOfWeek.SUNDAY);
     }
 
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTREarlyCloseTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTREarlyCloseTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code TR} calendar's early-close (BIST Republic Day Eve
+ * half-day closure) holiday, provided by {@link TurkeyHolidays#earlyCloseHolidays()}.
+ */
+public class HolidayCalendarServiceTREarlyCloseTest {
+
+    private static final int EARLY_CLOSE_COUNT = 1;
+    private static final int FULL_DAY_HOLIDAY_COUNT = 14;
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 30);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/Istanbul");
+
+    private final HolidayCalendarServiceTR service = new HolidayCalendarServiceTR();
+
+    @Test
+    public void testEarlyCloseHolidayCount2025() {
+        // Oct 28, 2025 is a Tuesday
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+    }
+
+    @Test
+    public void testFullDayHolidayCount_Unchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    @Test
+    public void testRepublicDayEve_NameCloseTimeAndZone2025() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        HolidayDate republicDayEve = earlyCloses.stream()
+                .filter(hd -> "Republic Day Eve".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Republic Day Eve not found in calculateEarlyCloses(2025)"));
+        assertEquals(republicDayEve.getDate(), LocalDate.of(2025, Month.OCTOBER, 28));
+        assertTrue(republicDayEve.getHoliday() instanceof EarlyCloseHoliday);
+        EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) republicDayEve.getHoliday();
+        assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME, "Republic Day Eve must close at 12:30");
+        assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE, "Republic Day Eve must be expressed in Europe/Istanbul");
+    }
+
+    @Test
+    public void testRepublicDayEve_SkippedWhenOct28FallsOnWeekend2023() {
+        // Oct 28, 2023 is a Saturday (Oct 29, 2023 is a Sunday)
+        assertEquals(LocalDate.of(2023, Month.OCTOBER, 28).getDayOfWeek(), DayOfWeek.SATURDAY);
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2023);
+        assertTrue(earlyCloses.isEmpty(),
+                "BIST does not shift the half-day close to the preceding Friday when Oct 28 falls on a weekend");
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -560,16 +560,17 @@ public class HolidayCalendarServiceTRTest {
     }
 
     // =========================================================================
-    // Republic Day Eve (Oct 28) — confirmed absent; half-day not modelled
+    // Republic Day Eve (Oct 28) — early close, not a full-day holiday
     // =========================================================================
 
     @Test
-    public void testRepublicDayEveAbsent2025() {
+    public void testRepublicDayEveAbsentFromCalculate2025() {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
         boolean oct28Present = holidays.stream()
                 .anyMatch(hd -> hd.date().equals(LocalDate.of(2025, Month.OCTOBER, 28)));
         assertFalse(oct28Present,
-                "Oct 28 (Republic Day Eve) must not be present — half-day closures are not modelled");
+                "Oct 28 (Republic Day Eve) is an EARLY_CLOSE holiday and must not appear in calculate(), "
+                        + "only in calculateEarlyCloses() — see HolidayCalendarServiceTREarlyCloseTest");
     }
 
     // =========================================================================


### PR DESCRIPTION
### Title of the PR

TR: Model BIST Republic Day Eve half-day close

**Description**

- Adds an `EARLY_CLOSE` holiday to `HolidayCalendarServiceTR` for Borsa İstanbul's (BIST) half-day close on 28 October (Republic Day Eve), closing at 12:30 `Europe/Istanbul`, following the `IsraelHolidays.earlyCloseHolidays()` pattern.
- New `RepublicDayEveEarlyClose` observance (`org.holiday.calendar.observance.tr`) skips the half-day when 28 October falls on a Saturday or Sunday — confirmed against BIST's 2023 holiday schedule, where the market had no preceding half-day session that year.
- `HolidayCalendarServiceTRY` (BIST/TCMB settlement calendar) is intentionally left out of scope for this change; it has the same Javadoc gap but will be addressed separately.

**Related Issue**

- [#204](https://github.com/holiday-calendar/holiday-calendar-java/issues/204) (part of tracking issue [#203](https://github.com/holiday-calendar/holiday-calendar-java/issues/203))

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed