### PR TITLE
#206 Model TSX Christmas Eve half-day close for CA

### DIFF
--- a/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
+++ b/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
@@ -92,6 +92,22 @@ This repo's reusable conventions to follow:
   via `Holiday.builder()...build()` then `.holiday(...)` in the
   `HolidayCalendar.builder()` chain (or `.holidays(list)` if there's a shared
   factory list like Israel's).
+- SonarCloud rule S8696 (never use `==`/`!=` to compare value-based types —
+  `DayOfWeek`, `Month`, `LocalDate`, etc. — always use `.equals()`) has been
+  flagged and fixed on multiple prior PRs (#204/TR, #205/US, #206/CA) as a
+  CRITICAL reliability bug. Any new code you propose must use `.equals()` for
+  these comparisons from the start (e.g.
+  `DayOfWeek.SATURDAY.equals(someDate.getDayOfWeek())`, not
+  `someDate.getDayOfWeek() == DayOfWeek.SATURDAY`). Critically, SonarCloud's
+  PR analysis re-flags **pre-existing** violations anywhere in a file the PR
+  touches — not just the changed lines — as "new" issues that fail the
+  quality gate. This bit the #206/CA PR: a latent `==` comparison in
+  `HolidayCalendarServiceCA`'s existing `dateRoll` lambda, untouched by that
+  PR's own diff, still failed CI once the file was modified elsewhere. So:
+  when your plan modifies an existing `HolidayCalendarService{CODE}` or
+  `Observance` file, explicitly grep that whole file for `==`/`!=` comparisons
+  against `DayOfWeek`/`Month`/`LocalDate`/other value-based types and include
+  fixing any you find as part of the plan, even if unrelated to this issue.
 
 Propose:
 1. Package/class layout — new Observance class(es), and whether any existing
@@ -112,6 +128,12 @@ Propose:
    consumer might match on? State the impact plainly. Do not assert
    CHANGELOG.md conventions without checking `git log -- CHANGELOG.md` and
    recent precedent commits first.
+7. SonarCloud S8696 sweep — for every existing file this plan modifies (not
+   just newly-created files), report whether you grepped it for `==`/`!=`
+   comparisons against `DayOfWeek`/`Month`/`LocalDate`/other value-based
+   types, and list any found (with line numbers) as required fixes alongside
+   the feature change, so CI doesn't fail on a pre-existing issue the PR
+   incidentally surfaces.
 
 Report a structured, detailed plan (headers per point above).
 ```

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
@@ -172,7 +172,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                     final boolean isNewYearsDay = newYearsDayDate.isPresent() && dateToRoll.equals(newYearsDayDate.get());
                     final boolean isCanadaDay = canadaDayDate.isPresent() && dateToRoll.equals(canadaDayDate.get());
                     final boolean isRemembranceDay = remembranceDayDate.isPresent() && dateToRoll.equals(remembranceDayDate.get());
-                    if (dateToRoll.getDayOfWeek() == DayOfWeek.SUNDAY) {
+                    if (DayOfWeek.SUNDAY.equals(dateToRoll.getDayOfWeek())) {
                         return (isNewYearsDay || isCanadaDay || isRemembranceDay) ? dateToRoll.plusDays(1L) : dateToRoll;
                     }
                     return dateToRoll;

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
@@ -25,6 +25,7 @@ import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.ca.ChristmasEveEarlyClose;
 import org.holiday.calendar.observance.ca.CivicHoliday;
 import org.holiday.calendar.observance.ca.FamilyDay;
 import org.holiday.calendar.observance.ca.LabourDay;
@@ -33,7 +34,9 @@ import org.holiday.calendar.observance.ca.VictoriaDay;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
@@ -47,6 +50,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
 
     private static final String CODE = "CA";
     private static final String NAME = "Canada National Holidays";
+    private static final ZoneId TSX_ZONE = ZoneId.of("America/Toronto");
 
     public HolidayCalendarServiceCA() {
         super(CODE, NAME);
@@ -133,6 +137,16 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .monthDay(Month.NOVEMBER, 11)
                 .rollable(true)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("TSX 1:00pm local early close; occurs whenever "
+                             + "December 24 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(13, 0))
+                .zoneId(TSX_ZONE)
+                .build();
         final Holiday christmas = Holiday.builder()
                 .name("Christmas Day")
                 .description("Christmas Day")
@@ -175,6 +189,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .holiday(nationalDayForTruthAndReconciliation)
                 .holiday(thanksgiving)
                 .holiday(remembranceDay)
+                .holiday(christmasEveEarlyClose)
                 .holiday(christmas)
                 .holiday(boxingDay)
                 .build();

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyClose.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Toronto Stock Exchange's Christmas Eve half-day close
+ * (December 24). Unlike {@code org.holiday.calendar.observance.us.ChristmasEveEarlyClose}
+ * — whose eligibility is keyed off December 25's day of week — TSX's rule is
+ * keyed directly off December 24 itself: the early close applies whenever
+ * December 24 falls Monday through Friday, and is suppressed entirely (not
+ * shifted, unlike {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose})
+ * when December 24 falls on a weekend. This is why {@link #isValidYear(int)}
+ * is overridden here to signal absence in ineligible years, rather than
+ * {@link #computeDate(int)} shifting to a different day.
+ *
+ * <p>Note this differs from the only other pre-existing use of
+ * {@link #isValidYear(int)} in this codebase ({@code WesternEaster} /
+ * {@code OrthodoxEaster}), where it bounds algorithm validity rather than
+ * encoding a business-calendar exclusion — the same mechanism, two different
+ * purposes.
+ *
+ * <p>Verified against TMX Group's official Holiday Operating Schedule
+ * (tsx.com trading calendar / TMX PDF schedules), 2017-2026. Confirmed
+ * divergence from NYSE convention in 2021: December 25, 2021 fell on a
+ * Saturday (which would suppress NYSE's Dec 24 early close), yet December 24,
+ * 2021 fell on a Friday and TSX held its early close that day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCAEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCAEarlyCloseTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.ca.ChristmasEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code CA} calendar's early-close (TSX half-day closure)
+ * holiday: Christmas Eve. Unlike US's Christmas Eve early close (keyed off
+ * December 25's day of week), CA registers exactly one EARLY_CLOSE holiday,
+ * so the count per year is either 0 or 1 — never more than one.
+ */
+public class HolidayCalendarServiceCAEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("America/Toronto");
+
+    // 13 full-day holidays registered in HolidayCalendarServiceCA; Christmas Eve is the
+    // only EARLY_CLOSE holiday and is excluded by calculate(), so calculate() sees 13.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 13;
+
+    private final HolidayCalendarServiceCA service = new HolidayCalendarServiceCA();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2017-2026 TSX cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "caEarlyCloseFixture")
+    public Iterator<Object[]> caEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2017, false},
+                new Object[]{2018, true},
+                new Object[]{2019, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 1 : 0, "CA " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "CA " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    // -------------------------------------------------------------------------
+    // Suppressed-year sanity checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasEveSuppressedIn2022() {
+        // 2022: December 25 = Sunday, December 24 = Saturday.
+        assertFalse(earlyCloseNames(2022).contains("Christmas Eve"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedIn2023() {
+        // 2023: December 25 = Monday, December 24 = Sunday.
+        assertFalse(earlyCloseNames(2023).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // NYSE-divergence regression case
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTsxClosesEarlyIn2021DespiteNyseStyleRuleSuppressing() {
+        // 2021: December 25 = Saturday, December 24 = Friday. NYSE's rule (keyed off
+        // Dec 25) would suppress this year; TSX's rule (keyed off Dec 24) does not.
+        assertTrue(earlyCloseNames(2021).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs13_00() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 13:00");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsAmericaToronto() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in America/Toronto");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyCloseNotRollable() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // No date appears in both calculate() and calculateEarlyCloses() for the same year
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+        assertTrue(intersection.isEmpty(),
+                "CA " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testEarlyCloseDateMatchesRawObservance(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        if (!present) {
+            assertTrue(earlyCloses.isEmpty(), "CA " + year + ": expected no early closes");
+            return;
+        }
+        LocalDate expected = new ChristmasEveEarlyClose().apply(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> "Christmas Eve".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Christmas Eve not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                "Christmas Eve via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCATest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCATest.java
@@ -20,7 +20,8 @@ public class HolidayCalendarServiceCATest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] familyDay = {"Family Day"};
         final Object[] victoriaDay = {"Victoria Day"};
-        return Arrays.asList(familyDay, victoriaDay).listIterator();
+        final Object[] christmasEve = {"Christmas Eve"};
+        return Arrays.asList(familyDay, victoriaDay, christmasEve).listIterator();
     }
 
     @DataProvider

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2017, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2018, LocalDate.of(2018, Month.DECEMBER, 24) }); // Dec 24 Mon -> eligible
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> eligible (NYSE-divergence year)
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible
+        // Edge years outside the sampled 2017-2026 cycle
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> ineligible
+        data.add(new Object[]{ 2034, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2099, LocalDate.of(2099, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible, far-future edge
+        return data;
+    }
+
+    @Test
+    public void testTsxClosesEarlyIn2021EvenThoughNyseRuleWouldSuppress() {
+        // 2021: December 25 = Saturday, December 24 = Friday. NYSE's rule keys off
+        // December 25 and would suppress when December 25 falls on Sat/Sun/Mon. TSX's
+        // rule keys off December 24 directly: Friday is a valid weekday, so TSX still
+        // closes early. This is the key behavioral divergence justifying a CA-specific
+        // Observance rather than reusing the US one.
+        assertEquals(observance.apply(2021), LocalDate.of(2021, Month.DECEMBER, 24));
+    }
+
+    @Test
+    public void testDivergesFromUsRuleIn2021() {
+        assertNull(new org.holiday.calendar.observance.us.ChristmasEveEarlyClose().apply(2021),
+                "US rule (keyed off Dec 25) must suppress in 2021");
+        assertEquals(observance.apply(2021), LocalDate.of(2021, Month.DECEMBER, 24),
+                "CA/TSX rule (keyed off Dec 24) must NOT suppress in 2021");
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -316,4 +316,55 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 8. CA EARLY CLOSES (TSX Christmas Eve half-day closure) OVER 30 YEARS
+    // =========================================================================
+
+    // TSX's Christmas Eve early close is suppressed (not shifted) when December 24
+    // falls on a weekend, so count is either 0 or 1 per year; expected presence is
+    // re-derived from December 24's day-of-week rule for every year rather than
+    // hand-fixtured.
+    @Test(description = "CA calculateEarlyCloses across 2026-2055: count always in [0,1], "
+            + "Christmas Eve presence matches December 24 dow rule (excludes Sat/Sun), "
+            + "no nulls, chronological order")
+    public void testCAEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("CA");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "CA: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 1,
+                    "CA " + year + ": expected count in [0,1], got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean dec24Expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), dec24Expected,
+                    "CA " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "CA: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "CA: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "CA: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "CA: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }


### PR DESCRIPTION
### Title of the PR

Model TSX Christmas Eve half-day close for CA

**Description**

Adds the Toronto Stock Exchange's Christmas Eve early close to `HolidayCalendarServiceCA`, following the `EARLY_CLOSE` pattern established by `IsraelHolidays.earlyCloseHolidays()` and `HolidayCalendarServiceUS`'s NYSE half-day closes (#205).

Research corrected the issue's premise that this "mirrors NYSE convention": TSX's rule is keyed off **December 24** itself (early close whenever Dec 24 falls Monday–Friday, suppressed only when Dec 24 falls on a weekend), not December 25's day of week like NYSE. Verified against TMX Group's official Holiday Operating Schedule (2017–2026); the 2021 case (Dec 25 = Saturday, Dec 24 = Friday) proves the divergence — NYSE's rule would suppress that year, but TSX still closes early since Dec 24 is a weekday.

- New `org.holiday.calendar.observance.ca.ChristmasEveEarlyClose` (extends `AbstractObservance`, overriding `isValidYear` to suppress on weekends)
- New `TSX_ZONE` (`America/Toronto`) constant and `EARLY_CLOSE` holiday registration in `HolidayCalendarServiceCA`
- Unit tests for the observance (9-year verified fixture + edge years + named 2021 NYSE-divergence regression test)
- Integration tests (`HolidayCalendarServiceCAEarlyCloseTest`) covering count, presence, close time, zone, rollability, and no-collision-with-`calculate()`
- `HolidayCalendar30YearIT` addition (`testCAEarlyClosesOver30Years`) re-deriving expected presence from Dec 24's day-of-week over 2026–2055

No `holiday-calendar-core` changes needed — `Holiday.Type.EARLY_CLOSE` and `calculateEarlyCloses()` already exist and are exercised by prior precedents.

**Related Issue**

- #206 (part of #203)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally (`mvn clean install`)
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed