### PR TITLE
#211 AU: Model ASX Christmas Eve / New Year's Eve half-day closes

### DIFF
--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
@@ -22,13 +22,17 @@ import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.au.ChristmasEveEarlyClose;
 import org.holiday.calendar.observance.au.KingsBirthday;
+import org.holiday.calendar.observance.au.NewYearsEveEarlyClose;
 import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
 
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
@@ -114,6 +118,26 @@ public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("ASX half-day close; suppressed entirely (not shifted) " +
+                             "when December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(14, 10))
+                .zoneId(ZoneId.of("Australia/Sydney"))
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("ASX half-day close; suppressed entirely (not shifted) " +
+                             "when December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(14, 10))
+                .zoneId(ZoneId.of("Australia/Sydney"))
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -129,6 +153,8 @@ public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
                 .holiday(kingsBirthday)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/AsxEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/AsxEveEarlyClose.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Package-private template for the Australian Securities Exchange's
+ * Christmas Eve / New Year's Eve half-day close Observances: the early close
+ * occurs on the fixed date whenever that date falls on a weekday, and is
+ * suppressed entirely (not shifted, unlike the London Stock Exchange) when
+ * the date falls on a Saturday or Sunday.
+ *
+ * <p>Other calendars in this codebase (e.g. {@code observance.ca},
+ * {@code observance.sg}) intentionally keep their Christmas Eve/New Year's
+ * Eve Observances as separate, non-sharing classes despite near-identical
+ * bodies. This package deviates from that convention with a package-private
+ * shared base, scoped only to {@code observance.au}, purely to avoid
+ * duplicating that same body a second time (SonarCloud's new-code
+ * duplication gate flags the repeated {@code computeDate}/{@code isValidYear}
+ * pattern, same as it did for {@code observance.fr}'s
+ * {@code EuronextEveEarlyClose}).
+ */
+abstract class AsxEveEarlyClose extends AbstractObservance {
+
+    private final Month month;
+    private final int dayOfMonth;
+
+    AsxEveEarlyClose(Month month, int dayOfMonth) {
+        this.month = month;
+        this.dayOfMonth = dayOfMonth;
+    }
+
+    @Override
+    protected final LocalDate computeDate(int year) {
+        return LocalDate.of(year, month, dayOfMonth);
+    }
+
+    @Override
+    protected final boolean isValidYear(int year) {
+        DayOfWeek dayOfWeek = computeDate(year).getDayOfWeek();
+        return switch (dayOfWeek) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Australian Securities Exchange's Christmas Eve half-day
+ * close (December 24). ASX runs a shortened trading session (normal trading
+ * ceasing at 14:10 Sydney time) on December 24 whenever that date falls on a
+ * weekday; when December 24 falls on a Saturday or Sunday, the half-day close
+ * is not observed that year at all — unlike the London Stock Exchange (see
+ * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose}), ASX
+ * does not shift the half-day session to the preceding Friday. This is why
+ * {@link #isValidYear(int)} is overridden here to signal absence in
+ * ineligible years, rather than {@link #computeDate(int)} shifting to a
+ * different day.
+ *
+ * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
+ * New Year" notices (asxonline.com): the 2025/2026 notice confirms the 14:10
+ * Sydney close, and the 2022/2023 notice confirms suppression — with
+ * December 24, 2022 falling on a Saturday, that notice designates Friday
+ * December 23, 2022 as a normal, full-hours trading day rather than shifting
+ * the half-day session to it.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
@@ -18,10 +18,6 @@
 
 package org.holiday.calendar.observance.au;
 
-import org.holiday.calendar.observance.AbstractObservance;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.Month;
 
 /**
@@ -31,10 +27,12 @@ import java.time.Month;
  * weekday; when December 24 falls on a Saturday or Sunday, the half-day close
  * is not observed that year at all — unlike the London Stock Exchange (see
  * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose}), ASX
- * does not shift the half-day session to the preceding Friday. This is why
- * {@link #isValidYear(int)} is overridden here to signal absence in
- * ineligible years, rather than {@link #computeDate(int)} shifting to a
- * different day.
+ * does not shift the half-day session to the preceding Friday. See
+ * {@link AsxEveEarlyClose} for the shared eligibility logic (a different
+ * use of {@code isValidYear} than its algorithm-validity use in
+ * {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
+ * for the same note).
  *
  * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
  * New Year" notices (asxonline.com): the 2025/2026 notice confirms the 14:10
@@ -45,20 +43,10 @@ import java.time.Month;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class ChristmasEveEarlyClose extends AbstractObservance {
+public class ChristmasEveEarlyClose extends AsxEveEarlyClose {
 
-    @Override
-    protected LocalDate computeDate(int year) {
-        return LocalDate.of(year, Month.DECEMBER, 24);
-    }
-
-    @Override
-    protected boolean isValidYear(int year) {
-        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
-        return switch (christmasEve) {
-            case SATURDAY, SUNDAY -> false;
-            default -> true;
-        };
+    public ChristmasEveEarlyClose() {
+        super(Month.DECEMBER, 24);
     }
 
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
@@ -18,10 +18,6 @@
 
 package org.holiday.calendar.observance.au;
 
-import org.holiday.calendar.observance.AbstractObservance;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.Month;
 
 /**
@@ -31,10 +27,12 @@ import java.time.Month;
  * weekday; when December 31 falls on a Saturday or Sunday, the half-day close
  * is not observed that year at all — unlike the London Stock Exchange (see
  * {@code org.holiday.calendar.observance.uk.NewYearsEveEarlyClose}), ASX does
- * not shift the half-day session to the preceding Friday. This is why
- * {@link #isValidYear(int)} is overridden here to signal absence in
- * ineligible years, rather than {@link #computeDate(int)} shifting to a
- * different day.
+ * not shift the half-day session to the preceding Friday. See
+ * {@link AsxEveEarlyClose} for the shared eligibility logic (a different
+ * use of {@code isValidYear} than its algorithm-validity use in
+ * {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
+ * for the same note).
  *
  * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
  * New Year" notices (asxonline.com): the 2025/2026 notice confirms the same
@@ -42,20 +40,10 @@ import java.time.Month;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class NewYearsEveEarlyClose extends AbstractObservance {
+public class NewYearsEveEarlyClose extends AsxEveEarlyClose {
 
-    @Override
-    protected LocalDate computeDate(int year) {
-        return LocalDate.of(year, Month.DECEMBER, 31);
-    }
-
-    @Override
-    protected boolean isValidYear(int year) {
-        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
-        return switch (newYearsEve) {
-            case SATURDAY, SUNDAY -> false;
-            default -> true;
-        };
+    public NewYearsEveEarlyClose() {
+        super(Month.DECEMBER, 31);
     }
 
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Australian Securities Exchange's New Year's Eve half-day
+ * close (December 31). ASX runs a shortened trading session (normal trading
+ * ceasing at 14:10 Sydney time) on December 31 whenever that date falls on a
+ * weekday; when December 31 falls on a Saturday or Sunday, the half-day close
+ * is not observed that year at all — unlike the London Stock Exchange (see
+ * {@code org.holiday.calendar.observance.uk.NewYearsEveEarlyClose}), ASX does
+ * not shift the half-day session to the preceding Friday. This is why
+ * {@link #isValidYear(int)} is overridden here to signal absence in
+ * ineligible years, rather than {@link #computeDate(int)} shifting to a
+ * different day.
+ *
+ * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
+ * New Year" notices (asxonline.com): the 2025/2026 notice confirms the same
+ * 14:10 Sydney close applies to both December 24 and December 31.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
@@ -193,8 +193,9 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
     }
 
     // -------------------------------------------------------------------------
-    // Cross-list date collision: empty in ordinary years, exactly {Dec 24}
-    // in Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve)
+    // Cross-list date collision: empty in ordinary years, exactly one date
+    // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
+    // onto Christmas Eve
     // -------------------------------------------------------------------------
 
     @Test(dataProvider = "auEarlyCloseFixture")

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
@@ -1,0 +1,313 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.au.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.au.NewYearsEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code AU} calendar's early-close (ASX half-day closure)
+ * holidays: Christmas Eve and New Year's Eve. Because December 24 and
+ * December 31 are always exactly 7 days apart, they always share the same
+ * day-of-week within a given year — both early closes are always present
+ * together or absent together, never one without the other, same shape as
+ * FR.
+ *
+ * <p>AU's Christmas Day and New Year's Day are both {@code rollable(true)}
+ * under {@code previousFridayOrFollowingMonday} (the same roll rule FR
+ * uses), producing the same two genuine date collisions with the early
+ * closes that FR's test suite covers, both verified explicitly below:
+ * <ul>
+ *     <li>Christmas Day rolls back onto December 24 whenever December 25
+ *     falls on a Saturday (e.g. 2021, 2027) — the same date Christmas Eve's
+ *     early close independently occupies that year.</li>
+ *     <li>New Year's Day rolls back onto December 31 of the <em>prior</em>
+ *     year whenever January 1 falls on a Saturday (e.g. January 1, 2028
+ *     rolls to December 31, 2027) — the same date New Year's Eve's early
+ *     close independently occupies in that prior year. This crosses a
+ *     {@code calculate(year)} year boundary, so it is not caught by a
+ *     same-year intersection check alone.</li>
+ * </ul>
+ */
+public class HolidayCalendarServiceAUEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(14, 10);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Australia/Sydney");
+
+    // 9 full-day holidays registered in HolidayCalendarServiceAU; the two Eve
+    // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 9.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 9;
+
+    private final HolidayCalendarServiceAU service = new HolidayCalendarServiceAU();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2020-2029 ASX cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "auEarlyCloseFixture")
+    public Iterator<Object[]> auEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2020, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true},
+                new Object[]{2027, true},
+                new Object[]{2028, false},
+                new Object[]{2029, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "AU " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "AU " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testNewYearsEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
+                "AU " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testEarlyCloseCountAlwaysZeroOrTwo(int year, boolean present) {
+        int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
+        assertNotEquals(count, 1, "AU " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+    }
+
+    // -------------------------------------------------------------------------
+    // Suppressed-year sanity checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasEveSuppressedIn2022() {
+        // 2022: December 24 = Saturday.
+        assertFalse(earlyCloseNames(2022).contains("Christmas Eve"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedIn2023() {
+        // 2023: December 24 = Sunday.
+        assertFalse(earlyCloseNames(2023).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs14_10() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 14:10");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsAustraliaSydney() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in Australia/Sydney");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyClosesNotRollable() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate() -- checked
+    // in both a non-collision year and a Dec-24-collision year
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        for (int year : List.of(2024, 2027)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            assertNotNull(holidays);
+            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "AU " + year + ": unexpected full-day holiday count");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-list date collision: empty in ordinary years, exactly {Dec 24}
+    // in Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve)
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testCrossListDateOverlapOnlyOnKnownChristmasDayRollYears(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+
+        boolean isChristmasDaySaturdayRollYear =
+                DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
+        if (isChristmasDaySaturdayRollYear) {
+            assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
+                    "AU " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+        } else {
+            assertTrue(intersection.isEmpty(), "AU " + year + ": unexpected cross-list date collision: " + intersection);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Named regression: Christmas Day (rolled) and Christmas Eve (early close)
+    // both legitimately appear on the same date in a Dec-25-Saturday year
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasDayAndChristmasEveCoexistOn24Dec2027() {
+        // December 25, 2027 is a Saturday and rolls to Friday December 24 under AU's
+        // previousFridayOrFollowingMonday roll rule -- the same date the non-rolling
+        // Christmas Eve EARLY_CLOSE independently occupies (December 24, 2027 is a
+        // Friday, a valid early-close weekday). Both facts are true simultaneously and
+        // must both surface, across calculate() and calculateEarlyCloses() respectively.
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        LocalDate dec24 = LocalDate.of(2027, Month.DECEMBER, 24);
+
+        boolean christmasDayPresent = calendar.calculate(2027).stream()
+                .anyMatch(hd -> "Christmas Day".equals(hd.getHoliday().getName()) && dec24.equals(hd.getDate()));
+        boolean christmasEvePresent = calendar.calculateEarlyCloses(2027).stream()
+                .anyMatch(hd -> "Christmas Eve".equals(hd.getHoliday().getName()) && dec24.equals(hd.getDate()));
+
+        assertTrue(christmasDayPresent, "Christmas Day (rolled) must appear on Dec 24, 2027");
+        assertTrue(christmasEvePresent, "Christmas Eve early close must independently appear on Dec 24, 2027");
+    }
+
+    // -------------------------------------------------------------------------
+    // Named regression: New Year's Day (rolled back onto the prior Dec 31) and
+    // New Year's Eve (early close) both legitimately appear on the same date --
+    // this crosses a calculate(year) year boundary and is not caught by the
+    // same-year cross-list check above
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testNewYearsDayAndNewYearsEveCoexistOn31Dec2027() {
+        // January 1, 2028 is a Saturday and rolls back to Friday December 31, 2027
+        // under AU's previousFridayOrFollowingMonday roll rule -- the same date the
+        // non-rolling New Year's Eve EARLY_CLOSE independently occupies in 2027
+        // (December 31, 2027 is a Friday, a valid early-close weekday). This is a
+        // genuine same-date coexistence spanning two different year arguments:
+        // calculate(2028) and calculateEarlyCloses(2027).
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        LocalDate dec31 = LocalDate.of(2027, Month.DECEMBER, 31);
+
+        boolean newYearsDayPresent = calendar.calculate(2028).stream()
+                .anyMatch(hd -> "New Year's Day".equals(hd.getHoliday().getName()) && dec31.equals(hd.getDate()));
+        boolean newYearsEvePresent = calendar.calculateEarlyCloses(2027).stream()
+                .anyMatch(hd -> "New Year's Eve".equals(hd.getHoliday().getName()) && dec31.equals(hd.getDate()));
+
+        assertTrue(newYearsDayPresent, "New Year's Day (rolled back from Jan 1, 2028) must appear on Dec 31, 2027");
+        assertTrue(newYearsEvePresent, "New Year's Eve early close must independently appear on Dec 31, 2027");
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2026},
+                new Object[]{"Christmas Eve", 2027},
+                new Object[]{"New Year's Eve", 2024},
+                new Object[]{"New Year's Eve", 2026},
+                new Object[]{"New Year's Eve", 2027}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            case "New Year's Eve" -> new NewYearsEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2011, null });                                   // Dec 24 Sat -> suppressed, pre-cycle edge year
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 24 Thu -> present
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> present
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> suppressed
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> suppressed
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> present
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> present
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> present, confirmed by ASX's 2025/2026 notice
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 24) }); // Dec 24 Fri -> present
+        data.add(new Object[]{ 2028, null });                                   // Dec 24 Sun -> suppressed
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 24) }); // Dec 24 Mon -> present, boundary check adjacent to 2028
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> suppressed
+        return data;
+    }
+
+    @Test
+    public void testApplyNullYear() {
+        assertNull(observance.apply(null));
+    }
+
+    @Test
+    public void testTestNullYear() {
+        assertEquals(observance.test(null), false);
+    }
+
+    @Test
+    public void testDivergesFromUkShiftRuleIn2022() {
+        LocalDate ukShifted = new org.holiday.calendar.observance.uk.ChristmasEveEarlyClose().apply(2022);
+        assertEquals(ukShifted, LocalDate.of(2022, Month.DECEMBER, 23),
+                "UK rule shifts to the preceding Friday and must not be null");
+        assertNull(observance.apply(2022), "ASX rule must suppress entirely, not shift like UK");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/NewYearsEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/NewYearsEveEarlyCloseTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class NewYearsEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public NewYearsEveEarlyCloseTest() {
+        super(new NewYearsEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2011, null });                                   // Dec 31 Sat -> suppressed, pre-cycle edge year
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 31) }); // Dec 31 Thu -> present
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> present
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> suppressed
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> suppressed
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> present
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> present
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> present, confirmed by ASX's 2025/2026 notice
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 31) }); // Dec 31 Fri -> present
+        data.add(new Object[]{ 2028, null });                                   // Dec 31 Sun -> suppressed
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 31) }); // Dec 31 Mon -> present, boundary check adjacent to 2028
+        data.add(new Object[]{ 2033, null });                                   // Dec 31 Sat -> suppressed
+        return data;
+    }
+
+    @Test
+    public void testApplyNullYear() {
+        assertNull(observance.apply(null));
+    }
+
+    @Test
+    public void testTestNullYear() {
+        assertEquals(observance.test(null), false);
+    }
+
+    @Test
+    public void testDivergesFromUkShiftRuleIn2022() {
+        LocalDate ukShifted = new org.holiday.calendar.observance.uk.NewYearsEveEarlyClose().apply(2022);
+        assertEquals(ukShifted, LocalDate.of(2022, Month.DECEMBER, 30),
+                "UK rule shifts to the preceding Friday and must not be null");
+        assertNull(observance.apply(2022), "ASX rule must suppress entirely, not shift like UK");
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -554,4 +554,98 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 12. AU EARLY CLOSES (ASX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Both ASX Eve early closes are suppressed (not shifted) when their date falls on a
+    // weekend; since December 24 and December 31 are always exactly 7 days apart, they always
+    // share the same day-of-week within a year, so count is always 0 or 2, never 1. Expected
+    // presence is re-derived from December 24's day-of-week rule for every year rather than
+    // hand-fixtured.
+    //
+    // AU's Christmas Day and New Year's Day are both rollable under
+    // previousFridayOrFollowingMonday, same as FR, so this section additionally verifies the
+    // two genuine cross-list date collisions this produces: Christmas Day rolling back onto
+    // December 24 in Dec-25-Saturday years, and New Year's Day rolling back onto the prior
+    // December 31 in Jan-1-Saturday years (a year-boundary-crossing collision that a same-year
+    // intersection check alone would miss).
+    @Test(description = "AU calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
+            + "and always co-occur, no nulls, chronological order, and known Christmas Day/New Year's "
+            + "Day roll collisions are accounted for")
+    public void testAUEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("AU");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "AU: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 2,
+                    "AU " + year + ": expected count in {0,2}, got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), expected,
+                    "AU " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+            assertEquals(names.contains("New Year's Eve"), expected,
+                    "AU " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            // Cross-list date collision: empty in ordinary years, exactly {Dec 24} in
+            // Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve).
+            List<HolidayDate> fullDay = calendar.calculate(year);
+            Set<LocalDate> fullDayDates = fullDay.stream().map(HolidayDate::date).collect(Collectors.toSet());
+            Set<LocalDate> earlyCloseDates = earlyCloses.stream().map(HolidayDate::date).collect(Collectors.toSet());
+            Set<LocalDate> intersection = fullDayDates.stream()
+                    .filter(earlyCloseDates::contains)
+                    .collect(Collectors.toSet());
+            boolean isChristmasDaySaturdayRollYear =
+                    DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
+            if (isChristmasDaySaturdayRollYear) {
+                assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
+                        "AU " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+            } else {
+                assertTrue(intersection.isEmpty(), "AU " + year + ": unexpected cross-list date collision: " + intersection);
+            }
+
+            // Cross-year collision: New Year's Day rolling back onto this year's December 31
+            // whenever January 1 of the following year falls on a Saturday.
+            boolean isNewYearsDaySaturdayRollYear =
+                    DayOfWeek.SATURDAY.equals(LocalDate.of(year + 1, Month.JANUARY, 1).getDayOfWeek());
+            if (isNewYearsDaySaturdayRollYear) {
+                LocalDate dec31 = LocalDate.of(year, Month.DECEMBER, 31);
+                boolean newYearsDayPresent = calendar.calculate(year + 1).stream()
+                        .anyMatch(hd -> "New Year's Day".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
+                boolean newYearsEvePresent = names.contains("New Year's Eve");
+                assertTrue(newYearsDayPresent,
+                        "AU " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
+                assertTrue(newYearsEvePresent,
+                        "AU " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
+            }
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "AU: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "AU: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "AU: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "AU: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -597,8 +597,9 @@ public class HolidayCalendar30YearIT {
             assertEquals(names.contains("New Year's Eve"), expected,
                     "AU " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
 
-            // Cross-list date collision: empty in ordinary years, exactly {Dec 24} in
-            // Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve).
+            // Cross-list date collision: empty in ordinary years, exactly one date
+            // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
+            // onto Christmas Eve.
             List<HolidayDate> fullDay = calendar.calculate(year);
             Set<LocalDate> fullDayDates = fullDay.stream().map(HolidayDate::date).collect(Collectors.toSet());
             Set<LocalDate> earlyCloseDates = earlyCloses.stream().map(HolidayDate::date).collect(Collectors.toSet());


### PR DESCRIPTION
### Title of the PR

#211 AU: Model ASX Christmas Eve / New Year's Eve half-day closes

**Description**

- Adds Christmas Eve (Dec 24) and New Year's Eve (Dec 31) to `HolidayCalendarServiceAU` as `EARLY_CLOSE` holidays (ASX half-day close, 14:10 `Australia/Sydney`).
- Verified against ASX's own official trading-hours notices: the Nov 2025 Christmas/New Year notice confirms the 14:10 Sydney close applies to both dates, and the Nov 2022 notice confirms ASX **suppresses** the half-day entirely (does not shift to the preceding Friday) when Dec 24/31 falls on a Saturday or Sunday — with Dec 24, 2022 on a Saturday, Dec 23, 2022 traded normal full hours rather than an early close.
- Issue #211 originally scoped only Christmas Eve; this research found ASX runs the identical half-day on New Year's Eve too, so the issue was updated (see #211) before implementation to match.
- New `org.holiday.calendar.observance.au` classes (`ChristmasEveEarlyClose`, `NewYearsEveEarlyClose`), modeled on the existing CA/FR suppress-on-weekend mechanism rather than the UK shift mechanism.
- AU's Christmas Day and New Year's Day are both rollable, same as FR, which produces two genuine date collisions with the new early closes — a same-year Dec 24 collision (Christmas Day rolls back onto Christmas Eve in Dec-25-Saturday years) and a cross-year Dec 31 collision (New Year's Day rolls back onto the prior year's New Year's Eve in Jan-1-Saturday years). Both are covered by explicit named regression tests, including in the 30-year integration suite.
- No `holiday-calendar-core` changes needed — `EARLY_CLOSE` + `isValidYear`-based suppression is already a proven composition (`ca`, `fr`).
- Investigated whether TSX (CA) has a similarly unmodeled New Year's Eve half-day; TMX Group's own holiday schedule shows TSX/TSXV trade regular hours on Dec 31 (only the Montréal Exchange's interest-rate derivatives get an early close that day), so no corresponding CA change was made.

**Related Issue**

- #211

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed (none required — no README changes needed for early-close-only additions, per repo convention)
- [x] Screenshots or additional notes added, if needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)
