### PR TITLE
#212 SG: Model SGX Christmas Eve / New Year's Eve half-day closes

### DIFF
--- a/holiday-calendar-apac/src/main/java/module-info.java
+++ b/holiday-calendar-apac/src/main/java/module-info.java
@@ -34,6 +34,7 @@ module org.holiday.calendar.apac {
     exports org.holiday.calendar.observance.islamic.apac;
     exports org.holiday.calendar.observance.hindu;
     exports org.holiday.calendar.observance.jp;
+    exports org.holiday.calendar.observance.sg;
 
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceCNY,

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
@@ -19,13 +19,23 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.sg.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.sg.NewYearsEveEarlyClose;
 
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.OptionalInt;
 
 /**
  * Service for provision of Singapore Exchange (SGX) holiday calendar.
+ *
+ * <p>Includes two {@code EARLY_CLOSE} holidays representing SGX's Christmas
+ * Eve and New Year's Eve half-day trading closes. The MAS/MEPS+ settlement
+ * calendar ({@link HolidayCalendarServiceSGD}) does not include these — MEPS+
+ * RTGS settlement and SGX equities trading are distinct systems.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -33,6 +43,7 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
 
     private static final String CODE = "SG";
     private static final String NAME = "Singapore (SGX) Holidays";
+    private static final ZoneId SGX_ZONE = ZoneId.of("Asia/Singapore");
 
     public HolidayCalendarServiceSG() {
         super(CODE, NAME);
@@ -45,12 +56,35 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
+                             + "December 24 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(12, 0))
+                .zoneId(SGX_ZONE)
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
+                             + "December 31 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(12, 0))
+                .zoneId(SGX_ZONE)
+                .build();
+
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holidays(SingaporeHolidays.baseHolidays(true))
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyClose.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Singapore Exchange's (SGX) Christmas Eve half-day close
+ * (December 24). SGX's securities/equities market runs a half-day trading
+ * session (09:00-12:00 SGT) on December 24 whenever that date falls on a
+ * trading day; when December 24 falls on a Saturday or Sunday, the half-day
+ * close is simply not observed that year — it is not shifted to another
+ * date. {@link #isValidYear(int)} is overridden here to signal that
+ * business-rule absence, while {@link #computeDate(int)} unconditionally
+ * returns December 24.
+ *
+ * <p>Verified against SGX's Rulebook Regulatory/Practice Notice 8.2.1
+ * ("Trading Hours, Market Phases...") and cross-checked against SGX's
+ * published trading calendars, 2018-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyClose.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Singapore Exchange's (SGX) New Year's Eve half-day close
+ * (December 31). SGX's securities/equities market runs a half-day trading
+ * session (09:00-12:00 SGT) on December 31 whenever that date falls on a
+ * trading day; when December 31 falls on a Saturday or Sunday, the half-day
+ * close is simply not observed that year — it is not shifted to another
+ * date. {@link #isValidYear(int)} is overridden here to signal that
+ * business-rule absence, while {@link #computeDate(int)} unconditionally
+ * returns December 31.
+ *
+ * <p>Verified against SGX's Rulebook Regulatory/Practice Notice 8.2.1
+ * ("Trading Hours, Market Phases...") and cross-checked against SGX's
+ * published trading calendars, 2018-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGDTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGDTest.java
@@ -213,6 +213,29 @@ public class HolidayCalendarServiceSGDTest {
                 "at boundary: " + holidaysAtBoundary.size() + ", beyond: " + holidaysBeyond.size());
     }
 
+    // ── SGX early-close non-leakage ──────────────────────────────────────────
+    // SGX's Christmas Eve / New Year's Eve half-day closes apply only to the SG
+    // (SGX equities) calendar, not SGD (MAS/MEPS+ settlement). Guards against a
+    // future accidental copy-paste of SG's builder logic into SGD.
+
+    @Test
+    public void testCalculateEarlyClosesReturnsEmpty2018() {
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2018).isEmpty(),
+                "SGD must not have any EARLY_CLOSE holidays");
+    }
+
+    @Test
+    public void testCalculateEarlyClosesReturnsEmpty2022() {
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2022).isEmpty(),
+                "SGD must not have any EARLY_CLOSE holidays");
+    }
+
+    @Test
+    public void testCalculateEarlyClosesReturnsEmpty2024() {
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2024).isEmpty(),
+                "SGD must not have any EARLY_CLOSE holidays");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private Optional<HolidayDate> findByName(List<HolidayDate> holidays, String name) {

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGEarlyCloseTest.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.sg.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.sg.NewYearsEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code SG} calendar's early-close (SGX half-day closure)
+ * holidays: Christmas Eve and New Year's Eve. Because December 24 and
+ * December 31 are always exactly 7 days apart, they always share the same
+ * day-of-week within a given year — both early closes are always present
+ * together or absent together, never one without the other. This is a real
+ * difference from CA (single early close) and worth its own dedicated
+ * assertions below, beyond the standard count/presence/closeTime/zone checks.
+ */
+public class HolidayCalendarServiceSGEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 0);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Asia/Singapore");
+
+    // 11 full-day holidays registered in HolidayCalendarServiceSG; the two Eve
+    // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 11.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 11;
+
+    private final HolidayCalendarServiceSG service = new HolidayCalendarServiceSG();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2018-2026 SGX cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "sgEarlyCloseFixture")
+    public Iterator<Object[]> sgEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2018, true},
+                new Object[]{2019, true},
+                new Object[]{2020, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "SG " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "SG " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testNewYearsEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
+                "SG " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    // -------------------------------------------------------------------------
+    // Dual-suppression / dual-presence boundary (the SG-specific difference)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testBothEarlyClosesSuppressedTogetherIn2022() {
+        // 2022: December 24 and December 31 both fall on Saturday.
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2022).isEmpty());
+    }
+
+    @Test
+    public void testBothEarlyClosesSuppressedTogetherIn2023() {
+        // 2023: December 24 and December 31 both fall on Sunday.
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2023).isEmpty());
+    }
+
+    @Test
+    public void testBothEarlyClosesPresentTogetherIn2024() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2024);
+        assertEquals(earlyCloses.size(), 2);
+        Set<String> names = earlyCloses.stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertEquals(names, Set.of("Christmas Eve", "New Year's Eve"));
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testCountIsNeverExactlyOne(int year, boolean present) {
+        int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
+        assertNotEquals(count, 1, "SG " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs12_00() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 12:00");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsAsiaSingapore() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in Asia/Singapore");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyClosesNotRollable() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // No date appears in both calculate() and calculateEarlyCloses() for the same year
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+        assertTrue(intersection.isEmpty(),
+                "SG " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Christmas Eve", 2018},
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2025},
+                new Object[]{"Christmas Eve", 2026},
+                new Object[]{"New Year's Eve", 2018},
+                new Object[]{"New Year's Eve", 2024},
+                new Object[]{"New Year's Eve", 2025},
+                new Object[]{"New Year's Eve", 2026}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            case "New Year's Eve" -> new NewYearsEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class ChristmasEveEarlyCloseTest {
+
+    private final ChristmasEveEarlyClose observance = new ChristmasEveEarlyClose();
+
+    @DataProvider
+    Iterator<Object[]> yearFixture() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2017, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2018, LocalDate.of(2018, Month.DECEMBER, 24) }); // Dec 24 Mon -> eligible
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> eligible
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible
+        // Edge years outside the sampled 2018-2026 cycle
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 24) }); // Dec 24 Fri -> eligible
+        data.add(new Object[]{ 2028, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 24) }); // Dec 24 Mon -> eligible
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> ineligible
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testApplyMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+                "ChristmasEveEarlyClose.apply(" + year + ") mismatch");
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testPredicateMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.test(year), expected != null,
+                "ChristmasEveEarlyClose.test(" + year + ") mismatch");
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSaturday() {
+        // 2033: December 24 is a Saturday.
+        assertNull(observance.apply(2033));
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSunday() {
+        // 2028: December 24 is a Sunday.
+        assertNull(observance.apply(2028));
+    }
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+                "ChristmasEveEarlyClose.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+                "ChristmasEveEarlyClose.test(null) must return false per AbstractObservance contract");
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyCloseTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class NewYearsEveEarlyCloseTest {
+
+    private final NewYearsEveEarlyClose observance = new NewYearsEveEarlyClose();
+
+    @DataProvider
+    Iterator<Object[]> yearFixture() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2017, null });                                   // Dec 31 Sun -> ineligible
+        data.add(new Object[]{ 2018, LocalDate.of(2018, Month.DECEMBER, 31) }); // Dec 31 Mon -> eligible
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 31) }); // Dec 31 Tue -> eligible
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 31) }); // Dec 31 Thu -> eligible
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> eligible
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> ineligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> eligible
+        // Edge years outside the sampled 2018-2026 cycle
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 31) }); // Dec 31 Fri -> eligible
+        data.add(new Object[]{ 2028, null });                                   // Dec 31 Sun -> ineligible
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 31) }); // Dec 31 Mon -> eligible
+        data.add(new Object[]{ 2033, null });                                   // Dec 31 Sat -> ineligible
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testApplyMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+                "NewYearsEveEarlyClose.apply(" + year + ") mismatch");
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testPredicateMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.test(year), expected != null,
+                "NewYearsEveEarlyClose.test(" + year + ") mismatch");
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSaturday() {
+        // 2033: December 31 is a Saturday.
+        assertNull(observance.apply(2033));
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSunday() {
+        // 2028: December 31 is a Sunday.
+        assertNull(observance.apply(2028));
+    }
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+                "NewYearsEveEarlyClose.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+                "NewYearsEveEarlyClose.test(null) must return false per AbstractObservance contract");
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -367,4 +367,58 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 9. SG EARLY CLOSES (SGX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Both SGX Eve early closes are suppressed (not shifted) when their date falls on a
+    // weekend; since December 24 and December 31 are always exactly 7 days apart, they
+    // always share the same day-of-week within a year, so count is always 0 or 2, never 1.
+    // Expected presence is re-derived from December 24's day-of-week rule for every year
+    // rather than hand-fixtured.
+    @Test(description = "SG calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
+            + "and always co-occur, no nulls, chronological order")
+    public void testSGEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("SG");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "SG: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 2,
+                    "SG " + year + ": expected count in {0,2}, got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), expected,
+                    "SG " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+            assertEquals(names.contains("New Year's Eve"), expected,
+                    "SG " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "SG: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "SG: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "SG: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "SG: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }


### PR DESCRIPTION
### SG: Model SGX Christmas Eve / New Year's Eve half-day closes

**Description**

- Adds `EARLY_CLOSE` holidays for SGX's Christmas Eve (Dec 24) and New Year's
  Eve (Dec 31) half-day trading sessions (09:00-12:00 SGT / close time 12:00,
  `Asia/Singapore`), following the `IsraelHolidays.earlyCloseHolidays()` /
  CA `ChristmasEveEarlyClose` pattern.
- Verified against SGX's Rulebook Regulatory/Practice Notice 8.2.1: the
  half-day close applies whenever the date falls on a weekday, and is
  suppressed entirely (not shifted) when it falls on a Saturday or Sunday.
  Because December 24 and December 31 are always exactly 7 days apart, they
  always share the same day-of-week within a given year, so both early
  closes always co-occur — never one without the other.
- `HolidayCalendarServiceSGD` (MAS/MEPS+ settlement) is untouched — this
  convention applies only to SGX securities/equities trading.
- New `org.holiday.calendar.observance.sg` package, exported from
  `holiday-calendar-apac`'s `module-info.java`.

**Related Issue**

- #212

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally (`mvn clean install`, full reactor)
- [x] Documentation has been updated, if needed (no README changes needed — documents calendars, not individual holidays)
- [x] Screenshots or additional notes added, if needed (see fixture tables in test files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)