### PR TITLE
#209 DE: Model Xetra/FSE Christmas Eve / New Year's Eve as full non-trading days

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module org.holiday.calendar.western {
     exports org.holiday.calendar.observance.christian;
     exports org.holiday.calendar.observance.au;
     exports org.holiday.calendar.observance.ca;
+    exports org.holiday.calendar.observance.de;
     exports org.holiday.calendar.observance.eu;
     exports org.holiday.calendar.observance.uk;
     exports org.holiday.calendar.observance.us;

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceDE.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceDE.java
@@ -28,6 +28,8 @@ import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.christian.WhitMonday;
+import org.holiday.calendar.observance.de.ChristmasEve;
+import org.holiday.calendar.observance.de.NewYearsEve;
 
 import java.time.Month;
 
@@ -100,6 +102,14 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.OCTOBER, 3)
                 .build();
+        final Holiday christmasEve = Holiday.builder()
+                .name("Christmas Eve")
+                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
+                        + "Exchange; omitted (not shifted) when it falls on a weekend")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ChristmasEve())
+                .build();
         final Holiday christmasDay = Holiday.builder()
                 .name("Christmas Day")
                 .description("Celebration of traditional Christmas holiday")
@@ -114,6 +124,14 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday newYearsEve = Holiday.builder()
+                .name("New Year's Eve")
+                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
+                        + "Exchange; omitted (not shifted) when it falls on a weekend")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new NewYearsEve())
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -127,8 +145,10 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
                 .holiday(ascensionDay)
                 .holiday(whitMonday)
                 .holiday(germanUnityDay)
+                .holiday(christmasEve)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(newYearsEve)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/ChristmasEve.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/ChristmasEve.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Xetra/Frankfurt Stock Exchange's Christmas Eve full non-trading
+ * day (December 24, an "Erfüllungstag"/settlement day). Unlike
+ * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose} — which
+ * always occurs, shifting to the preceding Friday on a weekend — Xetra/FWB is
+ * simply not a trading day at all on weekends, so December 24 is omitted
+ * entirely (not shifted) in years it falls on a Saturday or Sunday. This
+ * mirrors {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s
+ * suppression semantics, applied here to a {@code FLOATING} full-day holiday
+ * rather than an {@code EARLY_CLOSE}.
+ *
+ * <p>Verified against Deutsche Börse's official Xetra-Handelskalender
+ * (cashmarket.deutsche-boerse.com), 2023-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEve extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/NewYearsEve.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/NewYearsEve.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Xetra/Frankfurt Stock Exchange's New Year's Eve full non-trading
+ * day (December 31, an "Erfüllungstag"/settlement day). Mirrors {@link ChristmasEve}'s
+ * suppression semantics: omitted entirely (not shifted) in years December 31 falls
+ * on a Saturday or Sunday, since Xetra/FWB is simply not a trading day at all on
+ * weekends.
+ *
+ * <p>Verified against Deutsche Börse's official Xetra-Handelskalender
+ * (cashmarket.deutsche-boerse.com), 2023-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEve extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceDETest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceDETest.java
@@ -18,12 +18,22 @@
 
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarServiceTest {
 
@@ -38,7 +48,9 @@ public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] germanUnityDay = {"German Unity Day"};
         final Object[] labourDay = {"Labour Day"};
-        return Arrays.asList(germanUnityDay, labourDay).listIterator();
+        final Object[] christmasEve = {"Christmas Eve"};
+        final Object[] newYearsEve = {"New Year's Eve"};
+        return Arrays.asList(germanUnityDay, labourDay, christmasEve, newYearsEve).listIterator();
     }
 
     @DataProvider
@@ -56,8 +68,45 @@ public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarService
         final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // Boxing Day 2023: Dec 26 is Tuesday -> no roll
         final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        // Christmas Eve 2024: Dec 24 is Tuesday -> present, unrolled (primary-sourced)
+        final Object[] christmasEve24 = {2024, "Christmas Eve", LocalDate.of(2024, Month.DECEMBER, 24)};
+        // New Year's Eve 2025: Dec 31 is Wednesday -> present, unrolled (primary-sourced)
+        final Object[] newYearsEve25 = {2025, "New Year's Eve", LocalDate.of(2025, Month.DECEMBER, 31)};
+        // Christmas Eve 2021: Dec 24 is Friday -> present, unrolled (collision year, see
+        // testChristmasEveAndChristmasDayCoexistOn24Dec2021 below)
+        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
         return Arrays.asList(christmas21, christmas22, christmas23,
-                             boxingDay21, boxingDay22, boxingDay23).listIterator();
+                             boxingDay21, boxingDay22, boxingDay23,
+                             christmasEve24, newYearsEve25, christmasEve21).listIterator();
+    }
+
+    @Test
+    public void testChristmasEveAndNewYearsEveOmittedOnWeekend() {
+        // 2023: Dec 24 and Dec 31 both fall on a Sunday, so Xetra/FWB simply doesn't
+        // list an exception day at all -- no shift, no entry.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Set<String> names = calendar.calculate(2023).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertFalse(names.contains("Christmas Eve"), "Christmas Eve must be omitted in 2023 (Sunday)");
+        assertFalse(names.contains("New Year's Eve"), "New Year's Eve must be omitted in 2023 (Sunday)");
+    }
+
+    @Test
+    public void testChristmasEveAndChristmasDayCoexistOn24Dec2021() {
+        // Dec 25, 2021 is a Saturday and rolls to Friday Dec 24 under DE's
+        // previousFridayOrFollowingMonday roll rule, landing on the same calendar date
+        // as the new non-rolling Christmas Eve holiday. Both facts are independently
+        // true and must both appear -- no accidental de-duplication.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final List<HolidayDate> dec24 = calendar.calculate(2021).stream()
+                .filter(hd -> LocalDate.of(2021, Month.DECEMBER, 24).equals(hd.getDate()))
+                .toList();
+
+        assertEquals(dec24.size(), 2, "Expected both Christmas Day (rolled) and Christmas Eve on 2021-12-24");
+        final Set<String> names = dec24.stream().map(hd -> hd.getHoliday().getName()).collect(Collectors.toSet());
+        assertTrue(names.contains("Christmas Day"));
+        assertTrue(names.contains("Christmas Eve"));
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/ChristmasEveTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/ChristmasEveTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChristmasEveTest extends AbstractObservanceTest {
+
+    public ChristmasEveTest() {
+        super(new ChristmasEve());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        // Primary-sourced against Deutsche Börse's Xetra-Handelskalender PDFs (2023-2026)
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> omitted
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> full holiday
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> full holiday
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> full holiday
+        // Arithmetic-inferred (stable rule applied to day-of-week, not independently
+        // confirmed against an archived PDF for these specific years)
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> full holiday
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> omitted
+        return data;
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/NewYearsEveTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/NewYearsEveTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewYearsEveTest extends AbstractObservanceTest {
+
+    public NewYearsEveTest() {
+        super(new NewYearsEve());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        // Primary-sourced against Deutsche Börse's Xetra-Handelskalender PDFs (2023-2026)
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> omitted
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> full holiday
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> full holiday
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> full holiday
+        // Arithmetic-inferred (stable rule applied to day-of-week, not independently
+        // confirmed against an archived PDF for these specific years)
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> full holiday
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> omitted
+        return data;
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -402,7 +402,10 @@ public class HolidayCalendar30YearIT {
                     "New Year's Eve".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
             assertEquals(dec31Present, dec31Expected,
                     "DE " + year + ": New Year's Eve presence/date must match December 31 dow rule (dow=" + dec31Dow + ")");
+        }
+    }
 
+    // =========================================================================
     // 10. SG EARLY CLOSES (SGX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
     // =========================================================================
 

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -367,4 +367,42 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 9. DE CHRISTMAS EVE / NEW YEAR'S EVE (Xetra/FWB full non-trading days) OVER 30 YEARS
+    // =========================================================================
+
+    // Xetra/FWB's Christmas Eve and New Year's Eve are full non-trading days, not
+    // half-day early closes, so they're asserted via calculate() rather than
+    // calculateEarlyCloses(). Each is omitted (not shifted) when its date falls on a
+    // weekend; expected presence is re-derived from each date's day-of-week rule for
+    // every year rather than hand-fixtured.
+    @Test(description = "DE calculate() across 2026-2055: Christmas Eve/New Year's Eve present "
+            + "unrolled whenever not Sat/Sun, absent (not shifted) when Sat/Sun, no nulls")
+    public void testDEChristmasEveAndNewYearsEveOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("DE");
+
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> all = calendar.calculate(year);
+            assertNotNull(all, "DE: calculate(" + year + ") must not be null");
+
+            LocalDate dec24 = LocalDate.of(year, Month.DECEMBER, 24);
+            DayOfWeek dec24Dow = dec24.getDayOfWeek();
+            boolean dec24Expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            boolean dec24Present = all.stream().anyMatch(hd ->
+                    "Christmas Eve".equals(hd.holiday().getName()) && dec24.equals(hd.date()));
+            assertEquals(dec24Present, dec24Expected,
+                    "DE " + year + ": Christmas Eve presence/date must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            LocalDate dec31 = LocalDate.of(year, Month.DECEMBER, 31);
+            DayOfWeek dec31Dow = dec31.getDayOfWeek();
+            boolean dec31Expected = !DayOfWeek.SATURDAY.equals(dec31Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec31Dow);
+            boolean dec31Present = all.stream().anyMatch(hd ->
+                    "New Year's Eve".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
+            assertEquals(dec31Present, dec31Expected,
+                    "DE " + year + ": New Year's Eve presence/date must match December 31 dow rule (dow=" + dec31Dow + ")");
+        }
+    }
+
 }


### PR DESCRIPTION
### Title of the PR

DE: Model Xetra/FSE Christmas Eve / New Year's Eve as full non-trading days

**Description**

- `HolidayCalendarServiceDE` had no modeling for Xetra/Frankfurt Stock Exchange's Dec 24 and Dec 31 closures. The issue originally requested `EARLY_CLOSE` (half-day) modeling, but research against Deutsche Börse's official Xetra-Handelskalender PDFs (2023–2026) confirmed these are actually **full non-trading days** ("Erfüllungstage"/settlement days), not half-day early closes — there is no shortened trading session on either date.
- Adds `Christmas Eve` (Dec 24) and `New Year's Eve` (Dec 31) to `HolidayCalendarServiceDE` as non-rollable `FLOATING` holidays, each backed by a dedicated `Observance` (`observance.de.ChristmasEve` / `NewYearsEve`) that suppresses (omits, does not shift) the date when it falls on a Saturday or Sunday — mirroring the suppression pattern already used by `observance.ca.ChristmasEveEarlyClose` for TSX.
- No `holiday-calendar-core` changes required; no calendar-level `DateRoll` change — `.rollable(false)` on the two new holidays suppresses rolling per-holiday while DE's other 9 holidays continue to roll via `previousFridayOrFollowingMonday()`.
- Added `exports org.holiday.calendar.observance.de;` to `holiday-calendar-western`'s `module-info.java`.
- Posted a scope-correction comment on #209 and retitled it to reflect the corrected (FLOATING, not EARLY_CLOSE) model.

**Related Issue**

- [#209](https://github.com/holiday-calendar/holiday-calendar-java/issues/209)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [x] Screenshots or additional notes added, if needed

**Additional notes**

- New tests: `observance/de/ChristmasEveTest.java`, `NewYearsEveTest.java` (Observance fixtures, primary-sourced 2023–2026 + arithmetic-inferred 2021/2022); `HolidayCalendarServiceDETest` additions including an explicit regression test for the real 2021 same-date collision between rolled `Christmas Day` (Dec 25 Sat → Fri Dec 24) and the new non-rolling `Christmas Eve`, and a weekend-omission test for 2023; a new rule-derived DE section in `HolidayCalendar30YearIT` (2026–2055).
- Verified `mvn clean install` passes across all modules; grepped `HolidayCalendarServiceDE.java` and the new observance classes for `==`/`!=` value-type comparisons (SonarCloud S8696) — none found.
- No README changes needed (adds holidays to an existing calendar, doesn't add a new one).