### PR TITLE
#205 Model NYSE half-day closes (Day After Thanksgiving, Christmas Eve, July 3rd)

### DIFF
--- a/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
+++ b/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
@@ -1,0 +1,211 @@
+# Agent prompt templates
+
+Placeholders: `{ISSUE_NUMBER}`, `{ISSUE_TEXT}` (full `gh issue view` output),
+`{CODE}` (region/exchange code, e.g. `US`), `{HOLIDAY_OR_CHANGE_DESC}` (one
+sentence naming what's being added/changed), `{EXPLORE_FINDINGS}` (Phase 1
+results, summarized), `{RESEARCH_FINDINGS}`, `{ENGINEER_DESIGN}`,
+`{COMBINED_DRAFT}` (research + engineer + test sections concatenated).
+
+Launch each via the `Agent` tool, `subagent_type: general-purpose`,
+`run_in_background: false` — each depends on the prior one's output.
+
+---
+
+## 1. Research analyst
+
+```
+You are acting as a research analyst with expertise in [world equities market
+conventions | regional/cultural holiday conventions — pick whichever fits
+{HOLIDAY_OR_CHANGE_DESC}]. I need you to verify the factual claims in GitHub
+issue #{ISSUE_NUMBER} of this holiday-calendar library against authoritative
+primary sources before an engineer builds on them.
+
+Issue text:
+{ISSUE_TEXT}
+
+Use WebSearch/WebFetch. Prefer the exchange's/authority's own official
+calendar or press releases over secondary aggregators — if a secondary
+source and the primary source disagree, trust the primary source and say so.
+
+I need:
+1. Exact date(s)/rule(s) as officially published — confirm or correct the
+   issue's stated rule. Pay special attention to boundary conditions (e.g.
+   "falls on a Monday" vs "falls Tuesday-Friday" are NOT the same set of
+   days — the issue text has been wrong about exactly this kind of boundary
+   before).
+2. Any conditions under which the holiday/close does NOT occur, and whether
+   in that case it's suppressed entirely for the year or shifted to another
+   date — these are different semantics and matter a lot for implementation.
+3. Exact time/timezone if applicable (IANA zone id, not just an offset).
+4. A multi-year table (at least one full cycle of the relevant day-of-week
+   pattern, typically 7-9 years) of concrete example years with the actual
+   observed date/absence, sourced from primary references, suitable for use
+   as test fixtures.
+5. Cite every source URL you used.
+
+Report structured findings (numbered per point above), flagging explicitly
+anywhere the issue text was imprecise or wrong.
+```
+
+---
+
+## 2. Senior engineer
+
+```
+You are a senior Java engineer (Java 21+) proposing an implementation for
+GitHub issue #{ISSUE_NUMBER} in the holiday-calendar-java repo (multi-module
+Maven, TestNG). Do NOT write code files — produce a detailed implementation
+PLAN a plan document can include verbatim.
+
+Issue: {HOLIDAY_OR_CHANGE_DESC} in HolidayCalendarService{CODE}.
+
+Verified research findings (primary-sourced, treat as ground truth over the
+issue's own text):
+{RESEARCH_FINDINGS}
+
+Codebase context already confirmed by exploration:
+{EXPLORE_FINDINGS}
+
+This repo's reusable conventions to follow:
+- `Holiday.builder()...type(Holiday.Type.X)...build()` — Type values include
+  FIXED, FLOATING, SPECIAL_ANNIVERSARY, EARLY_CLOSE. Pick the one that
+  actually matches the semantics confirmed by research, not the one the
+  issue assumed.
+- For EARLY_CLOSE: `IsraelHolidays.earlyCloseHolidays()` (mena module) is the
+  original pattern; `HolidayCalendarServiceUK`'s Christmas Eve/New Year's Eve
+  is the most recent precedent. Both ALWAYS produce a date (UK shifts
+  weekend dates to the preceding Friday; Israel's Erev holidays are always
+  the day before their anchor). If your research found a "sometimes there is
+  no early close/holiday at all this year" rule, that is a DIFFERENT
+  semantic from either precedent — say so explicitly, and use
+  `AbstractObservance.isValidYear(int)` returning `false` (not a shifting
+  `computeDate`) to represent absence. Note in the new Observance's Javadoc
+  that this is a different use of `isValidYear` than its only other existing
+  use (`WesternEaster`/`OrthodoxEaster`, an algorithm-validity bound, not a
+  business-rule exclusion).
+- Observance classes live in `observance/<lowercase-code>/`, extend
+  `AbstractObservance`, override `computeDate` and (if needed) `isValidYear`.
+  Small single-purpose classes — this repo's precedent (UK) does NOT share a
+  helper between near-identical eligibility checks; follow that unless you
+  have a concrete reason not to.
+- Registration happens in `HolidayCalendarService{CODE}.getHolidayCalendar()`
+  via `Holiday.builder()...build()` then `.holiday(...)` in the
+  `HolidayCalendar.builder()` chain (or `.holidays(list)` if there's a shared
+  factory list like Israel's).
+
+Propose:
+1. Package/class layout — new Observance class(es), and whether any existing
+   Observance needs modification (usually not — only its registration type
+   changes) or reuse.
+2. Exact `computeDate`/`isValidYear` logic (or `test`/`apply` if implementing
+   `Observance` directly), matching the confirmed semantics from research.
+3. Exact new/changed `Holiday.builder()` blocks and `HolidayCalendar.builder()`
+   chain additions for `HolidayCalendarService{CODE}`.
+4. Naming — check for existing naming conventions in this calendar and
+   others; flag if your chosen name is a stylistic outlier (e.g. ordinals,
+   redundant type-suffixes).
+5. Whether `holiday-calendar-core` needs any changes — usually none, if this
+   fits an existing `Holiday.Type`; confirm by reading the relevant core
+   classes rather than assuming.
+6. Breaking-change / migration considerations — does this move a holiday
+   between `calculate()` and `calculateEarlyCloses()`, or change a name any
+   consumer might match on? State the impact plainly. Do not assert
+   CHANGELOG.md conventions without checking `git log -- CHANGELOG.md` and
+   recent precedent commits first.
+
+Report a structured, detailed plan (headers per point above).
+```
+
+---
+
+## 3. Test engineer
+
+```
+You are a test engineer reviewing this proposed implementation for GitHub
+issue #{ISSUE_NUMBER} (holiday-calendar-java, TestNG 7.7.1 with
+@DataProvider). Examine existing test patterns for the relevant holiday type
+in this codebase, identify best practices, and propose concrete tests.
+Do not write code files — produce a test plan section.
+
+Finalized engineering design:
+{ENGINEER_DESIGN}
+
+Verified research fixture data (use this for DataProvider rows, not
+invented dates):
+{RESEARCH_FINDINGS}
+
+This repo's test conventions:
+- `AbstractHolidayCalendarServiceTest` (holiday-calendar-western,
+  org.holiday.calendar.impl) — every `HolidayCalendarService<CODE>Test`
+  extends this; supplies `expectedHolidayNames()` and
+  `expectedHolidayOccurrences()` DataProviders.
+- `AbstractObservanceTest` (org.holiday.calendar.western.test) — every
+  `<Observance>Test` extends this, passing the Observance instance to
+  `super()` and overriding `createData()` with `{year, expectedDateOrNull}`
+  rows.
+- The closest `<Code>EarlyCloseTest`/equivalent precedent class (e.g.
+  `HolidayCalendarServiceUKEarlyCloseTest`) for count/presence/closeTime/
+  zoneId/rollability assertions — adapt for this issue's actual semantics
+  (fixed count vs. variable count per year, always-present vs.
+  sometimes-absent).
+- `tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java` —
+  add a rule-derived (not hand-fixtured) 30-year section if the change is a
+  recurring annual rule, re-deriving expected presence/date from the
+  day-of-week rule for every year in range rather than hardcoding results.
+
+Propose:
+1. New/updated test files — exact paths, one-line purpose each.
+2. Observance unit test(s) — fixture rows from the verified research table,
+   plus 1-2 edge years outside the sampled cycle (compute and verify the
+   actual day-of-week yourself before hardcoding — do not guess).
+3. Any explicitly-named regression test for a boundary case the research
+   analyst flagged as easy to get wrong (e.g. an off-by-one weekday) — this
+   must be a named test, not incidental DataProvider coverage.
+4. Integration-level test class changes/additions (count, presence/absence
+   per holiday name — not just count, since count alone can mask one
+   holiday's presence covering for another's incorrect absence).
+5. `HolidayCalendar30YearIT` addition, if applicable.
+6. Any risk/gap you'd flag (e.g. a date-collision test between this change
+   and an existing rollable holiday landing on the same computed date).
+
+Report a structured plan (headers per point above).
+```
+
+---
+
+## 4. Devil's advocate
+
+```
+You are a devil's advocate reviewer. Below is a draft implementation plan
+(research + engineering + test sections) for GitHub issue #{ISSUE_NUMBER} in
+this holiday-calendar-java repo. Find weaknesses, challenge assumptions, and
+verify claims against the actual codebase — don't just approve. Cite the
+specific claim you're challenging. If something is genuinely fine after
+scrutiny, say so briefly rather than manufacturing a complaint.
+
+{COMBINED_DRAFT}
+
+Specifically check:
+- Does the cited precedent actually support the proposed design, or is it a
+  superficially-similar-but-semantically-different case (e.g. "shifts to
+  another date" vs. "is absent this year" are not the same mechanism, even
+  if both are called EARLY_CLOSE)?
+- Any reused core-abstraction hook (e.g. `isValidYear`) being used for a
+  purpose different from its only other existing use in this codebase — is
+  that a problem, or just worth a comment?
+- Any repo-convention claim (CHANGELOG.md handling, README update rules,
+  versioning) — verify against actual `git log`/recent commits rather than
+  trusting the engineer agent's assertion.
+- Test coverage gaps: does a boundary/edge case the research analyst flagged
+  get an explicitly-named test, or only incidental coverage? Is there a
+  same-date collision risk between the new holiday and an existing rollable
+  holiday that isn't tested?
+- Naming: is the proposed name consistent with this codebase's existing
+  naming conventions, or an outlier worth a second opinion?
+- Anything module-info.java/JPMS-related, or any mismatch between the
+  explored package names and this repo's documented module names.
+
+Report findings as a concise, prioritized list (most important first), each
+with: the specific claim being challenged, why it's a concern, and a
+concrete suggestion or question to resolve it before implementation begins.
+```

--- a/.claude/skills/region-calendar-issue-plan/SKILL.md
+++ b/.claude/skills/region-calendar-issue-plan/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: region-calendar-issue-plan
+description: Turn a GitHub issue about a region/exchange-specific holiday-calendar change (new national/market calendar, new holiday, EARLY_CLOSE/half-day modeling, roll-rule change) into a reviewed implementation plan for this repo, using a 4-agent workflow (research analyst, senior engineer, test engineer, devil's advocate). Use when planning work for a HolidayCalendarService<CODE> change, or any issue that names a specific market/region convention (close times, eligibility rules, observance dates) that must be verified before implementing.
+---
+
+# Region/exchange calendar issue → implementation plan
+
+Produces a written plan (Plan Mode plan file) for a GitHub issue that adds or
+changes holidays in a `HolidayCalendarService<CODE>` in this repo. Do not
+write implementation code from this skill — it only produces the plan.
+Requires: a GitHub issue number, and the region/exchange code (e.g. `US`,
+`UK`, `CHF`) the issue targets. If the user hasn't given both, ask first.
+
+Run this inside Plan Mode. If not already in Plan Mode, invoke `EnterPlanMode`
+before starting.
+
+## Phase 1 — Read the issue, explore the codebase (parallel)
+
+1. `gh issue view <number>` to get the exact requirements text. Do not
+   paraphrase from memory — the issue text itself may contain an incorrect
+   rule (this has happened before; catching it is the research analyst's job
+   in Phase 2).
+2. Launch up to 3 `Explore` agents in parallel:
+   - **Core abstractions**: `Holiday` sealed interface + builder, `Holiday.Type`
+     enum, `Observance`/`AbstractObservance`, `HolidayCalendar.calculate()` /
+     `calculateEarlyCloses()`, and (if the issue is about a half-day/early
+     close) `EarlyCloseHoliday` plus its two real precedents:
+     `IsraelHolidays.earlyCloseHolidays()` (mena module) and
+     `HolidayCalendarServiceUK`'s Christmas Eve/New Year's Eve early closes
+     (western module). Read the actual source, not just names.
+   - **Closest precedent for this specific issue**: find the
+     `HolidayCalendarService<CODE>` and its `observance/<code>/` package for
+     the target region, and the most recently-added holiday of the *same
+     kind* elsewhere in the codebase (another EARLY_CLOSE, another new
+     calendar, another roll-rule change — whichever matches this issue).
+   - **Test infrastructure**: `AbstractHolidayCalendarServiceTest`,
+     `AbstractObservanceTest`, the closest `HolidayCalendarService<CODE>Test`
+     / `<Code>EarlyCloseTest` precedent, and the `tests` module's
+     `HolidayCalendar30YearIT`.
+
+## Phase 2 — Four specialist agents, run sequentially in the foreground
+
+Run in the foreground (`run_in_background: false`) and in this order —
+each later agent depends on the previous one's output, so do not parallelize:
+
+1. **Research analyst** — verifies the issue's factual claims (dates, close
+   times, eligibility rules, timezone) against primary sources (official
+   exchange/market calendars, not secondary aggregators). Must explicitly
+   flag any place the issue text is wrong or imprecise, and produce a
+   multi-year fixture table an engineer/tester can build from.
+2. **Senior engineer** — given the research findings and Phase 1 codebase
+   context, proposes concrete classes/files, registration changes, naming,
+   and states plainly whether core-module changes are needed (usually none
+   are, if this fits an existing `Holiday.Type`). Must not assume the closest
+   precedent's *mechanism* transfers unchanged — state explicitly what's the
+   same and what's different (e.g. "shift to nearest weekday" vs "suppress
+   entirely in some years" are different semantics that look similar).
+3. **Test engineer** — given the engineer's finalized design, proposes new
+   test files/methods grounded in the research analyst's fixture table,
+   reusing `AbstractObservanceTest`/`AbstractHolidayCalendarServiceTest` and
+   proposing a `HolidayCalendar30YearIT` addition if the change is long-lived.
+4. **Devil's advocate** — given the combined draft (research + engineering +
+   test sections), actively looks for holes: mismatched precedent semantics,
+   unverified assumptions, missing edge-year coverage, breaking-change
+   handling, and repo-convention claims that aren't actually true (verify
+   against real commit history, e.g. whether CHANGELOG.md is actually
+   updated per-PR or only at release — check, don't assume either way).
+
+Prompt templates for all four agents: see [AGENT_PROMPTS.md](AGENT_PROMPTS.md).
+
+## Phase 3 — Resolve findings, don't just collect them
+
+Every devil's-advocate finding must be resolved before the plan is written,
+not appended as a footnote:
+- If it's a factual question only the user can answer (naming preference,
+  version/release targeting, scope) → `AskUserQuestion`.
+- If it's a verifiable claim (e.g. "does this repo actually update
+  CHANGELOG.md per PR?") → check it yourself (`git log`, `git show` on the
+  closest precedent commits) and correct the plan.
+- If it's a design concern → make the call and state the reasoning in the
+  plan; don't leave it open.
+
+## Phase 4 — Write the plan and exit
+
+Write the plan file with these sections (see the `#205` NYSE half-day-close
+plan in this repo's history for a worked example of this shape):
+- **Context** — why this change, what precedent it follows, what is
+  genuinely different from that precedent (don't overstate similarity).
+- **Implementation** — concrete new/changed files, registration blocks,
+  naming decisions, explicit "no core-module changes needed" confirmation
+  (or what's needed if not).
+- **Tests** — concrete new/updated test files, fixture tables sourced from
+  the research analyst's verified data, and any `HolidayCalendar30YearIT`
+  addition.
+- **Verification** — the `mvn` commands to run before considering this done.
+
+Call `ExitPlanMode` once the plan is written and any open questions are
+resolved.

--- a/.gitignore
+++ b/.gitignore
@@ -98,14 +98,21 @@ local.properties
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
+
+# Other per-developer IntelliJ files not covered above (this project uses
+# Maven with auto-import; .idea/copyright/ is intentionally tracked for
+# shared license-header settings)
+.idea/encodings.xml
+.idea/vcs.xml
+.idea/sonarlint.xml
 
 # CMake
 cmake-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -243,4 +243,6 @@ gradle-app.setting
 # JDT-specific (Eclipse Java Development Tools)
 
 ### Claude Code ###
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,19 +33,21 @@ This is a multi-module Maven project:
 
 | Module | JPMS Module Name | Purpose |
 |--------|------------------|---------|
-| `holiday-calendar-core` | `holiday.calendar.core` | Core API and abstractions |
-| `holiday-calendar-western` | `holiday.calendar.western` | Western calendars: US, CA, UK, CH, DE, FR, AU |
-| `holiday-calendar-apac` | `holiday.calendar.apac` | APAC calendars: SG (uses Time4J for non-Gregorian) |
+| `holiday-calendar-core` | `org.holiday.calendar.core` | Core API and abstractions |
+| `holiday-calendar-western` | `org.holiday.calendar.western` | Western calendars: US, CA, UK, CH, DE, FR, AU |
+| `holiday-calendar-apac` | `org.holiday.calendar.apac` | APAC calendars: SG, JP, CN (uses Time4J for non-Gregorian) |
+| `holiday-calendar-mena` | `org.holiday.calendar.mena` | MENA calendars: AE, SA, IL, TR, QA, EG, KW, BH, MA, JO (uses Time4J for Islamic calendar) |
 | `tests` | — | Test aggregation and JaCoCo coverage reporting for SonarCloud |
 
 ## Architecture
 
 ### Core Abstractions (`holiday-calendar-core`)
 
-**`Holiday`** (sealed interface) — base for all holidays; three permitted types selected via builder:
+**`Holiday`** (sealed interface) — base for all holidays; four permitted types selected via builder:
 - `FixedHoliday` — same `MonthDay` every year (e.g., New Year's Day)
 - `FloatingHoliday` — date computed per year via an `Observance` function (e.g., Easter)
 - `SpecialAnniversary` — anniversary-based holidays
+- `EarlyCloseHoliday` — half-day market close (`Holiday.Type.EARLY_CLOSE`); carries a `closeTime`/`zoneId`, is always non-rollable, and is excluded from `HolidayCalendar.calculate()` — use `calculateEarlyCloses(int year)` instead. See `IsraelHolidays.earlyCloseHolidays()` (mena) and `HolidayCalendarServiceUK`'s Christmas Eve/New Year's Eve (western) for precedent.
 
 **`HolidayCalendar`** — named collection of holidays with a `DateRoll` strategy and configurable `weekendDays`. Its `calculate(int year)` returns sorted `HolidayDate` instances with rolling applied (respects the `rollable` flag per holiday).
 
@@ -63,10 +65,37 @@ This is a multi-module Maven project:
 
 ### Implementations (`holiday-calendar-western`)
 
-Regional `HolidayCalendarService` implementations: `HolidayCalendarServiceUS`, `HolidayCalendarServiceCA`, `HolidayCalendarServiceUK`, `HolidayCalendarServiceCH`, `HolidayCalendarServiceDE`, `HolidayCalendarServiceFR`, `HolidayCalendarServiceAU`.
+National and market/central-bank `HolidayCalendarService` implementations, one pair per country where both exist:
+- `US` (United States National) / `USD` (Federal Reserve)
+- `CA` (Canada National) / `CAD` (Bank of Canada / Lynx)
+- `UK` (United Kingdom National) / `GBP` (CHAPS)
+- `CH` (Switzerland / SIX) / `CHF` (SIC/SNB)
+- `DE` (Germany / Xetra)
+- `FR` (France / Euronext Paris)
+- `AU` (Australian Securities Exchange) / `AUD` (RBA)
+- `EUR` (TARGET2)
 
 Observances are organized by region under the `observance` package. Easter-related observances live in `observance.christian` and extend `CompositeObservance` (e.g., `GoodFriday`, `EasterMonday`). `WesternEaster` and `OrthodoxEaster` extend `AbstractObservance` directly. Regional sub-packages: `us/`, `ca/`, `uk/`, `eu/`, `au/`.
 
 ### Implementations (`holiday-calendar-apac`)
 
-`HolidayCalendarServiceSG` (SGX). Non-Gregorian holidays use Time4J (`ChineseCalendar` for Chinese New Year) or lookup tables (Vesak Day, Hari Raya Puasa/Haji, Deepavali).
+- `SG` (Singapore SGX) / `SGD` (MAS/MEPS+)
+- `JP` (Tokyo Stock Exchange) / `JPY` (Bank of Japan)
+- `CN` (China National) / `CNY` (People's Bank of China)
+
+Non-Gregorian holidays use Time4J (`ChineseCalendar` for Chinese New Year) or lookup tables (Vesak Day, Hari Raya Puasa/Haji, Deepavali). Observance sub-packages: `observance.lunar`, `observance.islamic.apac`, `observance.hindu`, `observance.jp`.
+
+### Implementations (`holiday-calendar-mena`)
+
+- `AE` (United Arab Emirates National) / `AED` (CBUAE/DFM/ADX)
+- `SA` (Saudi Arabia National) / `SAR` (Tadawul/SAMA)
+- `IL` (Israel National) / `ILS` (TASE/Bank of Israel)
+- `TR` (Turkey National) / `TRY` (BIST/TCMB)
+- `QA` (Qatar National) / `QAR` (QSE/QCB)
+- `EG` (Egypt National) / `EGP` (EGX/CBE)
+- `KW` (Kuwait National) / `KWD` (Boursa Kuwait/CBK)
+- `BH` (Bahrain National) / `BHD` (Boursa Bahrain/CBB)
+- `MA` (Morocco National) / `MAD` (CSE/BAM)
+- `JO` (Jordan National) / `JOD` (ASE/CBJ)
+
+Islamic-calendar holidays (Eid al-Fitr, Eid al-Adha, Islamic New Year, Ashura, etc.) use CSV-backed lookup data with a Diyanet "ilmi takvim" astronomical fallback calculator for years beyond the data ceiling; see `observance.islamic.mena`. `IsraelHolidays` (package-private) centralizes the shared holiday list — including `earlyCloseHolidays()` — consumed by both `HolidayCalendarServiceIL` and `HolidayCalendarServiceILS`. Observance sub-packages: `observance.eg`, `observance.islamic.mena`, `observance.hebrew`, `observance.qa`.

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
@@ -27,7 +27,9 @@ import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.us.*;
 
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 /**
  * Service for provision of US national holiday calendar.
@@ -126,11 +128,33 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                             .build();
         final Holiday dayAfterThanksgiving = Holiday.builder()
                                                      .name("Day After Thanksgiving")
-                                                     .description("Day after Thanksgiving (NYSE market closure by convention)")
-                                                     .type(Holiday.Type.FLOATING)
+                                                     .description("NYSE 1:00pm ET early close, the day after Thanksgiving")
+                                                     .type(Holiday.Type.EARLY_CLOSE)
                                                      .rollable(false)
                                                      .observance(new DayAfterThanksgiving())
+                                                     .closeTime(LocalTime.of(13, 0))
+                                                     .zoneId(ZoneId.of("America/New_York"))
                                                      .build();
+        final Holiday julyThirdEarlyClose = Holiday.builder()
+                                                    .name("July 3rd")
+                                                    .description("NYSE 1:00pm ET early close; occurs only when " +
+                                                                 "July 4 falls Tuesday through Friday")
+                                                    .type(Holiday.Type.EARLY_CLOSE)
+                                                    .rollable(false)
+                                                    .observance(new JulyThirdEarlyClose())
+                                                    .closeTime(LocalTime.of(13, 0))
+                                                    .zoneId(ZoneId.of("America/New_York"))
+                                                    .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                                                       .name("Christmas Eve")
+                                                       .description("NYSE 1:00pm ET early close; occurs only when " +
+                                                                    "December 25 falls Tuesday through Friday")
+                                                       .type(Holiday.Type.EARLY_CLOSE)
+                                                       .rollable(false)
+                                                       .observance(new ChristmasEveEarlyClose())
+                                                       .closeTime(LocalTime.of(13, 0))
+                                                       .zoneId(ZoneId.of("America/New_York"))
+                                                       .build();
         final Holiday christmasDay = Holiday.builder()
                                             .name("Christmas Day")
                                             .description("Celebration of traditional Christmas holiday")
@@ -154,11 +178,13 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                 .holiday(memorialDay)
                 .holiday(juneteenth)
                 .holiday(independenceDay)
+                .holiday(julyThirdEarlyClose)
                 .holiday(laborDay)
                 .holiday(columbusDay)
                 .holiday(veteransDay)
                 .holiday(thanksgiving)
                 .holiday(dayAfterThanksgiving)
+                .holiday(christmasEveEarlyClose)
                 .holiday(christmasDay)
                 .build();
     }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
@@ -40,6 +40,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
 
     private static final String CODE = "US";
     private static final String NAME = "United States National Holidays";
+    private static final ZoneId NYSE_ZONE = ZoneId.of("America/New_York");
 
     public HolidayCalendarServiceUS() {
         super(CODE, NAME);
@@ -133,7 +134,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                                      .rollable(false)
                                                      .observance(new DayAfterThanksgiving())
                                                      .closeTime(LocalTime.of(13, 0))
-                                                     .zoneId(ZoneId.of("America/New_York"))
+                                                     .zoneId(NYSE_ZONE)
                                                      .build();
         final Holiday julyThirdEarlyClose = Holiday.builder()
                                                     .name("July 3rd")
@@ -143,7 +144,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                                     .rollable(false)
                                                     .observance(new JulyThirdEarlyClose())
                                                     .closeTime(LocalTime.of(13, 0))
-                                                    .zoneId(ZoneId.of("America/New_York"))
+                                                    .zoneId(NYSE_ZONE)
                                                     .build();
         final Holiday christmasEveEarlyClose = Holiday.builder()
                                                        .name("Christmas Eve")
@@ -153,7 +154,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                                        .rollable(false)
                                                        .observance(new ChristmasEveEarlyClose())
                                                        .closeTime(LocalTime.of(13, 0))
-                                                       .zoneId(ZoneId.of("America/New_York"))
+                                                       .zoneId(NYSE_ZONE)
                                                        .build();
         final Holiday christmasDay = Holiday.builder()
                                             .name("Christmas Day")

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/ChristmasEveEarlyClose.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the NYSE's Christmas Eve half-day close (December 24). Unlike
+ * a weekend-shifting observance, this early close does not occur at all in
+ * years where December 25 falls on a Monday, Saturday, or Sunday — it is
+ * suppressed for that year rather than moved to an adjacent date. This is why
+ * {@link #isValidYear(int)} is overridden here to signal absence, rather than
+ * {@link #computeDate(int)} shifting to a different day as
+ * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose} does.
+ *
+ * <p>Verified against NYSE Group's official Holiday and Early Closings
+ * Calendar press releases (ir.theice.com): December 24 is an early close only
+ * when December 25 falls Tuesday through Friday.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasDay = LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek();
+        return switch (christmasDay) {
+            case MONDAY, SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/JulyThirdEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/JulyThirdEarlyClose.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the NYSE's July 3rd half-day close, ahead of Independence
+ * Day. This early close does not occur at all in years where July 4 falls on
+ * a Monday, Saturday, or Sunday — it is suppressed for that year rather than
+ * moved to an adjacent date. Note in particular that a Monday July 4 also
+ * suppresses this early close (July 3 would be a Sunday, not a trading day),
+ * not just Saturday/Sunday.
+ *
+ * <p>Verified against NYSE Group's official Holiday and Early Closings
+ * Calendar press releases (ir.theice.com): July 3 is an early close only when
+ * July 4 falls Tuesday through Friday.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class JulyThirdEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.JULY, 3);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek independenceDay = LocalDate.of(year, Month.JULY, 4).getDayOfWeek();
+        return switch (independenceDay) {
+            case MONDAY, SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSEarlyCloseTest.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.us.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.us.DayAfterThanksgiving;
+import org.holiday.calendar.observance.us.JulyThirdEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code US} calendar's early-close (NYSE half-day closure)
+ * holidays: Day After Thanksgiving (unconditional), Christmas Eve, and July
+ * 3rd (both conditional on the day-of-week of their anchor holiday). Unlike
+ * the UK's early closes, which always occur exactly twice per year, the US
+ * count varies from 1 to 3 depending on where Dec 25 / Jul 4 fall — so this
+ * test asserts explicit per-holiday presence/absence per year, not just a
+ * fixed count.
+ */
+public class HolidayCalendarServiceUSEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("America/New_York");
+
+    // 12 full-day holidays in calculate() once Day After Thanksgiving moves to EARLY_CLOSE
+    // (13 holidays registered total, minus 1 EarlyCloseHoliday excluded by calculate()).
+    private static final int FULL_DAY_HOLIDAY_COUNT = 12;
+
+    private final HolidayCalendarServiceUS service = new HolidayCalendarServiceUS();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2019-2027 NYSE cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "usEarlyCloseFixture")
+    public Iterator<Object[]> usEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2019, true, true, 3},
+                new Object[]{2020, false, true, 2},
+                new Object[]{2021, false, false, 1},
+                new Object[]{2022, false, false, 1},
+                new Object[]{2023, true, false, 2},
+                new Object[]{2024, true, true, 3},
+                new Object[]{2025, true, true, 3},
+                new Object[]{2026, false, true, 2},
+                new Object[]{2027, false, false, 1}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), expectedCount, "US " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testJulyThirdPresenceForYear(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        Set<String> names = earlyCloseNames(year);
+        assertEquals(names.contains("July 3rd"), july3Present,
+                "US " + year + ": July 3rd presence must match July 4 day-of-week rule");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testChristmasEveEarlyClosePresenceForYear(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        Set<String> names = earlyCloseNames(year);
+        assertEquals(names.contains("Christmas Eve"), dec24Present,
+                "US " + year + ": Christmas Eve presence must match December 25 day-of-week rule");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testDayAfterThanksgivingAlwaysPresent(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        assertTrue(earlyCloseNames(year).contains("Day After Thanksgiving"),
+                "US " + year + ": Day After Thanksgiving must always be present");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testDayAfterThanksgivingCloseIsAlwaysFriday(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        HolidayDate matched = service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .filter(hd -> "Day After Thanksgiving".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Day After Thanksgiving not found in " + year));
+        assertEquals(matched.getDate().getDayOfWeek(), DayOfWeek.FRIDAY);
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    // -------------------------------------------------------------------------
+    // Monday-exclusion regression cases (issue text incorrectly said "Monday-Friday")
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testJulyThirdSuppressedWhenJuly4IsMonday() {
+        // 2022: July 4 = Monday.
+        Set<String> names = earlyCloseNames(2022);
+        assertFalse(names.contains("July 3rd"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedWhenDecember25IsMonday() {
+        // 2023: December 25 = Monday.
+        Set<String> names = earlyCloseNames(2023);
+        assertFalse(names.contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testAllEarlyCloses_CloseTimeIs13_00() {
+        for (int year : List.of(2021, 2024)) { // one 1-count year, one 3-count year
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 13:00");
+            }
+        }
+    }
+
+    @Test
+    public void testAllEarlyCloses_ZoneId_IsNewYork() {
+        for (int year : List.of(2021, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in America/New_York");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyCloses_NotRollable() {
+        for (int year : List.of(2021, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCount_Unchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // No date appears in both calculate() and calculateEarlyCloses() for the same year
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+        assertTrue(intersection.isEmpty(),
+                "US " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Day After Thanksgiving", 2021},
+                new Object[]{"Day After Thanksgiving", 2024},
+                new Object[]{"July 3rd", 2019},
+                new Object[]{"July 3rd", 2023},
+                new Object[]{"July 3rd", 2024},
+                new Object[]{"Christmas Eve", 2019},
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2025}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Day After Thanksgiving" -> new DayAfterThanksgiving().apply(year);
+            case "July 3rd" -> new JulyThirdEarlyClose().apply(year);
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSTest.java
@@ -1,11 +1,19 @@
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendarService;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertFalse;
 
 public class HolidayCalendarServiceUSTest extends AbstractHolidayCalendarServiceTest {
 
@@ -40,6 +48,22 @@ public class HolidayCalendarServiceUSTest extends AbstractHolidayCalendarService
         final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
         return Arrays.asList(veteransDay18, veteransDay19, veteransDay20, veteransDay21, veteransDay22, veteransDay23,
                              christmas18, christmas19, christmas20, christmas21, christmas22, christmas23).listIterator();
+    }
+
+    @Test
+    public void testEarlyCloseHolidaysAbsentFromCalculate() {
+        HolidayCalendarService service = factory.getService(CODE);
+        Set<String> earlyCloseNames = Set.of("Day After Thanksgiving", "Christmas Eve", "July 3rd");
+        for (int year : List.of(2021, 2023, 2024, 2025)) { // mix of 1/2/3-count early-close years
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            Set<String> actualNames = holidays.stream()
+                    .map(hd -> hd.getHoliday().getName())
+                    .collect(Collectors.toSet());
+            for (String earlyCloseName : earlyCloseNames) {
+                assertFalse(actualNames.contains(earlyCloseName),
+                        earlyCloseName + " must not appear in calculate(" + year + ")");
+            }
+        }
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 24) }); // Dec 25 Wed -> eligible
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 25 Fri -> eligible
+        data.add(new Object[]{ 2021, null });                                   // Dec 25 Sat -> ineligible
+        data.add(new Object[]{ 2022, null });                                   // Dec 25 Sun -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 25 Mon -> ineligible (Monday-exclusion case)
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 25 Wed -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 25 Thu -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 25 Fri -> eligible
+        data.add(new Object[]{ 2027, null });                                   // Dec 25 Sat -> ineligible
+        data.add(new Object[]{ 2000, null });                                   // Dec 25 2000 Mon -> ineligible, edge year
+        data.add(new Object[]{ 2099, LocalDate.of(2099, Month.DECEMBER, 24) }); // Dec 25 2099 Fri -> eligible, edge year
+        return data;
+    }
+
+    @Test
+    public void testSuppressedWhenChristmasDayIsMonday() {
+        // 2023: December 25 falls on a Monday. Must be ineligible — the issue text's
+        // "Monday through Friday" claim was incorrect; the verified NYSE rule excludes Monday.
+        assertNull(observance.apply(2023));
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/DayAfterThanksgivingTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/DayAfterThanksgivingTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DayAfterThanksgivingTest extends AbstractObservanceTest {
+
+    public DayAfterThanksgivingTest() {
+        super(new DayAfterThanksgiving());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 1978, LocalDate.of(1978, Month.NOVEMBER, 24) });
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.NOVEMBER, 26) });
+        data.add(new Object[]{ 2022, LocalDate.of(2022, Month.NOVEMBER, 25) });
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.NOVEMBER, 29) });
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.NOVEMBER, 28) });
+
+        return data;
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/JulyThirdEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/JulyThirdEarlyCloseTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNull;
+
+public class JulyThirdEarlyCloseTest extends AbstractObservanceTest {
+
+    public JulyThirdEarlyCloseTest() {
+        super(new JulyThirdEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.JULY, 3) });  // Jul 4 Thu -> eligible
+        data.add(new Object[]{ 2020, null });                                // Jul 4 Sat -> ineligible
+        data.add(new Object[]{ 2021, null });                                // Jul 4 Sun -> ineligible
+        data.add(new Object[]{ 2022, null });                                // Jul 4 Mon -> ineligible (Monday-exclusion case)
+        data.add(new Object[]{ 2023, LocalDate.of(2023, Month.JULY, 3) });   // Jul 4 Tue -> eligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.JULY, 3) });   // Jul 4 Thu -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.JULY, 3) });   // Jul 4 Fri -> eligible
+        data.add(new Object[]{ 2026, null });                                // Jul 4 Sat -> ineligible
+        data.add(new Object[]{ 2027, null });                                // Jul 4 Sun -> ineligible
+        data.add(new Object[]{ 2000, LocalDate.of(2000, Month.JULY, 3) });   // Jul 4 2000 Tue -> eligible, edge year
+        data.add(new Object[]{ 2099, null });                                // Jul 4 2099 Sat -> ineligible, edge year
+        return data;
+    }
+
+    @Test
+    public void testSuppressedWhenIndependenceDayIsMonday() {
+        // 2022: July 4 falls on a Monday. Must be ineligible — the issue text's
+        // "Monday through Friday" claim was incorrect; the verified NYSE rule excludes Monday.
+        assertNull(observance.apply(2022));
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -284,16 +284,16 @@ public class HolidayCalendar30YearIT {
                     "US " + year + ": Day After Thanksgiving must always be present");
 
             DayOfWeek july4Dow = LocalDate.of(year, Month.JULY, 4).getDayOfWeek();
-            boolean july3Expected = july4Dow != DayOfWeek.MONDAY
-                    && july4Dow != DayOfWeek.SATURDAY
-                    && july4Dow != DayOfWeek.SUNDAY;
+            boolean july3Expected = !DayOfWeek.MONDAY.equals(july4Dow)
+                    && !DayOfWeek.SATURDAY.equals(july4Dow)
+                    && !DayOfWeek.SUNDAY.equals(july4Dow);
             assertEquals(names.contains("July 3rd"), july3Expected,
                     "US " + year + ": July 3rd presence must match July 4 dow rule (dow=" + july4Dow + ")");
 
             DayOfWeek dec25Dow = LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek();
-            boolean dec24Expected = dec25Dow != DayOfWeek.MONDAY
-                    && dec25Dow != DayOfWeek.SATURDAY
-                    && dec25Dow != DayOfWeek.SUNDAY;
+            boolean dec24Expected = !DayOfWeek.MONDAY.equals(dec25Dow)
+                    && !DayOfWeek.SATURDAY.equals(dec25Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec25Dow);
             assertEquals(names.contains("Christmas Eve"), dec24Expected,
                     "US " + year + ": Christmas Eve presence must match December 25 dow rule (dow=" + dec25Dow + ")");
 

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -21,10 +21,14 @@ package org.holiday.calendar;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.*;
 
@@ -246,6 +250,68 @@ public class HolidayCalendar30YearIT {
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
                     "UK: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
+    // =========================================================================
+    // 7. US EARLY CLOSES (NYSE half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Day After Thanksgiving is unconditional; Christmas Eve / July 3rd are suppressed
+    // (not shifted) when their anchor holiday falls Monday, Saturday, or Sunday. Count
+    // therefore varies 1-3 per year, so expected presence is re-derived from the
+    // day-of-week rule for every year rather than hand-fixtured.
+    @Test(description = "US calculateEarlyCloses across 2026-2055: count always in [1,3], "
+            + "Day After Thanksgiving always present, July 3rd/Christmas Eve presence "
+            + "correlates exactly with July 4/December 25 day-of-week, no nulls, chronological order")
+    public void testUSEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("US");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "US: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count >= 1 && count <= 3,
+                    "US " + year + ": expected count in [1,3], got " + count);
+
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertTrue(names.contains("Day After Thanksgiving"),
+                    "US " + year + ": Day After Thanksgiving must always be present");
+
+            DayOfWeek july4Dow = LocalDate.of(year, Month.JULY, 4).getDayOfWeek();
+            boolean july3Expected = july4Dow != DayOfWeek.MONDAY
+                    && july4Dow != DayOfWeek.SATURDAY
+                    && july4Dow != DayOfWeek.SUNDAY;
+            assertEquals(names.contains("July 3rd"), july3Expected,
+                    "US " + year + ": July 3rd presence must match July 4 dow rule (dow=" + july4Dow + ")");
+
+            DayOfWeek dec25Dow = LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek();
+            boolean dec24Expected = dec25Dow != DayOfWeek.MONDAY
+                    && dec25Dow != DayOfWeek.SATURDAY
+                    && dec25Dow != DayOfWeek.SUNDAY;
+            assertEquals(names.contains("Christmas Eve"), dec24Expected,
+                    "US " + year + ": Christmas Eve presence must match December 25 dow rule (dow=" + dec25Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "US: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "US: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "US: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "US: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
         }
     }


### PR DESCRIPTION
### Title of the PR

Model NYSE half-day closes (Day After Thanksgiving, Christmas Eve, July 3rd)

**Description**

- Converts `HolidayCalendarServiceUS`'s "Day After Thanksgiving" from a full `FLOATING` holiday to an `EARLY_CLOSE` (NYSE 1:00pm ET), matching the fact that it's a half-day, not a full closure.
- Adds two new `EARLY_CLOSE` holidays: Christmas Eve (Dec 24) and July 3rd — both 1:00pm ET, and both *conditional*: they are suppressed entirely (not shifted to another day) in years where December 25 / July 4 falls on a Monday, Saturday, or Sunday.
- Verified against NYSE Group's official Holiday and Early Closings Calendar press releases (ir.theice.com), 2019–2027. This also corrects the original issue text, which said eligibility was "July 4 falls Monday–Friday" — the actual rule excludes Monday too, since a Monday July 4/Dec 25 means the eve falls on a non-trading Sunday.
- Follows the `IsraelHolidays.earlyCloseHolidays()` / UK `ChristmasEveEarlyClose` pattern (builder with `.type(EARLY_CLOSE)`, `.rollable(false)`, dedicated `Observance` per date rule, `.closeTime(...)`, `.zoneId(...)`), adapted for the new case where an early close can be entirely absent in a given year rather than shifted, via `AbstractObservance.isValidYear(int)`.
- No `holiday-calendar-core` changes were needed — the existing `EarlyCloseHoliday`/`calculateEarlyCloses()` machinery already handles a `null` observance result correctly (entry is simply omitted for that year).

**Breaking change**

`Day After Thanksgiving` currently appears in `HolidayCalendar.calculate(year)` (as a `FLOATING` holiday). After this change it is excluded from `calculate(year)` (as `calculate()` filters out all `EarlyCloseHoliday` instances) and appears only in `calculateEarlyCloses(year)`. Any consumer relying on `calculate()` including this holiday will see one fewer entry. This is a semantic correction (it always was a half-day, not a full closure), targeted at the in-progress `2.0.0` major release.

**Related Issue**

- #205 (part of #203)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally (`mvn clean verify`)
- [ ] Documentation has been updated, if needed — README's calendar table only lists calendar codes/names, not per-holiday detail, so no change needed there; a CHANGELOG.md entry is added at release time per this repo's convention (not per-PR, per precedent from #207/#208)
- [x] Screenshots or additional notes added, if needed — see verified 9-year fixture table below

**Verified NYSE fixture table (2019–2027)**

| Year | July 4 dow | July 3 early close | Dec 25 dow | Dec 24 early close |
|---|---|---|---|---|
| 2019 | Thu | Jul 3 | Wed | Dec 24 |
| 2020 | Sat | none | Fri | Dec 24 |
| 2021 | Sun | none | Sat | none |
| 2022 | Mon | none | Sun | none |
| 2023 | Tue | Jul 3 | Mon | none (Monday-exclusion case) |
| 2024 | Thu | Jul 3 | Wed | Dec 24 |
| 2025 | Fri | Jul 3 | Thu | Dec 24 |
| 2026 | Sat | none | Fri | Dec 24 |
| 2027 | Sun | none | Sat | none |