### PR TITLE
chore: release 2.0.0

### DIFF
--- a/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
+++ b/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
@@ -1,0 +1,211 @@
+# Agent prompt templates
+
+Placeholders: `{ISSUE_NUMBER}`, `{ISSUE_TEXT}` (full `gh issue view` output),
+`{CODE}` (region/exchange code, e.g. `US`), `{HOLIDAY_OR_CHANGE_DESC}` (one
+sentence naming what's being added/changed), `{EXPLORE_FINDINGS}` (Phase 1
+results, summarized), `{RESEARCH_FINDINGS}`, `{ENGINEER_DESIGN}`,
+`{COMBINED_DRAFT}` (research + engineer + test sections concatenated).
+
+Launch each via the `Agent` tool, `subagent_type: general-purpose`,
+`run_in_background: false` — each depends on the prior one's output.
+
+---
+
+## 1. Research analyst
+
+```
+You are acting as a research analyst with expertise in [world equities market
+conventions | regional/cultural holiday conventions — pick whichever fits
+{HOLIDAY_OR_CHANGE_DESC}]. I need you to verify the factual claims in GitHub
+issue #{ISSUE_NUMBER} of this holiday-calendar library against authoritative
+primary sources before an engineer builds on them.
+
+Issue text:
+{ISSUE_TEXT}
+
+Use WebSearch/WebFetch. Prefer the exchange's/authority's own official
+calendar or press releases over secondary aggregators — if a secondary
+source and the primary source disagree, trust the primary source and say so.
+
+I need:
+1. Exact date(s)/rule(s) as officially published — confirm or correct the
+   issue's stated rule. Pay special attention to boundary conditions (e.g.
+   "falls on a Monday" vs "falls Tuesday-Friday" are NOT the same set of
+   days — the issue text has been wrong about exactly this kind of boundary
+   before).
+2. Any conditions under which the holiday/close does NOT occur, and whether
+   in that case it's suppressed entirely for the year or shifted to another
+   date — these are different semantics and matter a lot for implementation.
+3. Exact time/timezone if applicable (IANA zone id, not just an offset).
+4. A multi-year table (at least one full cycle of the relevant day-of-week
+   pattern, typically 7-9 years) of concrete example years with the actual
+   observed date/absence, sourced from primary references, suitable for use
+   as test fixtures.
+5. Cite every source URL you used.
+
+Report structured findings (numbered per point above), flagging explicitly
+anywhere the issue text was imprecise or wrong.
+```
+
+---
+
+## 2. Senior engineer
+
+```
+You are a senior Java engineer (Java 21+) proposing an implementation for
+GitHub issue #{ISSUE_NUMBER} in the holiday-calendar-java repo (multi-module
+Maven, TestNG). Do NOT write code files — produce a detailed implementation
+PLAN a plan document can include verbatim.
+
+Issue: {HOLIDAY_OR_CHANGE_DESC} in HolidayCalendarService{CODE}.
+
+Verified research findings (primary-sourced, treat as ground truth over the
+issue's own text):
+{RESEARCH_FINDINGS}
+
+Codebase context already confirmed by exploration:
+{EXPLORE_FINDINGS}
+
+This repo's reusable conventions to follow:
+- `Holiday.builder()...type(Holiday.Type.X)...build()` — Type values include
+  FIXED, FLOATING, SPECIAL_ANNIVERSARY, EARLY_CLOSE. Pick the one that
+  actually matches the semantics confirmed by research, not the one the
+  issue assumed.
+- For EARLY_CLOSE: `IsraelHolidays.earlyCloseHolidays()` (mena module) is the
+  original pattern; `HolidayCalendarServiceUK`'s Christmas Eve/New Year's Eve
+  is the most recent precedent. Both ALWAYS produce a date (UK shifts
+  weekend dates to the preceding Friday; Israel's Erev holidays are always
+  the day before their anchor). If your research found a "sometimes there is
+  no early close/holiday at all this year" rule, that is a DIFFERENT
+  semantic from either precedent — say so explicitly, and use
+  `AbstractObservance.isValidYear(int)` returning `false` (not a shifting
+  `computeDate`) to represent absence. Note in the new Observance's Javadoc
+  that this is a different use of `isValidYear` than its only other existing
+  use (`WesternEaster`/`OrthodoxEaster`, an algorithm-validity bound, not a
+  business-rule exclusion).
+- Observance classes live in `observance/<lowercase-code>/`, extend
+  `AbstractObservance`, override `computeDate` and (if needed) `isValidYear`.
+  Small single-purpose classes — this repo's precedent (UK) does NOT share a
+  helper between near-identical eligibility checks; follow that unless you
+  have a concrete reason not to.
+- Registration happens in `HolidayCalendarService{CODE}.getHolidayCalendar()`
+  via `Holiday.builder()...build()` then `.holiday(...)` in the
+  `HolidayCalendar.builder()` chain (or `.holidays(list)` if there's a shared
+  factory list like Israel's).
+
+Propose:
+1. Package/class layout — new Observance class(es), and whether any existing
+   Observance needs modification (usually not — only its registration type
+   changes) or reuse.
+2. Exact `computeDate`/`isValidYear` logic (or `test`/`apply` if implementing
+   `Observance` directly), matching the confirmed semantics from research.
+3. Exact new/changed `Holiday.builder()` blocks and `HolidayCalendar.builder()`
+   chain additions for `HolidayCalendarService{CODE}`.
+4. Naming — check for existing naming conventions in this calendar and
+   others; flag if your chosen name is a stylistic outlier (e.g. ordinals,
+   redundant type-suffixes).
+5. Whether `holiday-calendar-core` needs any changes — usually none, if this
+   fits an existing `Holiday.Type`; confirm by reading the relevant core
+   classes rather than assuming.
+6. Breaking-change / migration considerations — does this move a holiday
+   between `calculate()` and `calculateEarlyCloses()`, or change a name any
+   consumer might match on? State the impact plainly. Do not assert
+   CHANGELOG.md conventions without checking `git log -- CHANGELOG.md` and
+   recent precedent commits first.
+
+Report a structured, detailed plan (headers per point above).
+```
+
+---
+
+## 3. Test engineer
+
+```
+You are a test engineer reviewing this proposed implementation for GitHub
+issue #{ISSUE_NUMBER} (holiday-calendar-java, TestNG 7.7.1 with
+@DataProvider). Examine existing test patterns for the relevant holiday type
+in this codebase, identify best practices, and propose concrete tests.
+Do not write code files — produce a test plan section.
+
+Finalized engineering design:
+{ENGINEER_DESIGN}
+
+Verified research fixture data (use this for DataProvider rows, not
+invented dates):
+{RESEARCH_FINDINGS}
+
+This repo's test conventions:
+- `AbstractHolidayCalendarServiceTest` (holiday-calendar-western,
+  org.holiday.calendar.impl) — every `HolidayCalendarService<CODE>Test`
+  extends this; supplies `expectedHolidayNames()` and
+  `expectedHolidayOccurrences()` DataProviders.
+- `AbstractObservanceTest` (org.holiday.calendar.western.test) — every
+  `<Observance>Test` extends this, passing the Observance instance to
+  `super()` and overriding `createData()` with `{year, expectedDateOrNull}`
+  rows.
+- The closest `<Code>EarlyCloseTest`/equivalent precedent class (e.g.
+  `HolidayCalendarServiceUKEarlyCloseTest`) for count/presence/closeTime/
+  zoneId/rollability assertions — adapt for this issue's actual semantics
+  (fixed count vs. variable count per year, always-present vs.
+  sometimes-absent).
+- `tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java` —
+  add a rule-derived (not hand-fixtured) 30-year section if the change is a
+  recurring annual rule, re-deriving expected presence/date from the
+  day-of-week rule for every year in range rather than hardcoding results.
+
+Propose:
+1. New/updated test files — exact paths, one-line purpose each.
+2. Observance unit test(s) — fixture rows from the verified research table,
+   plus 1-2 edge years outside the sampled cycle (compute and verify the
+   actual day-of-week yourself before hardcoding — do not guess).
+3. Any explicitly-named regression test for a boundary case the research
+   analyst flagged as easy to get wrong (e.g. an off-by-one weekday) — this
+   must be a named test, not incidental DataProvider coverage.
+4. Integration-level test class changes/additions (count, presence/absence
+   per holiday name — not just count, since count alone can mask one
+   holiday's presence covering for another's incorrect absence).
+5. `HolidayCalendar30YearIT` addition, if applicable.
+6. Any risk/gap you'd flag (e.g. a date-collision test between this change
+   and an existing rollable holiday landing on the same computed date).
+
+Report a structured plan (headers per point above).
+```
+
+---
+
+## 4. Devil's advocate
+
+```
+You are a devil's advocate reviewer. Below is a draft implementation plan
+(research + engineering + test sections) for GitHub issue #{ISSUE_NUMBER} in
+this holiday-calendar-java repo. Find weaknesses, challenge assumptions, and
+verify claims against the actual codebase — don't just approve. Cite the
+specific claim you're challenging. If something is genuinely fine after
+scrutiny, say so briefly rather than manufacturing a complaint.
+
+{COMBINED_DRAFT}
+
+Specifically check:
+- Does the cited precedent actually support the proposed design, or is it a
+  superficially-similar-but-semantically-different case (e.g. "shifts to
+  another date" vs. "is absent this year" are not the same mechanism, even
+  if both are called EARLY_CLOSE)?
+- Any reused core-abstraction hook (e.g. `isValidYear`) being used for a
+  purpose different from its only other existing use in this codebase — is
+  that a problem, or just worth a comment?
+- Any repo-convention claim (CHANGELOG.md handling, README update rules,
+  versioning) — verify against actual `git log`/recent commits rather than
+  trusting the engineer agent's assertion.
+- Test coverage gaps: does a boundary/edge case the research analyst flagged
+  get an explicitly-named test, or only incidental coverage? Is there a
+  same-date collision risk between the new holiday and an existing rollable
+  holiday that isn't tested?
+- Naming: is the proposed name consistent with this codebase's existing
+  naming conventions, or an outlier worth a second opinion?
+- Anything module-info.java/JPMS-related, or any mismatch between the
+  explored package names and this repo's documented module names.
+
+Report findings as a concise, prioritized list (most important first), each
+with: the specific claim being challenged, why it's a concern, and a
+concrete suggestion or question to resolve it before implementation begins.
+```

--- a/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
+++ b/.claude/skills/region-calendar-issue-plan/AGENT_PROMPTS.md
@@ -92,6 +92,22 @@ This repo's reusable conventions to follow:
   via `Holiday.builder()...build()` then `.holiday(...)` in the
   `HolidayCalendar.builder()` chain (or `.holidays(list)` if there's a shared
   factory list like Israel's).
+- SonarCloud rule S8696 (never use `==`/`!=` to compare value-based types —
+  `DayOfWeek`, `Month`, `LocalDate`, etc. — always use `.equals()`) has been
+  flagged and fixed on multiple prior PRs (#204/TR, #205/US, #206/CA) as a
+  CRITICAL reliability bug. Any new code you propose must use `.equals()` for
+  these comparisons from the start (e.g.
+  `DayOfWeek.SATURDAY.equals(someDate.getDayOfWeek())`, not
+  `someDate.getDayOfWeek() == DayOfWeek.SATURDAY`). Critically, SonarCloud's
+  PR analysis re-flags **pre-existing** violations anywhere in a file the PR
+  touches — not just the changed lines — as "new" issues that fail the
+  quality gate. This bit the #206/CA PR: a latent `==` comparison in
+  `HolidayCalendarServiceCA`'s existing `dateRoll` lambda, untouched by that
+  PR's own diff, still failed CI once the file was modified elsewhere. So:
+  when your plan modifies an existing `HolidayCalendarService{CODE}` or
+  `Observance` file, explicitly grep that whole file for `==`/`!=` comparisons
+  against `DayOfWeek`/`Month`/`LocalDate`/other value-based types and include
+  fixing any you find as part of the plan, even if unrelated to this issue.
 
 Propose:
 1. Package/class layout — new Observance class(es), and whether any existing
@@ -112,6 +128,12 @@ Propose:
    consumer might match on? State the impact plainly. Do not assert
    CHANGELOG.md conventions without checking `git log -- CHANGELOG.md` and
    recent precedent commits first.
+7. SonarCloud S8696 sweep — for every existing file this plan modifies (not
+   just newly-created files), report whether you grepped it for `==`/`!=`
+   comparisons against `DayOfWeek`/`Month`/`LocalDate`/other value-based
+   types, and list any found (with line numbers) as required fixes alongside
+   the feature change, so CI doesn't fail on a pre-existing issue the PR
+   incidentally surfaces.
 
 Report a structured, detailed plan (headers per point above).
 ```

--- a/.claude/skills/region-calendar-issue-plan/SKILL.md
+++ b/.claude/skills/region-calendar-issue-plan/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: region-calendar-issue-plan
+description: Turn a GitHub issue about a region/exchange-specific holiday-calendar change (new national/market calendar, new holiday, EARLY_CLOSE/half-day modeling, roll-rule change) into a reviewed implementation plan for this repo, using a 4-agent workflow (research analyst, senior engineer, test engineer, devil's advocate). Use when planning work for a HolidayCalendarService<CODE> change, or any issue that names a specific market/region convention (close times, eligibility rules, observance dates) that must be verified before implementing.
+---
+
+# Region/exchange calendar issue → implementation plan
+
+Produces a written plan (Plan Mode plan file) for a GitHub issue that adds or
+changes holidays in a `HolidayCalendarService<CODE>` in this repo. Do not
+write implementation code from this skill — it only produces the plan.
+Requires: a GitHub issue number, and the region/exchange code (e.g. `US`,
+`UK`, `CHF`) the issue targets. If the user hasn't given both, ask first.
+
+Run this inside Plan Mode. If not already in Plan Mode, invoke `EnterPlanMode`
+before starting.
+
+## Phase 1 — Read the issue, explore the codebase (parallel)
+
+1. `gh issue view <number>` to get the exact requirements text. Do not
+   paraphrase from memory — the issue text itself may contain an incorrect
+   rule (this has happened before; catching it is the research analyst's job
+   in Phase 2).
+2. Launch up to 3 `Explore` agents in parallel:
+   - **Core abstractions**: `Holiday` sealed interface + builder, `Holiday.Type`
+     enum, `Observance`/`AbstractObservance`, `HolidayCalendar.calculate()` /
+     `calculateEarlyCloses()`, and (if the issue is about a half-day/early
+     close) `EarlyCloseHoliday` plus its two real precedents:
+     `IsraelHolidays.earlyCloseHolidays()` (mena module) and
+     `HolidayCalendarServiceUK`'s Christmas Eve/New Year's Eve early closes
+     (western module). Read the actual source, not just names.
+   - **Closest precedent for this specific issue**: find the
+     `HolidayCalendarService<CODE>` and its `observance/<code>/` package for
+     the target region, and the most recently-added holiday of the *same
+     kind* elsewhere in the codebase (another EARLY_CLOSE, another new
+     calendar, another roll-rule change — whichever matches this issue).
+   - **Test infrastructure**: `AbstractHolidayCalendarServiceTest`,
+     `AbstractObservanceTest`, the closest `HolidayCalendarService<CODE>Test`
+     / `<Code>EarlyCloseTest` precedent, and the `tests` module's
+     `HolidayCalendar30YearIT`.
+
+## Phase 2 — Four specialist agents, run sequentially in the foreground
+
+Run in the foreground (`run_in_background: false`) and in this order —
+each later agent depends on the previous one's output, so do not parallelize:
+
+1. **Research analyst** — verifies the issue's factual claims (dates, close
+   times, eligibility rules, timezone) against primary sources (official
+   exchange/market calendars, not secondary aggregators). Must explicitly
+   flag any place the issue text is wrong or imprecise, and produce a
+   multi-year fixture table an engineer/tester can build from.
+2. **Senior engineer** — given the research findings and Phase 1 codebase
+   context, proposes concrete classes/files, registration changes, naming,
+   and states plainly whether core-module changes are needed (usually none
+   are, if this fits an existing `Holiday.Type`). Must not assume the closest
+   precedent's *mechanism* transfers unchanged — state explicitly what's the
+   same and what's different (e.g. "shift to nearest weekday" vs "suppress
+   entirely in some years" are different semantics that look similar).
+3. **Test engineer** — given the engineer's finalized design, proposes new
+   test files/methods grounded in the research analyst's fixture table,
+   reusing `AbstractObservanceTest`/`AbstractHolidayCalendarServiceTest` and
+   proposing a `HolidayCalendar30YearIT` addition if the change is long-lived.
+4. **Devil's advocate** — given the combined draft (research + engineering +
+   test sections), actively looks for holes: mismatched precedent semantics,
+   unverified assumptions, missing edge-year coverage, breaking-change
+   handling, and repo-convention claims that aren't actually true (verify
+   against real commit history, e.g. whether CHANGELOG.md is actually
+   updated per-PR or only at release — check, don't assume either way).
+
+Prompt templates for all four agents: see [AGENT_PROMPTS.md](AGENT_PROMPTS.md).
+
+## Phase 3 — Resolve findings, don't just collect them
+
+Every devil's-advocate finding must be resolved before the plan is written,
+not appended as a footnote:
+- If it's a factual question only the user can answer (naming preference,
+  version/release targeting, scope) → `AskUserQuestion`.
+- If it's a verifiable claim (e.g. "does this repo actually update
+  CHANGELOG.md per PR?") → check it yourself (`git log`, `git show` on the
+  closest precedent commits) and correct the plan.
+- If it's a design concern → make the call and state the reasoning in the
+  plan; don't leave it open.
+
+## Phase 4 — Write the plan and exit
+
+Write the plan file with these sections (see the `#205` NYSE half-day-close
+plan in this repo's history for a worked example of this shape):
+- **Context** — why this change, what precedent it follows, what is
+  genuinely different from that precedent (don't overstate similarity).
+- **Implementation** — concrete new/changed files, registration blocks,
+  naming decisions, explicit "no core-module changes needed" confirmation
+  (or what's needed if not).
+- **Tests** — concrete new/updated test files, fixture tables sourced from
+  the research analyst's verified data, and any `HolidayCalendar30YearIT`
+  addition.
+- **Verification** — the `mvn` commands to run before considering this done.
+
+Call `ExitPlanMode` once the plan is written and any open questions are
+resolved.

--- a/.gitignore
+++ b/.gitignore
@@ -98,14 +98,21 @@ local.properties
 # When using Gradle or Maven with auto-import, you should exclude module files,
 # since they will be recreated, and may cause churn.  Uncomment if using
 # auto-import.
-# .idea/artifacts
-# .idea/compiler.xml
-# .idea/jarRepositories.xml
-# .idea/modules.xml
-# .idea/*.iml
-# .idea/modules
-# *.iml
-# *.ipr
+.idea/artifacts
+.idea/compiler.xml
+.idea/jarRepositories.xml
+.idea/modules.xml
+.idea/*.iml
+.idea/modules
+*.iml
+*.ipr
+
+# Other per-developer IntelliJ files not covered above (this project uses
+# Maven with auto-import; .idea/copyright/ is intentionally tracked for
+# shared license-header settings)
+.idea/encodings.xml
+.idea/vcs.xml
+.idea/sonarlint.xml
 
 # CMake
 cmake-build-*/

--- a/.gitignore
+++ b/.gitignore
@@ -243,4 +243,6 @@ gradle-app.setting
 # JDT-specific (Eclipse Java Development Tools)
 
 ### Claude Code ###
-.claude/
+.claude/*
+!.claude/skills/
+!.claude/skills/**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,37 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.0.0] - 2026-08-01
+
+### Added
+
+- New `EarlyCloseHoliday` sealed interface type to model half-day market closures with specific close times and timezones (#176)
+- New `HolidayCalendar.calculateEarlyCloses(int year)` API to retrieve early close days separately from regular holidays
+- New `HolidayCalendar.hasEarlyCloses()` convenience method to check if a calendar has early close days
+- Half-day close modeling for 8 regional exchanges:
+  - US NYSE: Thanksgiving Friday, Christmas Eve, July 3rd half-day closes (#205)
+  - CA TSX: Christmas Eve half-day close; confirmed no Dec 31 close (#206, #220)
+  - AU ASX: Christmas Eve and New Year's Eve 14:10 Sydney early closes (#211, #221)
+  - FR Euronext Paris: Christmas Eve and New Year's Eve half-day closes (#210)
+  - UK LSE: Christmas Eve and New Year's Eve half-day closes (#207)
+  - SG SGX: Christmas Eve and New Year's Eve half-day closes (#212)
+  - CH SIX: Christmas Eve and New Year's Eve (no-roll convention) (#208)
+  - DE Xetra: Christmas Eve and New Year's Eve modeling (#209)
+- Improved Turkey Islamic holiday accuracy (#180):
+  - Diyanet astronomical ilmi takvim calculator for years 2036-2055 (beyond published data)
+  - Corrected Arefe/Bayram confusion and invalid data entries
+  - Validated against all 24 published Diyanet dates 2024-2035
+
+### Changed
+
+- **BREAKING**: `Holiday` sealed interface now includes `EarlyCloseHoliday` as a permitted subtype. Existing code using switch/pattern matching on Holiday must account for this new type.
+- **BREAKING**: `HolidayCalendar.calculate(int year)` now explicitly excludes early close days; use `calculateEarlyCloses()` to retrieve them
+- Early close holidays are never rollable (by design; trading hours apply on the actual date)
+
+### Fixed
+
+- SonarCloud duplication and inspection violations in AU/ASX half-day close logic (#221)
+
 ## [1.4.0] - 2026-05-22
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,19 +33,21 @@ This is a multi-module Maven project:
 
 | Module | JPMS Module Name | Purpose |
 |--------|------------------|---------|
-| `holiday-calendar-core` | `holiday.calendar.core` | Core API and abstractions |
-| `holiday-calendar-western` | `holiday.calendar.western` | Western calendars: US, CA, UK, CH, DE, FR, AU |
-| `holiday-calendar-apac` | `holiday.calendar.apac` | APAC calendars: SG (uses Time4J for non-Gregorian) |
+| `holiday-calendar-core` | `org.holiday.calendar.core` | Core API and abstractions |
+| `holiday-calendar-western` | `org.holiday.calendar.western` | Western calendars: US, CA, UK, CH, DE, FR, AU |
+| `holiday-calendar-apac` | `org.holiday.calendar.apac` | APAC calendars: SG, JP, CN (uses Time4J for non-Gregorian) |
+| `holiday-calendar-mena` | `org.holiday.calendar.mena` | MENA calendars: AE, SA, IL, TR, QA, EG, KW, BH, MA, JO (uses Time4J for Islamic calendar) |
 | `tests` | — | Test aggregation and JaCoCo coverage reporting for SonarCloud |
 
 ## Architecture
 
 ### Core Abstractions (`holiday-calendar-core`)
 
-**`Holiday`** (sealed interface) — base for all holidays; three permitted types selected via builder:
+**`Holiday`** (sealed interface) — base for all holidays; four permitted types selected via builder:
 - `FixedHoliday` — same `MonthDay` every year (e.g., New Year's Day)
 - `FloatingHoliday` — date computed per year via an `Observance` function (e.g., Easter)
 - `SpecialAnniversary` — anniversary-based holidays
+- `EarlyCloseHoliday` — half-day market close (`Holiday.Type.EARLY_CLOSE`); carries a `closeTime`/`zoneId`, is always non-rollable, and is excluded from `HolidayCalendar.calculate()` — use `calculateEarlyCloses(int year)` instead. See `IsraelHolidays.earlyCloseHolidays()` (mena) and `HolidayCalendarServiceUK`'s Christmas Eve/New Year's Eve (western) for precedent.
 
 **`HolidayCalendar`** — named collection of holidays with a `DateRoll` strategy and configurable `weekendDays`. Its `calculate(int year)` returns sorted `HolidayDate` instances with rolling applied (respects the `rollable` flag per holiday).
 
@@ -63,10 +65,37 @@ This is a multi-module Maven project:
 
 ### Implementations (`holiday-calendar-western`)
 
-Regional `HolidayCalendarService` implementations: `HolidayCalendarServiceUS`, `HolidayCalendarServiceCA`, `HolidayCalendarServiceUK`, `HolidayCalendarServiceCH`, `HolidayCalendarServiceDE`, `HolidayCalendarServiceFR`, `HolidayCalendarServiceAU`.
+National and market/central-bank `HolidayCalendarService` implementations, one pair per country where both exist:
+- `US` (United States National) / `USD` (Federal Reserve)
+- `CA` (Canada National) / `CAD` (Bank of Canada / Lynx)
+- `UK` (United Kingdom National) / `GBP` (CHAPS)
+- `CH` (Switzerland / SIX) / `CHF` (SIC/SNB)
+- `DE` (Germany / Xetra)
+- `FR` (France / Euronext Paris)
+- `AU` (Australian Securities Exchange) / `AUD` (RBA)
+- `EUR` (TARGET2)
 
 Observances are organized by region under the `observance` package. Easter-related observances live in `observance.christian` and extend `CompositeObservance` (e.g., `GoodFriday`, `EasterMonday`). `WesternEaster` and `OrthodoxEaster` extend `AbstractObservance` directly. Regional sub-packages: `us/`, `ca/`, `uk/`, `eu/`, `au/`.
 
 ### Implementations (`holiday-calendar-apac`)
 
-`HolidayCalendarServiceSG` (SGX). Non-Gregorian holidays use Time4J (`ChineseCalendar` for Chinese New Year) or lookup tables (Vesak Day, Hari Raya Puasa/Haji, Deepavali).
+- `SG` (Singapore SGX) / `SGD` (MAS/MEPS+)
+- `JP` (Tokyo Stock Exchange) / `JPY` (Bank of Japan)
+- `CN` (China National) / `CNY` (People's Bank of China)
+
+Non-Gregorian holidays use Time4J (`ChineseCalendar` for Chinese New Year) or lookup tables (Vesak Day, Hari Raya Puasa/Haji, Deepavali). Observance sub-packages: `observance.lunar`, `observance.islamic.apac`, `observance.hindu`, `observance.jp`.
+
+### Implementations (`holiday-calendar-mena`)
+
+- `AE` (United Arab Emirates National) / `AED` (CBUAE/DFM/ADX)
+- `SA` (Saudi Arabia National) / `SAR` (Tadawul/SAMA)
+- `IL` (Israel National) / `ILS` (TASE/Bank of Israel)
+- `TR` (Turkey National) / `TRY` (BIST/TCMB)
+- `QA` (Qatar National) / `QAR` (QSE/QCB)
+- `EG` (Egypt National) / `EGP` (EGX/CBE)
+- `KW` (Kuwait National) / `KWD` (Boursa Kuwait/CBK)
+- `BH` (Bahrain National) / `BHD` (Boursa Bahrain/CBB)
+- `MA` (Morocco National) / `MAD` (CSE/BAM)
+- `JO` (Jordan National) / `JOD` (ASE/CBJ)
+
+Islamic-calendar holidays (Eid al-Fitr, Eid al-Adha, Islamic New Year, Ashura, etc.) use CSV-backed lookup data with a Diyanet "ilmi takvim" astronomical fallback calculator for years beyond the data ceiling; see `observance.islamic.mena`. `IsraelHolidays` (package-private) centralizes the shared holiday list — including `earlyCloseHolidays()` — consumed by both `HolidayCalendarServiceIL` and `HolidayCalendarServiceILS`. Observance sub-packages: `observance.eg`, `observance.islamic.mena`, `observance.hebrew`, `observance.qa`.

--- a/README.md
+++ b/README.md
@@ -85,28 +85,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>1.4.0</version>
+  <version>1.5.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,28 +85,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>1.5.0-SNAPSHOT</version>
+  <version>2.0.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/README.md
+++ b/README.md
@@ -85,28 +85,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>2.0.0-SNAPSHOT</version>
+  <version>2.0.0</version>
 </dependency>
 ```
 

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-apac/src/main/java/module-info.java
+++ b/holiday-calendar-apac/src/main/java/module-info.java
@@ -34,6 +34,7 @@ module org.holiday.calendar.apac {
     exports org.holiday.calendar.observance.islamic.apac;
     exports org.holiday.calendar.observance.hindu;
     exports org.holiday.calendar.observance.jp;
+    exports org.holiday.calendar.observance.sg;
 
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceCNY,

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
@@ -19,13 +19,23 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.sg.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.sg.NewYearsEveEarlyClose;
 
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.OptionalInt;
 
 /**
  * Service for provision of Singapore Exchange (SGX) holiday calendar.
+ *
+ * <p>Includes two {@code EARLY_CLOSE} holidays representing SGX's Christmas
+ * Eve and New Year's Eve half-day trading closes. The MAS/MEPS+ settlement
+ * calendar ({@link HolidayCalendarServiceSGD}) does not include these — MEPS+
+ * RTGS settlement and SGX equities trading are distinct systems.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -33,6 +43,7 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
 
     private static final String CODE = "SG";
     private static final String NAME = "Singapore (SGX) Holidays";
+    private static final ZoneId SGX_ZONE = ZoneId.of("Asia/Singapore");
 
     public HolidayCalendarServiceSG() {
         super(CODE, NAME);
@@ -45,12 +56,35 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
+                             + "December 24 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(12, 0))
+                .zoneId(SGX_ZONE)
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
+                             + "December 31 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(12, 0))
+                .zoneId(SGX_ZONE)
+                .build();
+
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holidays(SingaporeHolidays.baseHolidays(true))
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyClose.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Singapore Exchange's (SGX) Christmas Eve half-day close
+ * (December 24). SGX's securities/equities market runs a half-day trading
+ * session (09:00-12:00 SGT) on December 24 whenever that date falls on a
+ * trading day; when December 24 falls on a Saturday or Sunday, the half-day
+ * close is simply not observed that year — it is not shifted to another
+ * date. {@link #isValidYear(int)} is overridden here to signal that
+ * business-rule absence, while {@link #computeDate(int)} unconditionally
+ * returns December 24.
+ *
+ * <p>Verified against SGX's Rulebook Regulatory/Practice Notice 8.2.1
+ * ("Trading Hours, Market Phases...") and cross-checked against SGX's
+ * published trading calendars, 2018-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyClose.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Singapore Exchange's (SGX) New Year's Eve half-day close
+ * (December 31). SGX's securities/equities market runs a half-day trading
+ * session (09:00-12:00 SGT) on December 31 whenever that date falls on a
+ * trading day; when December 31 falls on a Saturday or Sunday, the half-day
+ * close is simply not observed that year — it is not shifted to another
+ * date. {@link #isValidYear(int)} is overridden here to signal that
+ * business-rule absence, while {@link #computeDate(int)} unconditionally
+ * returns December 31.
+ *
+ * <p>Verified against SGX's Rulebook Regulatory/Practice Notice 8.2.1
+ * ("Trading Hours, Market Phases...") and cross-checked against SGX's
+ * published trading calendars, 2018-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGDTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGDTest.java
@@ -213,6 +213,29 @@ public class HolidayCalendarServiceSGDTest {
                 "at boundary: " + holidaysAtBoundary.size() + ", beyond: " + holidaysBeyond.size());
     }
 
+    // ── SGX early-close non-leakage ──────────────────────────────────────────
+    // SGX's Christmas Eve / New Year's Eve half-day closes apply only to the SG
+    // (SGX equities) calendar, not SGD (MAS/MEPS+ settlement). Guards against a
+    // future accidental copy-paste of SG's builder logic into SGD.
+
+    @Test
+    public void testCalculateEarlyClosesReturnsEmpty2018() {
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2018).isEmpty(),
+                "SGD must not have any EARLY_CLOSE holidays");
+    }
+
+    @Test
+    public void testCalculateEarlyClosesReturnsEmpty2022() {
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2022).isEmpty(),
+                "SGD must not have any EARLY_CLOSE holidays");
+    }
+
+    @Test
+    public void testCalculateEarlyClosesReturnsEmpty2024() {
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2024).isEmpty(),
+                "SGD must not have any EARLY_CLOSE holidays");
+    }
+
     // ── Helpers ───────────────────────────────────────────────────────────────
 
     private Optional<HolidayDate> findByName(List<HolidayDate> holidays, String name) {

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceSGEarlyCloseTest.java
@@ -1,0 +1,245 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.sg.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.sg.NewYearsEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code SG} calendar's early-close (SGX half-day closure)
+ * holidays: Christmas Eve and New Year's Eve. Because December 24 and
+ * December 31 are always exactly 7 days apart, they always share the same
+ * day-of-week within a given year — both early closes are always present
+ * together or absent together, never one without the other. This is a real
+ * difference from CA (single early close) and worth its own dedicated
+ * assertions below, beyond the standard count/presence/closeTime/zone checks.
+ */
+public class HolidayCalendarServiceSGEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 0);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Asia/Singapore");
+
+    // 11 full-day holidays registered in HolidayCalendarServiceSG; the two Eve
+    // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 11.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 11;
+
+    private final HolidayCalendarServiceSG service = new HolidayCalendarServiceSG();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2018-2026 SGX cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "sgEarlyCloseFixture")
+    public Iterator<Object[]> sgEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2018, true},
+                new Object[]{2019, true},
+                new Object[]{2020, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "SG " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "SG " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testNewYearsEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
+                "SG " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    // -------------------------------------------------------------------------
+    // Dual-suppression / dual-presence boundary (the SG-specific difference)
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testBothEarlyClosesSuppressedTogetherIn2022() {
+        // 2022: December 24 and December 31 both fall on Saturday.
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2022).isEmpty());
+    }
+
+    @Test
+    public void testBothEarlyClosesSuppressedTogetherIn2023() {
+        // 2023: December 24 and December 31 both fall on Sunday.
+        assertTrue(service.getHolidayCalendar().calculateEarlyCloses(2023).isEmpty());
+    }
+
+    @Test
+    public void testBothEarlyClosesPresentTogetherIn2024() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2024);
+        assertEquals(earlyCloses.size(), 2);
+        Set<String> names = earlyCloses.stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertEquals(names, Set.of("Christmas Eve", "New Year's Eve"));
+    }
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testCountIsNeverExactlyOne(int year, boolean present) {
+        int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
+        assertNotEquals(count, 1, "SG " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs12_00() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 12:00");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsAsiaSingapore() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in Asia/Singapore");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyClosesNotRollable() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // No date appears in both calculate() and calculateEarlyCloses() for the same year
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "sgEarlyCloseFixture")
+    public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+        assertTrue(intersection.isEmpty(),
+                "SG " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Christmas Eve", 2018},
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2025},
+                new Object[]{"Christmas Eve", 2026},
+                new Object[]{"New Year's Eve", 2018},
+                new Object[]{"New Year's Eve", 2024},
+                new Object[]{"New Year's Eve", 2025},
+                new Object[]{"New Year's Eve", 2026}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            case "New Year's Eve" -> new NewYearsEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class ChristmasEveEarlyCloseTest {
+
+    private final ChristmasEveEarlyClose observance = new ChristmasEveEarlyClose();
+
+    @DataProvider
+    Iterator<Object[]> yearFixture() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2017, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2018, LocalDate.of(2018, Month.DECEMBER, 24) }); // Dec 24 Mon -> eligible
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> eligible
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible
+        // Edge years outside the sampled 2018-2026 cycle
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 24) }); // Dec 24 Fri -> eligible
+        data.add(new Object[]{ 2028, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 24) }); // Dec 24 Mon -> eligible
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> ineligible
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testApplyMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+                "ChristmasEveEarlyClose.apply(" + year + ") mismatch");
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testPredicateMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.test(year), expected != null,
+                "ChristmasEveEarlyClose.test(" + year + ") mismatch");
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSaturday() {
+        // 2033: December 24 is a Saturday.
+        assertNull(observance.apply(2033));
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSunday() {
+        // 2028: December 24 is a Sunday.
+        assertNull(observance.apply(2028));
+    }
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+                "ChristmasEveEarlyClose.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+                "ChristmasEveEarlyClose.test(null) must return false per AbstractObservance contract");
+    }
+
+}

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/observance/sg/NewYearsEveEarlyCloseTest.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.sg;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+public class NewYearsEveEarlyCloseTest {
+
+    private final NewYearsEveEarlyClose observance = new NewYearsEveEarlyClose();
+
+    @DataProvider
+    Iterator<Object[]> yearFixture() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2017, null });                                   // Dec 31 Sun -> ineligible
+        data.add(new Object[]{ 2018, LocalDate.of(2018, Month.DECEMBER, 31) }); // Dec 31 Mon -> eligible
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 31) }); // Dec 31 Tue -> eligible
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 31) }); // Dec 31 Thu -> eligible
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> eligible
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> ineligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> eligible
+        // Edge years outside the sampled 2018-2026 cycle
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 31) }); // Dec 31 Fri -> eligible
+        data.add(new Object[]{ 2028, null });                                   // Dec 31 Sun -> ineligible
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 31) }); // Dec 31 Mon -> eligible
+        data.add(new Object[]{ 2033, null });                                   // Dec 31 Sat -> ineligible
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testApplyMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.apply(year), expected,
+                "NewYearsEveEarlyClose.apply(" + year + ") mismatch");
+    }
+
+    @Test(dataProvider = "yearFixture")
+    public void testPredicateMatchesFixture(int year, LocalDate expected) {
+        assertEquals(observance.test(year), expected != null,
+                "NewYearsEveEarlyClose.test(" + year + ") mismatch");
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSaturday() {
+        // 2033: December 31 is a Saturday.
+        assertNull(observance.apply(2033));
+    }
+
+    @Test
+    public void testIsValidYearFalseWhenSunday() {
+        // 2028: December 31 is a Sunday.
+        assertNull(observance.apply(2028));
+    }
+
+    @Test
+    public void testApplyNullYearReturnsNull() {
+        assertNull(observance.apply(null),
+                "NewYearsEveEarlyClose.apply(null) must return null per AbstractObservance contract");
+    }
+
+    @Test
+    public void testPredicateNullYearReturnsFalse() {
+        assertFalse(observance.test(null),
+                "NewYearsEveEarlyClose.test(null) must return false per AbstractObservance contract");
+    }
+
+}

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/EarlyCloseHoliday.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/EarlyCloseHoliday.java
@@ -23,7 +23,6 @@ import org.holiday.calendar.function.Observance;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.ZoneId;
-import java.util.Objects;
 import java.util.Optional;
 
 import static java.util.Objects.requireNonNull;
@@ -49,23 +48,18 @@ import static java.util.Objects.requireNonNull;
  * @see HolidayCalendar#calculateEarlyCloses(int)
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public final class EarlyCloseHoliday implements Holiday {
-
-    private final String name;
-    private final String description;
-    private final Observance observance;
-    private final LocalTime closeTime;
-    private final ZoneId zoneId;
+public record EarlyCloseHoliday(String name, String description, Observance observance,
+                                 LocalTime closeTime, ZoneId zoneId) implements Holiday {
 
     /**
      * Canonical constructor.
      */
-    public EarlyCloseHoliday(String name, String description, Observance observance, LocalTime closeTime, ZoneId zoneId) {
-        this.name = requireNonNull(name, "Argument 'name' cannot be null");
-        this.description = Optional.ofNullable(description).orElse("");
-        this.observance = requireNonNull(observance, "Argument 'observance' cannot be null");
-        this.closeTime = requireNonNull(closeTime, "Argument 'closeTime' cannot be null");
-        this.zoneId = requireNonNull(zoneId, "Argument 'zoneId' cannot be null");
+    public EarlyCloseHoliday {
+        requireNonNull(name, "Argument 'name' cannot be null");
+        description = Optional.ofNullable(description).orElse("");
+        requireNonNull(observance, "Argument 'observance' cannot be null");
+        requireNonNull(closeTime, "Argument 'closeTime' cannot be null");
+        requireNonNull(zoneId, "Argument 'zoneId' cannot be null");
     }
 
     @Override
@@ -104,22 +98,6 @@ public final class EarlyCloseHoliday implements Holiday {
     @Override
     public Optional<LocalDate> dateForYear(int year) {
         return Optional.ofNullable(observance.apply(year));
-    }
-
-    @Override
-    public boolean equals(Object o) {
-        if (this == o) return true;
-        if (!(o instanceof EarlyCloseHoliday that)) return false;
-        return name.equals(that.name)
-            && description.equals(that.description)
-            && observance.equals(that.observance)
-            && closeTime.equals(that.closeTime)
-            && zoneId.equals(that.zoneId);
-    }
-
-    @Override
-    public int hashCode() {
-        return Objects.hash(name, description, observance, closeTime, zoneId);
     }
 
     @Override

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/EarlyCloseHoliday.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/EarlyCloseHoliday.java
@@ -1,0 +1,132 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar;
+
+import org.holiday.calendar.function.Observance;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Objects;
+import java.util.Optional;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * A holiday which represents a partial trading day — a day on which a market or
+ * exchange closes early rather than closing for the entire day. Examples are the
+ * holiday eves observed by the Tel Aviv Stock Exchange (e.g. Erev Rosh Hashanah,
+ * Erev Yom Kippur), on which trading halts around midday.
+ *
+ * <p>Like a {@link FloatingHoliday}, the calendar date of an early close is
+ * computed per year via an {@link Observance}. In addition, an early close
+ * carries the {@link #getCloseTime() local time} at which trading ceases and the
+ * {@link #getZoneId() time zone} in which that time is expressed.</p>
+ *
+ * <p>An early close is inherently {@link #isRollable() non-rollable}: it is tied
+ * to the specific calendar day preceding the associated full holiday and is never
+ * adjusted for weekend observance. Consequently, early closes are excluded from
+ * {@link HolidayCalendar#calculate(int)} and are reported separately by
+ * {@link HolidayCalendar#calculateEarlyCloses(int)}.</p>
+ *
+ * @see Observance
+ * @see HolidayCalendar#calculateEarlyCloses(int)
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public final class EarlyCloseHoliday implements Holiday {
+
+    private final String name;
+    private final String description;
+    private final Observance observance;
+    private final LocalTime closeTime;
+    private final ZoneId zoneId;
+
+    /**
+     * Canonical constructor.
+     */
+    public EarlyCloseHoliday(String name, String description, Observance observance, LocalTime closeTime, ZoneId zoneId) {
+        this.name = requireNonNull(name, "Argument 'name' cannot be null");
+        this.description = Optional.ofNullable(description).orElse("");
+        this.observance = requireNonNull(observance, "Argument 'observance' cannot be null");
+        this.closeTime = requireNonNull(closeTime, "Argument 'closeTime' cannot be null");
+        this.zoneId = requireNonNull(zoneId, "Argument 'zoneId' cannot be null");
+    }
+
+    @Override
+    public String getName() { return name; }
+
+    @Override
+    public String getDescription() { return description; }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>An early close is always non-rollable; this method always returns
+     * {@code false}.</p>
+     */
+    @Override
+    public boolean isRollable() { return false; }
+
+    public Observance getObservance() { return observance; }
+
+    /**
+     * Get the local time at which trading ceases on this early-close day.
+     *
+     * @return early close time, expressed in the {@link #getZoneId() zone} of
+     *         this holiday
+     */
+    public LocalTime getCloseTime() { return closeTime; }
+
+    /**
+     * Get the time zone in which this holiday's {@link #getCloseTime() close time}
+     * is expressed.
+     *
+     * @return early close time zone
+     */
+    public ZoneId getZoneId() { return zoneId; }
+
+    @Override
+    public Optional<LocalDate> dateForYear(int year) {
+        return Optional.ofNullable(observance.apply(year));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof EarlyCloseHoliday that)) return false;
+        return name.equals(that.name)
+            && description.equals(that.description)
+            && observance.equals(that.observance)
+            && closeTime.equals(that.closeTime)
+            && zoneId.equals(that.zoneId);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(name, description, observance, closeTime, zoneId);
+    }
+
+    @Override
+    public String toString() {
+        return "Holiday[name='" + name + "', description='" + description
+            + "', observance=" + observance + ", closeTime=" + closeTime
+            + ", zoneId=" + zoneId + "]";
+    }
+
+}

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/Holiday.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/Holiday.java
@@ -21,8 +21,10 @@ package org.holiday.calendar;
 import org.holiday.calendar.function.Observance;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Month;
 import java.time.MonthDay;
+import java.time.ZoneId;
 import java.util.Optional;
 
 /**
@@ -34,13 +36,13 @@ import java.util.Optional;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public sealed interface Holiday permits FixedHoliday, FloatingHoliday, SpecialAnniversary {
+public sealed interface Holiday permits FixedHoliday, FloatingHoliday, SpecialAnniversary, EarlyCloseHoliday {
 
     /**
      * Enumerated type of {@link Holiday}.
      */
     enum Type {
-        FIXED, FLOATING, SPECIAL_ANNIVERSARY
+        FIXED, FLOATING, SPECIAL_ANNIVERSARY, EARLY_CLOSE
     }
 
     /**
@@ -55,6 +57,8 @@ public sealed interface Holiday permits FixedHoliday, FloatingHoliday, SpecialAn
         private MonthDay monthDay;
         private Observance observance;
         private LocalDate anniversaryDate;
+        private LocalTime closeTime;
+        private ZoneId zoneId;
 
         /**
          * Package private constructor. Not intended to be called directly by
@@ -111,6 +115,16 @@ public sealed interface Holiday permits FixedHoliday, FloatingHoliday, SpecialAn
             return this;
         }
 
+        public HolidayBuilder closeTime(final LocalTime closeTime) {
+            this.closeTime = closeTime;
+            return this;
+        }
+
+        public HolidayBuilder zoneId(final ZoneId zoneId) {
+            this.zoneId = zoneId;
+            return this;
+        }
+
         /**
          * Build the {@link Holiday} object.
          *
@@ -123,6 +137,7 @@ public sealed interface Holiday permits FixedHoliday, FloatingHoliday, SpecialAn
                 case FIXED            -> new FixedHoliday(name, description, monthDay, rollable);
                 case FLOATING         -> new FloatingHoliday(name, description, observance, rollable);
                 case SPECIAL_ANNIVERSARY -> new SpecialAnniversary(name, description, anniversaryDate, rollable);
+                case EARLY_CLOSE      -> new EarlyCloseHoliday(name, description, observance, closeTime, zoneId);
             };
         }
     }

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendar.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendar.java
@@ -261,7 +261,7 @@ public class HolidayCalendar {
      */
     public List<HolidayDate> calculateEarlyCloses(int year) {
         return holidays.stream()
-            .filter(holiday -> holiday instanceof EarlyCloseHoliday)
+            .filter(EarlyCloseHoliday.class::isInstance)
             .<HolidayDate>mapMulti((holiday, sink) ->
                 holiday.dateForYear(year).ifPresent(date -> sink.accept(new HolidayDate(holiday, date)))
             )

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendar.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendar.java
@@ -232,6 +232,7 @@ public class HolidayCalendar {
      */
     public List<HolidayDate> calculate(int year) {
         return holidays.stream()
+            .filter(holiday -> !(holiday instanceof EarlyCloseHoliday))
             .<HolidayDate>mapMulti((holiday, sink) ->
                 holiday.dateForYear(year).ifPresent(date -> {
                     LocalDate observed = holiday.isRollable() && weekendDays.contains(date.getDayOfWeek())
@@ -239,6 +240,30 @@ public class HolidayCalendar {
                         : date;
                     sink.accept(new HolidayDate(holiday, observed));
                 })
+            )
+            .sorted(Comparator.comparing(HolidayDate::getDate))
+            .toList();
+    }
+
+    /**
+     * Calculate the dates of the early-close (partial trading day) holidays on
+     * this calendar for the specified year. Only {@link EarlyCloseHoliday}
+     * instances are considered; these are inherently non-rollable, so no date
+     * rolling is applied.
+     *
+     * <p>Early closes are deliberately excluded from {@link #calculate(int)} and
+     * are reported exclusively by this method.</p>
+     *
+     * @param year Common Era (CE) year for which to obtain early-close dates
+     * @return chronologically-sorted list of early-close holiday dates
+     * @see EarlyCloseHoliday
+     * @see #calculate(int)
+     */
+    public List<HolidayDate> calculateEarlyCloses(int year) {
+        return holidays.stream()
+            .filter(holiday -> holiday instanceof EarlyCloseHoliday)
+            .<HolidayDate>mapMulti((holiday, sink) ->
+                holiday.dateForYear(year).ifPresent(date -> sink.accept(new HolidayDate(holiday, date)))
             )
             .sorted(Comparator.comparing(HolidayDate::getDate))
             .toList();

--- a/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendar.java
+++ b/holiday-calendar-core/src/main/java/org/holiday/calendar/HolidayCalendar.java
@@ -270,6 +270,18 @@ public class HolidayCalendar {
     }
 
     /**
+     * Determine whether this calendar has any {@link EarlyCloseHoliday}
+     * entries configured. This is a cheap, year-independent check that lets
+     * callers branch without invoking {@link #calculateEarlyCloses(int)}.
+     *
+     * @return {@code true} if this calendar has at least one early-close holiday
+     * @see #calculateEarlyCloses(int)
+     */
+    public boolean hasEarlyCloses() {
+        return holidays.stream().anyMatch(EarlyCloseHoliday.class::isInstance);
+    }
+
+    /**
      * Calculate the dates of the holidays on this calendar for each year in
      * the specified range, returning all results as a single chronologically-
      * sorted list.

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/EarlyCloseHolidayTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/EarlyCloseHolidayTest.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar;
+
+import org.holiday.calendar.function.Observance;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+import static org.testng.Assert.*;
+
+public class EarlyCloseHolidayTest {
+
+    private static final Logger log = LoggerFactory.getLogger(EarlyCloseHolidayTest.class);
+
+    private static final LocalTime CLOSE_TIME = LocalTime.of(13, 0);
+    private static final ZoneId ZONE_JERUSALEM = ZoneId.of("Asia/Jerusalem");
+
+    // A simple synthetic observance: eve of a fixed Dec 25 "holiday" — Dec 24 each year.
+    private static Observance createObservanceEve() {
+        return year -> LocalDate.of(year, Month.DECEMBER, 25).minusDays(1);
+    }
+
+    // -------------------------------------------------------------------------
+    // Construction
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testConstructor_ValidArgs() {
+        Observance observance = createObservanceEve();
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "Eve of Christmas", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        assertEquals(holiday.getName(), "Erev Christmas");
+        assertEquals(holiday.getDescription(), "Eve of Christmas");
+        assertEquals(holiday.getObservance(), observance);
+        assertEquals(holiday.getCloseTime(), CLOSE_TIME);
+        assertEquals(holiday.getZoneId(), ZONE_JERUSALEM);
+        assertFalse(holiday.isRollable());
+    }
+
+    @Test
+    public void testConstructor_NullDescription_DefaultsToEmptyString() {
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", null, createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+        assertNotNull(holiday.getDescription());
+        assertEquals(holiday.getDescription(), "");
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConstructor_NullName() {
+        new EarlyCloseHoliday(null, "desc", createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConstructor_NullObservance() {
+        new EarlyCloseHoliday("Erev Christmas", "desc", null, CLOSE_TIME, ZONE_JERUSALEM);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConstructor_NullCloseTime() {
+        new EarlyCloseHoliday("Erev Christmas", "desc", createObservanceEve(), null, ZONE_JERUSALEM);
+    }
+
+    @Test(expectedExceptions = NullPointerException.class)
+    public void testConstructor_NullZoneId() {
+        new EarlyCloseHoliday("Erev Christmas", "desc", createObservanceEve(), CLOSE_TIME, null);
+    }
+
+    // -------------------------------------------------------------------------
+    // Accessors
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testGetObservance() {
+        Observance observance = createObservanceEve();
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "desc", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        assertEquals(holiday.getObservance(), observance);
+    }
+
+    @Test
+    public void testGetCloseTime() {
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "desc", createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+        assertEquals(holiday.getCloseTime(), CLOSE_TIME);
+    }
+
+    @Test
+    public void testGetZoneId() {
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "desc", createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+        assertEquals(holiday.getZoneId(), ZONE_JERUSALEM);
+    }
+
+    // -------------------------------------------------------------------------
+    // isRollable
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testIsRollable_AlwaysFalse() {
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "desc", createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+        assertFalse(holiday.isRollable());
+    }
+
+    // -------------------------------------------------------------------------
+    // dateForYear
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "data")
+    public void testDateForYear(String name, Observance observance, int yearToCalculate, LocalDate expected) {
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(name, "", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        Optional<LocalDate> actual = holiday.dateForYear(yearToCalculate);
+        assertTrue(actual.isPresent());
+        assertEquals(actual.get(), expected);
+
+        log.debug("{} {}: {}", name, yearToCalculate, actual.get());
+    }
+
+    @DataProvider
+    public Iterator<Object[]> data() {
+        final Observance eve = createObservanceEve();
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ "Erev Christmas", eve, 2021, LocalDate.of(2021, Month.DECEMBER, 24)});
+        data.add(new Object[]{ "Erev Christmas", eve, 2024, LocalDate.of(2024, Month.DECEMBER, 24)});
+        data.add(new Object[]{ "Erev Christmas", eve, 2025, LocalDate.of(2025, Month.DECEMBER, 24)});
+        return data.iterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Equality / hashCode / toString
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEquals() {
+        final Observance observance = createObservanceEve();
+        final Observance otherObservance = year -> LocalDate.of(year, Month.JANUARY, 1);
+        EarlyCloseHoliday holiday1 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        EarlyCloseHoliday holiday2 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        EarlyCloseHoliday holiday3 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", otherObservance, CLOSE_TIME, ZONE_JERUSALEM);
+        EarlyCloseHoliday holiday4 = new EarlyCloseHoliday("Erev Christmas", "Different description", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        EarlyCloseHoliday holiday5 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", observance, LocalTime.of(9, 0), ZONE_JERUSALEM);
+        EarlyCloseHoliday holiday6 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", observance, CLOSE_TIME, ZoneId.of("America/New_York"));
+        Object notAHoliday = new Object();
+
+        assertEquals(holiday1, holiday1);
+        assertEquals(holiday2, holiday1);
+        assertNotEquals(holiday1, null);
+        assertNotEquals(notAHoliday, holiday1);
+        assertNotEquals(holiday3, holiday1);
+        assertNotEquals(holiday4, holiday1);
+        assertNotEquals(holiday5, holiday1);
+        assertNotEquals(holiday6, holiday1);
+    }
+
+    @Test
+    public void testHashCode() {
+        final Observance observance = createObservanceEve();
+        EarlyCloseHoliday holiday1 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        EarlyCloseHoliday holiday2 = new EarlyCloseHoliday("Erev Christmas", "Eve of Christmas", observance, CLOSE_TIME, ZONE_JERUSALEM);
+        assertEquals(holiday2.hashCode(), holiday1.hashCode());
+    }
+
+    @Test
+    public void testToString() {
+        EarlyCloseHoliday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "Eve of Christmas", createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+        String expected = "Holiday\\[name='Erev Christmas', description='Eve of Christmas', observance=.+, closeTime=13:00, zoneId=Asia/Jerusalem]";
+        Pattern pattern = Pattern.compile(expected);
+        Matcher matcher = pattern.matcher(holiday.toString());
+        assertTrue(matcher.matches());
+        log.debug("EarlyCloseHoliday (string): {}", holiday);
+    }
+
+    // -------------------------------------------------------------------------
+    // Sealed-type pattern matching / switch exhaustiveness
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testSwitchExhaustiveness_EarlyCloseArm() {
+        Holiday holiday = new EarlyCloseHoliday(
+                "Erev Christmas", "Eve of Christmas", createObservanceEve(), CLOSE_TIME, ZONE_JERUSALEM);
+        String result = describe(holiday);
+        assertEquals(result, "early-close");
+    }
+
+    private String describe(Holiday holiday) {
+        return switch (holiday) {
+            case FixedHoliday fixed -> "fixed";
+            case FloatingHoliday floating -> "floating";
+            case SpecialAnniversary anniversary -> "special-anniversary";
+            case EarlyCloseHoliday earlyClose -> "early-close";
+        };
+    }
+
+}

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/HolidayCalendarTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/HolidayCalendarTest.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar;
 
 import org.holiday.calendar.function.DateRoll;
+import org.holiday.calendar.function.Observance;
 import org.testng.annotations.Test;
 
 import java.time.*;
@@ -229,6 +230,61 @@ public class HolidayCalendarTest {
         LocalDate monday = LocalDate.of(2021, Month.DECEMBER, 20);
         Instant mondayInstant = monday.atStartOfDay(ZoneOffset.UTC).toInstant();
         assertFalse(calendar.isWeekendUTC(mondayInstant));
+    }
+
+    // -------------------------------------------------------------------------
+    // calculateEarlyCloses
+    // -------------------------------------------------------------------------
+
+    @Test(groups = "core")
+    public void testCalculateEarlyCloses_ReturnsOnlyEarlyCloseEntries() {
+        HolidayCalendar calendar = createHolidayCalendarWithEarlyCloses();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(2025);
+
+        assertEquals(earlyCloses.size(), 2);
+        assertTrue(earlyCloses.stream().allMatch(hd -> hd.getHoliday() instanceof EarlyCloseHoliday));
+    }
+
+    @Test(groups = "core")
+    public void testCalculateEarlyCloses_IsChronologicallyOrdered() {
+        HolidayCalendar calendar = createHolidayCalendarWithEarlyCloses();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(2025);
+
+        assertEquals(earlyCloses.size(), 2);
+        assertTrue(earlyCloses.get(0).getDate().isBefore(earlyCloses.get(1).getDate()));
+        assertEquals(earlyCloses.get(0).getHoliday().getName(), "Erev A");
+        assertEquals(earlyCloses.get(1).getHoliday().getName(), "Erev B");
+    }
+
+    @Test(groups = "core")
+    public void testCalculateEarlyCloses_EmptyWhenNoEarlyCloses() {
+        HolidayCalendar calendar = createHolidayCalendarSifmaUS();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(2021);
+        assertNotNull(earlyCloses);
+        assertTrue(earlyCloses.isEmpty());
+    }
+
+    @Test(groups = "core")
+    public void testCalculate_DoesNotIncludeEarlyCloses() {
+        HolidayCalendar calendar = createHolidayCalendarWithEarlyCloses();
+        List<HolidayDate> dates = calendar.calculate(2025);
+
+        assertEquals(dates.size(), 1);
+        assertEquals(dates.getFirst().getHoliday().getName(), "Full Holiday");
+        assertTrue(dates.stream().noneMatch(hd -> hd.getHoliday() instanceof EarlyCloseHoliday));
+    }
+
+    private HolidayCalendar createHolidayCalendarWithEarlyCloses() {
+        final Observance observanceA = year -> LocalDate.of(year, Month.MARCH, 10);
+        final Observance observanceB = year -> LocalDate.of(year, Month.MARCH, 20);
+        final Observance mainObservance = year -> LocalDate.of(year, Month.MARCH, 15);
+        return HolidayCalendar.builder()
+                              .code("TEST-EC")
+                              .name("Early Close Test Calendar")
+                              .holiday(new FloatingHoliday("Full Holiday", "", mainObservance))
+                              .holiday(new EarlyCloseHoliday("Erev B", "", observanceB, LocalTime.of(13, 0), ZoneId.of("Asia/Jerusalem")))
+                              .holiday(new EarlyCloseHoliday("Erev A", "", observanceA, LocalTime.of(13, 0), ZoneId.of("Asia/Jerusalem")))
+                              .build();
     }
 
     private HolidayCalendar createHolidayCalendarSifmaUS() {

--- a/holiday-calendar-core/src/test/java/org/holiday/calendar/HolidayCalendarTest.java
+++ b/holiday-calendar-core/src/test/java/org/holiday/calendar/HolidayCalendarTest.java
@@ -274,6 +274,18 @@ public class HolidayCalendarTest {
         assertTrue(dates.stream().noneMatch(hd -> hd.getHoliday() instanceof EarlyCloseHoliday));
     }
 
+    @Test(groups = "core")
+    public void testHasEarlyCloses_TrueWhenPresent() {
+        HolidayCalendar calendar = createHolidayCalendarWithEarlyCloses();
+        assertTrue(calendar.hasEarlyCloses());
+    }
+
+    @Test(groups = "core")
+    public void testHasEarlyCloses_FalseWhenAbsent() {
+        HolidayCalendar calendar = createHolidayCalendarSifmaUS();
+        assertFalse(calendar.hasEarlyCloses());
+    }
+
     private HolidayCalendar createHolidayCalendarWithEarlyCloses() {
         final Observance observanceA = year -> LocalDate.of(year, Month.MARCH, 10);
         final Observance observanceB = year -> LocalDate.of(year, Month.MARCH, 20);

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceILS.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceILS.java
@@ -35,23 +35,17 @@ import org.holiday.calendar.function.DateRolls;
  *
  * <p>Weekend: Friday + Saturday (Israeli market convention).
  *
- * <p><strong>Scope limitation — half-day closures:</strong> TASE closes early
- * (typically 13:00 IST) on holiday eves: Erev Rosh Hashanah, Erev Yom Kippur,
- * Erev Passover, Erev Shavuot, and Erev Sukkot. The current {@code Holiday}
- * sealed interface models only full-day closures. These half-day eves are
- * <em>not</em> represented in this calendar. Users performing same-day or T+1
- * settlement date calculations for trades placed in the morning of an eve day
- * must apply additional TASE-specific adjustments outside this library.
- *
- * <p><strong>Hoshana Raba (21 Tishri) — intentionally excluded:</strong>
- * TASE closes on Hoshana Raba (the 7th day of Sukkot, 21 Tishri) consistently;
- * this was confirmed in official TASE vacation schedules for 2022–2025.
- * However, the Bank of Israel operates with reduced hours on that day (until
- * approximately 13:15 IST) and does not treat it as a full settlement closure —
- * per official Bank of Israel Markets Department schedules. Since {@code ILS}
- * represents shekel settlement availability (Bank of Israel), and the central
- * bank is open on 21 Tishri, Hoshana Raba is not an ILS closure day. Consumers
- * building TASE-only trading calendars must add 21 Tishri independently.
+ * <p><strong>Hoshana Raba (21 Tishri) — modeled as an early close:</strong>
+ * TASE closes fully on Hoshana Raba (the 7th day of Sukkot, 21 Tishri) consistently;
+ * this was confirmed in official TASE vacation schedules for 2022–2025. However,
+ * the Bank of Israel operates with reduced hours on that day (until approximately
+ * 13:15 IST) rather than a full settlement closure, per official Bank of Israel
+ * Markets Department schedules. Since {@code ILS} represents shekel settlement
+ * availability (Bank of Israel), Hoshana Raba is included as an {@code EARLY_CLOSE}
+ * holiday closing at 13:15 Asia/Jerusalem time — distinct from the 13:00 close
+ * used for the five TASE holiday-eve early closes. Consumers building TASE-only
+ * trading calendars, where the day is a full closure, should treat this date
+ * accordingly rather than relying on the 13:15 close time.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -72,6 +66,7 @@ public class HolidayCalendarServiceILS extends AbstractHolidayCalendarService {
                 .dateRoll(DateRolls.noRoll())
                 .weekendDays(IsraelHolidays.ISRAEL_WEEKEND)
                 .holidays(IsraelHolidays.baseHolidays())
+                .holidays(IsraelHolidays.earlyCloseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -48,12 +48,12 @@ import java.util.OptionalInt;
  * against official announcements as each year is
  * published. Corrections require a new JAR release.
  *
- * <p><strong>Half-day closure not modelled:</strong>
- * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
- * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
- * settlement from midday. This calendar does not include 28 October as a holiday.
- * Callers relying on afternoon liquidity or same-day settlement on this date must
- * apply their own adjustment.
+ * <p>Borsa Istanbul (BIST) observes a half-day closure on 28 October (Republic
+ * Day Eve), closing at 12:30 {@code Europe/Istanbul}. This is modelled as an
+ * {@code EARLY_CLOSE} holiday, non-rollable, and reported separately via
+ * {@link HolidayCalendar#calculateEarlyCloses(int)} rather than {@link
+ * HolidayCalendar#calculate(int)}. It does not shift when 28 October falls on
+ * a Saturday or Sunday.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -79,6 +79,7 @@ public class HolidayCalendarServiceTR extends AbstractHolidayCalendarService {
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(TurkeyHolidays.STANDARD_WEEKEND)
                 .holidays(TurkeyHolidays.baseHolidays(true, List.of()))
+                .holidays(TurkeyHolidays.earlyCloseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -41,10 +41,11 @@ import java.util.OptionalInt;
  * ilmi takvim (scientific calendar) via {@code eid-al-fitr-tr.csv} and
  * {@code eid-al-adha-tr.csv}. Dates for 2024–2035 are official Diyanet-published
  * dates (confirmed against BIST announcements for 2024–2026); 2036–2055 are
- * projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's own
- * publication of those years. Diyanet uses ilmi takvim, which is confirmed to
- * differ from the Umm al-Qura calendar by ±1–2 days in some years — verify
- * projected 2036–2055 dates against official announcements as each year is
+ * computed via an ilmi takvim calculator (true lunar conjunction + Ankara sunset
+ * visibility rule) pending Diyanet's own publication of those years. Diyanet's
+ * method is confirmed to differ from the Umm al-Qura calendar used by other MENA
+ * countries by ±1–2 days in some years — verify projected 2036–2055 dates
+ * against official announcements as each year is
  * published. Corrections require a new JAR release.
  *
  * <p><strong>Half-day closure not modelled:</strong>

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -39,11 +39,13 @@ import java.util.OptionalInt;
  * <p>Islamic holidays (Ramazan Bayramı / Eid al-Fitr × 3 days; Kurban Bayramı /
  * Eid al-Adha × 4 days) are sourced from Diyanet (Presidency of Religious Affairs)
  * ilmi takvim (scientific calendar) via {@code eid-al-fitr-tr.csv} and
- * {@code eid-al-adha-tr.csv}. Dates for 2024–2026 are official Diyanet / BIST
- * announcements; 2027–2055 are projected from the Umm al-Qura tabular Islamic
- * calendar. Diyanet uses ilmi takvim, which may differ from the Umm al-Qura
- * calendar by ±1 day — verify projected dates against official announcements as
- * each year is published. Corrections require a new JAR release.
+ * {@code eid-al-adha-tr.csv}. Dates for 2024–2035 are official Diyanet-published
+ * dates (confirmed against BIST announcements for 2024–2026); 2036–2055 are
+ * projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's own
+ * publication of those years. Diyanet uses ilmi takvim, which is confirmed to
+ * differ from the Umm al-Qura calendar by ±1–2 days in some years — verify
+ * projected 2036–2055 dates against official announcements as each year is
+ * published. Corrections require a new JAR release.
  *
  * <p><strong>Half-day closure not modelled:</strong>
  * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
@@ -76,6 +76,8 @@ class IsraelHolidays {
     // Israeli weekend: Friday + Saturday; Sunday is the first business day.
     static final List<DayOfWeek> ISRAEL_WEEKEND = List.of(DayOfWeek.FRIDAY, DayOfWeek.SATURDAY);
 
+    private static final ZoneId ISRAEL_ZONE = ZoneId.of("Asia/Jerusalem");
+
     private IsraelHolidays() {}
 
     /**
@@ -187,7 +189,7 @@ class IsraelHolidays {
                     .rollable(false)
                     .observance(new ErevRoshHashanah())
                     .closeTime(LocalTime.of(13, 0))
-                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .zoneId(ISRAEL_ZONE)
                     .build(),
             Holiday.builder()
                     .name("Erev Yom Kippur")
@@ -196,7 +198,7 @@ class IsraelHolidays {
                     .rollable(false)
                     .observance(new ErevYomKippur())
                     .closeTime(LocalTime.of(13, 0))
-                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .zoneId(ISRAEL_ZONE)
                     .build(),
             Holiday.builder()
                     .name("Erev Passover")
@@ -205,7 +207,7 @@ class IsraelHolidays {
                     .rollable(false)
                     .observance(new ErevPassover())
                     .closeTime(LocalTime.of(13, 0))
-                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .zoneId(ISRAEL_ZONE)
                     .build(),
             Holiday.builder()
                     .name("Erev Shavuot")
@@ -214,7 +216,7 @@ class IsraelHolidays {
                     .rollable(false)
                     .observance(new ErevShavuot())
                     .closeTime(LocalTime.of(13, 0))
-                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .zoneId(ISRAEL_ZONE)
                     .build(),
             Holiday.builder()
                     .name("Erev Sukkot")
@@ -223,7 +225,7 @@ class IsraelHolidays {
                     .rollable(false)
                     .observance(new ErevSukkot())
                     .closeTime(LocalTime.of(13, 0))
-                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .zoneId(ISRAEL_ZONE)
                     .build(),
             Holiday.builder()
                     .name("Hoshana Raba")
@@ -234,7 +236,7 @@ class IsraelHolidays {
                     .rollable(false)
                     .observance(new HoshanaRaba())
                     .closeTime(LocalTime.of(13, 15))
-                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .zoneId(ISRAEL_ZONE)
                     .build()
         );
     }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/IsraelHolidays.java
@@ -19,6 +19,12 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.hebrew.ErevPassover;
+import org.holiday.calendar.observance.hebrew.ErevRoshHashanah;
+import org.holiday.calendar.observance.hebrew.ErevShavuot;
+import org.holiday.calendar.observance.hebrew.ErevSukkot;
+import org.holiday.calendar.observance.hebrew.ErevYomKippur;
+import org.holiday.calendar.observance.hebrew.HoshanaRaba;
 import org.holiday.calendar.observance.hebrew.IndependenceDay;
 import org.holiday.calendar.observance.hebrew.Passover;
 import org.holiday.calendar.observance.hebrew.YomHazikaron;
@@ -31,6 +37,8 @@ import org.holiday.calendar.observance.hebrew.Sukkot;
 import org.holiday.calendar.observance.hebrew.YomKippur;
 
 import java.time.DayOfWeek;
+import java.time.LocalTime;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -49,10 +57,11 @@ import java.util.List;
  * Independence Day is additionally self-adjusting via the statutory
  * postponement rule embedded in {@link IndependenceDay#computeDate}.
  *
- * <p>Scope limitation: TASE closes early on holiday eves (Erev Rosh Hashanah,
- * Erev Yom Kippur, Erev Passover, Erev Shavuot, Erev Sukkot). These half-day
- * closures are not modelled here. See {@link HolidayCalendarServiceILS} for the
- * full limitation notice.
+ * <p>{@link #earlyCloseHolidays()} returns six {@code EARLY_CLOSE} holidays: five
+ * TASE half-day closures on holiday eves (Erev Rosh Hashanah, Erev Yom Kippur, Erev
+ * Passover, Erev Shavuot, Erev Sukkot), each closing at 13:00 Asia/Jerusalem time,
+ * plus Hoshana Raba (21 Tishri), on which the Bank of Israel operates with reduced
+ * hours until approximately 13:15 Asia/Jerusalem time.
  *
  * <p>Omitted holidays (conscious decisions):
  * <ul>
@@ -60,11 +69,6 @@ import java.util.List;
  *       commemoration day, but it is not a statutory public rest holiday under
  *       the Work and Rest Hours Law. TASE also remains open.</li>
  *   <li>Sigd (29 Heshvan) — low market relevance; not a TASE closure day.</li>
- *   <li>Hoshana Raba (21 Tishri) — TASE closes on this day, but the Bank of
- *       Israel operates with reduced hours (not a full settlement closure).
- *       ILS represents Bank of Israel settlement availability; since the central
- *       bank is open on 21 Tishri, it is not an ILS closure day. TASE-only
- *       trading calendars should add this date separately.</li>
  * </ul>
  */
 class IsraelHolidays {
@@ -163,6 +167,74 @@ class IsraelHolidays {
                     .type(Holiday.Type.FLOATING)
                     .rollable(false)
                     .observance(new Shavuot())
+                    .build()
+        );
+    }
+
+    /**
+     * Returns six {@code EARLY_CLOSE} holidays: five representing TASE's half-day
+     * closures on the eves of major Jewish holidays (closing at 13:00 Asia/Jerusalem
+     * time), plus Hoshana Raba (21 Tishri), on which the Bank of Israel operates
+     * with reduced hours until approximately 13:15 Asia/Jerusalem time per official
+     * Bank of Israel Markets Department schedules. None are subject to date rolling.
+     */
+    static List<Holiday> earlyCloseHolidays() {
+        return List.of(
+            Holiday.builder()
+                    .name("Erev Rosh Hashanah")
+                    .description("Eve of the Jewish New Year; TASE half-day closure")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new ErevRoshHashanah())
+                    .closeTime(LocalTime.of(13, 0))
+                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .build(),
+            Holiday.builder()
+                    .name("Erev Yom Kippur")
+                    .description("Eve of the Day of Atonement; TASE half-day closure")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new ErevYomKippur())
+                    .closeTime(LocalTime.of(13, 0))
+                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .build(),
+            Holiday.builder()
+                    .name("Erev Passover")
+                    .description("Eve of Passover; TASE half-day closure")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new ErevPassover())
+                    .closeTime(LocalTime.of(13, 0))
+                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .build(),
+            Holiday.builder()
+                    .name("Erev Shavuot")
+                    .description("Eve of the Feast of Weeks / Pentecost; TASE half-day closure")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new ErevShavuot())
+                    .closeTime(LocalTime.of(13, 0))
+                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .build(),
+            Holiday.builder()
+                    .name("Erev Sukkot")
+                    .description("Eve of the Festival of Tabernacles; TASE half-day closure")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new ErevSukkot())
+                    .closeTime(LocalTime.of(13, 0))
+                    .zoneId(ZoneId.of("Asia/Jerusalem"))
+                    .build(),
+            Holiday.builder()
+                    .name("Hoshana Raba")
+                    .description("Seventh day of Sukkot (21 Tishri); Bank of Israel operates " +
+                                 "with reduced hours until approximately 13:15 IST, per official " +
+                                 "Bank of Israel Markets Department schedules")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new HoshanaRaba())
+                    .closeTime(LocalTime.of(13, 15))
+                    .zoneId(ZoneId.of("Asia/Jerusalem"))
                     .build()
         );
     }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -26,9 +26,12 @@ import org.holiday.calendar.observance.islamic.mena.EidAlAdhaDay4;
 import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
 import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay2;
 import org.holiday.calendar.observance.islamic.mena.EidAlFitrDay3;
+import org.holiday.calendar.observance.tr.RepublicDayEveEarlyClose;
 
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -55,12 +58,12 @@ import java.util.List;
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days
  * of Eid al-Adha (Kurban Bayramı), consistent with BIST market closure announcements.
  *
- * <p><strong>Half-day closure not modelled:</strong>
- * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
- * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
- * settlement from midday. This calendar does not include 28 October as a holiday.
- * Callers relying on afternoon liquidity or same-day settlement on this date must
- * apply their own adjustment.
+ * <p>Borsa Istanbul (BIST) observes a half-day closure on 28 October (Republic
+ * Day Eve), closing at 12:30 {@code Europe/Istanbul}. This is modelled as an
+ * {@link Holiday.Type#EARLY_CLOSE} holiday via {@link #earlyCloseHolidays()},
+ * consumed by {@link HolidayCalendarServiceTR}. It does not shift when
+ * 28 October falls on a Saturday or Sunday — see {@link RepublicDayEveEarlyClose}.
+ * {@link HolidayCalendarServiceTRY} does not yet include this half-day closure.
  *
  * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
  * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
@@ -188,5 +191,26 @@ class TurkeyHolidays {
                 .build());
         holidays.addAll(additional);
         return List.copyOf(holidays);
+    }
+
+    /**
+     * Returns the single {@code EARLY_CLOSE} holiday representing BIST's
+     * Republic Day Eve half-day close (28 October, closing at 12:30
+     * {@code Europe/Istanbul}). Does not shift when 28 October falls on a
+     * Saturday or Sunday; see {@link RepublicDayEveEarlyClose}.
+     */
+    static List<Holiday> earlyCloseHolidays() {
+        return List.of(
+            Holiday.builder()
+                    .name("Republic Day Eve")
+                    .description("BIST half-day close ahead of Republic Day; no adjustment when "
+                            + "28 October falls on a Saturday or Sunday")
+                    .type(Holiday.Type.EARLY_CLOSE)
+                    .rollable(false)
+                    .observance(new RepublicDayEveEarlyClose())
+                    .closeTime(LocalTime.of(12, 30))
+                    .zoneId(ZoneId.of("Europe/Istanbul"))
+                    .build()
+        );
     }
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -38,11 +38,15 @@ import java.util.List;
  *
  * <p>All seven Islamic holidays are populated through {@value DATA_VALID_THROUGH}
  * via Diyanet-sourced CSV lookup tables (country code {@code tr}).
- * Dates for 2024–2026 are official Diyanet (Presidency of Religious Affairs) /
- * BIST market calendar announcements; dates for 2027–2055 are projected from
- * the Umm al-Qura tabular Islamic calendar. Diyanet uses ilmi takvim (scientific
- * method), which may differ from the Umm al-Qura calendar by ±1 day — verify
- * projected dates against Diyanet announcements as each year is published.
+ * Dates for 2024–2035 are official Diyanet (Presidency of Religious Affairs)
+ * published dates (Diyanet publishes several years ahead of the current year,
+ * not just 1–2 years as originally assumed — see GitHub issue #180), confirmed
+ * against BIST market calendar announcements for 2024–2026; dates for 2036–2055
+ * are projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's
+ * own publication of those years. Diyanet uses ilmi takvim (scientific method),
+ * which is confirmed to differ from the Umm al-Qura calendar by ±1–2 days in some
+ * years (e.g. 2026 Eid al-Adha: Diyanet 27 May vs. UAE/Umm al-Qura 26 May) — verify
+ * projected 2036–2055 dates against Diyanet announcements as each year is published.
  * Corrections require a new JAR release; no runtime update mechanism exists.
  *
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -42,11 +42,14 @@ import java.util.List;
  * published dates (Diyanet publishes several years ahead of the current year,
  * not just 1–2 years as originally assumed — see GitHub issue #180), confirmed
  * against BIST market calendar announcements for 2024–2026; dates for 2036–2055
- * are projected from the Umm al-Qura tabular Islamic calendar pending Diyanet's
- * own publication of those years. Diyanet uses ilmi takvim (scientific method),
- * which is confirmed to differ from the Umm al-Qura calendar by ±1–2 days in some
- * years (e.g. 2026 Eid al-Adha: Diyanet 27 May vs. UAE/Umm al-Qura 26 May) — verify
- * projected 2036–2055 dates against Diyanet announcements as each year is published.
+ * are computed via {@code IlmiTakvimCalculator} (true lunar conjunction + Ankara
+ * sunset visibility rule, calibrated against and exactly reproducing all 24
+ * Diyanet-published dates 2024–2035) pending Diyanet's own publication of those
+ * years. Diyanet's ilmi takvim (scientific method) is confirmed to differ from
+ * the Umm al-Qura calendar used by other MENA countries in this package by
+ * ±1–2 days in some years (e.g. 2026 Eid al-Adha: Diyanet 27 May vs.
+ * UAE/Umm al-Qura 26 May) — verify projected 2036–2055 dates against Diyanet
+ * announcements as each year is published.
  * Corrections require a new JAR release; no runtime update mechanism exists.
  *
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevPassover.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevPassover.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Erev Passover — the eve of Pesach, the day preceding
+ * {@link Passover}, on which many Israeli businesses close early.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ErevPassover extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return new Passover().apply(year).minusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevRoshHashanah.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevRoshHashanah.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Erev Rosh Hashanah — the eve of the Jewish New Year, the day
+ * preceding {@link RoshHashanah}, on which many Israeli businesses close early.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ErevRoshHashanah extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return new RoshHashanah().apply(year).minusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevShavuot.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevShavuot.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Erev Shavuot — the eve of the Feast of Weeks / Pentecost, the
+ * day preceding {@link Shavuot}, on which many Israeli businesses close early.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ErevShavuot extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return new Shavuot().apply(year).minusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevSukkot.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevSukkot.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Erev Sukkot — the eve of the Festival of Tabernacles, the day
+ * preceding {@link Sukkot}, on which many Israeli businesses close early.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ErevSukkot extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return new Sukkot().apply(year).minusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevYomKippur.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/ErevYomKippur.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Erev Yom Kippur — the eve of the Day of Atonement, the day
+ * preceding {@link YomKippur}, on which many Israeli businesses close early.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ErevYomKippur extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return new YomKippur().apply(year).minusDays(1);
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/HoshanaRaba.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/hebrew/HoshanaRaba.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import net.time4j.PlainDate;
+import net.time4j.calendar.HebrewCalendar;
+import net.time4j.calendar.HebrewMonth;
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.LocalDate;
+
+/**
+ * Observance of Hoshana Raba (21 Tishri) — the seventh and final day of Sukkot.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HoshanaRaba extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return HebrewCalendar.of(year + 3761, HebrewMonth.TISHRI, 21)
+                .transform(PlainDate.axis())
+                .toTemporalAccessor();
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.islamic.mena;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator;
 import org.holiday.calendar.util.CsvObservanceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -52,20 +53,44 @@ public class EidAlAdha extends AbstractObservance {
     static final int DATA_VALID_FROM = 2024;
     static final int DATA_VALID_THROUGH = 2055;
 
+    /**
+     * Country code for which a live {@link IlmiTakvimCalculator} fallback applies
+     * when the CSV table is missing a row for an in-range year (e.g. a future
+     * {@code DATA_VALID_THROUGH} extension made before the CSV is regenerated).
+     * All CSV rows for {@code tr} are currently populated through
+     * {@value #DATA_VALID_THROUGH}, so this fallback is a defensive safety net,
+     * not part of the normal lookup path.
+     */
+    private static final String ILMI_TAKVIM_COUNTRY_CODE = "tr";
+
     private static final Logger log = LoggerFactory.getLogger(EidAlAdha.class);
     private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
             new ConcurrentHashMap<>();
 
+    private final String countryCode;
     private final Map<Integer, LocalDate> dates;
 
     public EidAlAdha(String countryCode) {
-        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+        this.countryCode = countryCode.toLowerCase();
+        this.dates = CACHE.computeIfAbsent(this.countryCode,
                 cc -> CsvObservanceLoader.loadSingle(EidAlAdha.class, "eid-al-adha-" + cc + ".csv"));
     }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return dates.get(year);
+        LocalDate csvDate = dates.get(year);
+        if (csvDate != null) {
+            return csvDate;
+        }
+        if (ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode)) {
+            try {
+                return IlmiTakvimCalculator.eidAlAdha(year);
+            } catch (RuntimeException e) {
+                log.warn("Ilmi takvim calculation failed for Eid al-Adha {}; no fallback data available", year, e);
+                return null;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -74,7 +99,8 @@ public class EidAlAdha extends AbstractObservance {
             log.warn("Year {} exceeds data ceiling {}; Eid al-Adha date unavailable", year, DATA_VALID_THROUGH);
             return false;
         }
-        return dates.containsKey(year);
+        return year >= DATA_VALID_FROM
+                && (dates.containsKey(year) || ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode));
     }
 
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlAdha.java
@@ -36,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * Dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar;
  * verify against official announcements as each year is published.</p>
  *
+ * <p>For Turkey ({@code tr}), 2024–2035 are official Diyanet (Presidency of
+ * Religious Affairs) published dates rather than Umm al-Qura projections — Diyanet
+ * publishes several years ahead of the current year. See {@code eid-al-adha-tr.csv}
+ * for the confirmed 2026 divergence between Diyanet's ilmi takvim and Umm al-Qura.</p>
+ *
  * <p>Date data is loaded at runtime from {@code eid-al-adha-{countryCode}.csv}
  * in this package, where {@code countryCode} is the ISO 3166-1 alpha-2 country
  * code in lower case (e.g. {@code ae}, {@code sa}).</p>

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
@@ -19,6 +19,7 @@
 package org.holiday.calendar.observance.islamic.mena;
 
 import org.holiday.calendar.observance.AbstractObservance;
+import org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator;
 import org.holiday.calendar.util.CsvObservanceLoader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -56,20 +57,44 @@ public class EidAlFitr extends AbstractObservance {
     static final int DATA_VALID_FROM = 2024;
     static final int DATA_VALID_THROUGH = 2055;
 
+    /**
+     * Country code for which a live {@link IlmiTakvimCalculator} fallback applies
+     * when the CSV table is missing a row for an in-range year (e.g. a future
+     * {@code DATA_VALID_THROUGH} extension made before the CSV is regenerated).
+     * All CSV rows for {@code tr} are currently populated through
+     * {@value #DATA_VALID_THROUGH}, so this fallback is a defensive safety net,
+     * not part of the normal lookup path.
+     */
+    private static final String ILMI_TAKVIM_COUNTRY_CODE = "tr";
+
     private static final Logger log = LoggerFactory.getLogger(EidAlFitr.class);
     private static final ConcurrentHashMap<String, Map<Integer, LocalDate>> CACHE =
             new ConcurrentHashMap<>();
 
+    private final String countryCode;
     private final Map<Integer, LocalDate> dates;
 
     public EidAlFitr(String countryCode) {
-        this.dates = CACHE.computeIfAbsent(countryCode.toLowerCase(),
+        this.countryCode = countryCode.toLowerCase();
+        this.dates = CACHE.computeIfAbsent(this.countryCode,
                 cc -> CsvObservanceLoader.loadSingle(EidAlFitr.class, "eid-al-fitr-" + cc + ".csv"));
     }
 
     @Override
     protected LocalDate computeDate(int year) {
-        return dates.get(year);
+        LocalDate csvDate = dates.get(year);
+        if (csvDate != null) {
+            return csvDate;
+        }
+        if (ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode)) {
+            try {
+                return IlmiTakvimCalculator.eidAlFitr(year);
+            } catch (RuntimeException e) {
+                log.warn("Ilmi takvim calculation failed for Eid al-Fitr {}; no fallback data available", year, e);
+                return null;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -78,7 +103,8 @@ public class EidAlFitr extends AbstractObservance {
             log.warn("Year {} exceeds data ceiling {}; Eid al-Fitr date unavailable", year, DATA_VALID_THROUGH);
             return false;
         }
-        return dates.containsKey(year);
+        return year >= DATA_VALID_FROM
+                && (dates.containsKey(year) || ILMI_TAKVIM_COUNTRY_CODE.equals(countryCode));
     }
 
 }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/EidAlFitr.java
@@ -36,6 +36,11 @@ import java.util.concurrent.ConcurrentHashMap;
  * Dates for 2027–2055 are projected from the Umm al-Qura tabular Islamic calendar;
  * verify against official announcements as each year is published.</p>
  *
+ * <p>For Turkey ({@code tr}), 2024–2035 are official Diyanet (Presidency of
+ * Religious Affairs) published dates rather than Umm al-Qura projections — Diyanet
+ * publishes several years ahead of the current year. See {@code eid-al-fitr-tr.csv}
+ * for details.</p>
+ *
  * <p>Note: Gregorian year 2033 contains two Eid al-Fitr occurrences (~January 4 and
  * ~December 24). Only the first (January) occurrence is recorded; the December
  * occurrence cannot be represented under the single-date-per-year-key design.</p>

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
@@ -25,6 +25,7 @@ import net.time4j.calendar.astro.SolarTime;
 
 import java.time.Instant;
 import java.time.LocalDate;
+import java.time.Month;
 import java.time.ZoneId;
 
 /**
@@ -78,13 +79,13 @@ public final class IlmiTakvimCalculator {
      * Verified anchor: 1 Shawwal 1456 AH, per Diyanet's own published "Dini
      * Günler" table (confirmed 2035-12-01).
      */
-    private static final LocalDate FITR_MONTH_START_ANCHOR = LocalDate.of(2035, 12, 1);
+    private static final LocalDate FITR_MONTH_START_ANCHOR = LocalDate.of(2035, Month.DECEMBER, 1);
 
     /**
      * Verified anchor: 1 Dhu al-Hijjah 1456 AH, derived from Diyanet's published
      * Eid al-Adha 2035 date (2035-02-18) minus {@value ADHA_DAY_OFFSET} days.
      */
-    private static final LocalDate ADHA_MONTH_START_ANCHOR = LocalDate.of(2035, 2, 9);
+    private static final LocalDate ADHA_MONTH_START_ANCHOR = LocalDate.of(2035, Month.FEBRUARY, 9);
 
     private IlmiTakvimCalculator() {}
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculator.java
@@ -1,0 +1,171 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena.ilmitakvim;
+
+import net.time4j.Moment;
+import net.time4j.PlainDate;
+import net.time4j.calendar.astro.MoonPhase;
+import net.time4j.calendar.astro.SolarTime;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneId;
+
+/**
+ * Computes Turkish Diyanet ilmi takvim (scientific calendar) dates for Eid al-Fitr
+ * (1 Shawwal AH) and Eid al-Adha (10 Dhu al-Hijjah AH), for years beyond Diyanet's
+ * own published range.
+ *
+ * <p><strong>Methodology</strong>: a Hijri month begins the day after the true
+ * (perturbed, not mean-motion) astronomical lunar conjunction, computed via
+ * {@link MoonPhase#NEW_MOON} (Meeus Ch. 49) — unless the conjunction occurs after
+ * local sunset at Ankara (39.93°N, 32.85°E, via {@link SolarTime}), in which case
+ * the month begins two days after the conjunction's civil date
+ * ({@code Europe/Istanbul}, fixed UTC+3 since Turkey's 2016 DST abolition). Each
+ * Hijri year always advances by exactly 12 lunations (no intercalation), so a
+ * target year's relevant month start is located by walking forward one Hijri
+ * year at a time from a verified anchor date and re-snapping to the true
+ * conjunction at each step, rather than by independently computing each year.</p>
+ *
+ * <p>This rule was calibrated against, and exactly reproduces, all 24 Diyanet
+ * officially-published dates (Eid al-Fitr and Eid al-Adha, 2024–2035) fetched
+ * directly from {@code vakithesaplama.diyanet.gov.tr} — see
+ * {@code IlmiTakvimCalculatorTest} for the full verification dataset. It is used
+ * here only for years beyond Diyanet's own published range (2036 onward, as of
+ * this writing); for years Diyanet has already published, the CSV lookup tables
+ * in {@code eid-al-fitr-tr.csv}/{@code eid-al-adha-tr.csv} are the source of
+ * truth and take precedence.</p>
+ *
+ * <p><strong>Caveat</strong>: this remains a best-effort approximation, not a
+ * guarantee of Diyanet's future published dates — Diyanet's actual process may
+ * involve committee judgment beyond a pure astronomical rule. Projected dates
+ * should be verified against Diyanet's own publications as they become
+ * available (Diyanet has historically published several years ahead of the
+ * current year).</p>
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public final class IlmiTakvimCalculator {
+
+    static final double ANKARA_LATITUDE_DEG = 39.93;
+    static final double ANKARA_LONGITUDE_DEG = 32.85;
+
+    private static final ZoneId ANKARA_ZONE = ZoneId.of("Europe/Istanbul");
+    private static final SolarTime ANKARA_SOLAR_TIME = SolarTime.ofLocation(ANKARA_LATITUDE_DEG, ANKARA_LONGITUDE_DEG);
+    private static final double MEAN_SYNODIC_MONTH_DAYS = 29.530588861;
+    private static final int LUNATIONS_PER_HIJRI_YEAR = 12;
+
+    /** Days after 1 Dhu al-Hijjah that Eid al-Adha (10 Dhu al-Hijjah) falls on. */
+    private static final int ADHA_DAY_OFFSET = 9;
+
+    /**
+     * Verified anchor: 1 Shawwal 1456 AH, per Diyanet's own published "Dini
+     * Günler" table (confirmed 2035-12-01).
+     */
+    private static final LocalDate FITR_MONTH_START_ANCHOR = LocalDate.of(2035, 12, 1);
+
+    /**
+     * Verified anchor: 1 Dhu al-Hijjah 1456 AH, derived from Diyanet's published
+     * Eid al-Adha 2035 date (2035-02-18) minus {@value ADHA_DAY_OFFSET} days.
+     */
+    private static final LocalDate ADHA_MONTH_START_ANCHOR = LocalDate.of(2035, 2, 9);
+
+    private IlmiTakvimCalculator() {}
+
+    /**
+     * @param gregorianYear the Gregorian year in which Eid al-Fitr's first day falls
+     * @return the computed Gregorian date of 1 Shawwal AH (Eid al-Fitr, 1st day)
+     */
+    public static LocalDate eidAlFitr(int gregorianYear) {
+        return monthStartForYear(FITR_MONTH_START_ANCHOR, gregorianYear, 0);
+    }
+
+    /**
+     * @param gregorianYear the Gregorian year in which Eid al-Adha's first day falls
+     * @return the computed Gregorian date of 10 Dhu al-Hijjah AH (Eid al-Adha, 1st day)
+     */
+    public static LocalDate eidAlAdha(int gregorianYear) {
+        return monthStartForYear(ADHA_MONTH_START_ANCHOR, gregorianYear, ADHA_DAY_OFFSET)
+                .plusDays(ADHA_DAY_OFFSET);
+    }
+
+    /**
+     * Walks one Hijri year (12 lunations) at a time from the anchor month start,
+     * re-snapping to the true conjunction at each step, until the bucketed
+     * occurrence (month start + {@code dayOffsetForBucketing}) falls in
+     * {@code targetGregorianYear}. Walks forward for years after the anchor's own
+     * year, backward for years before it. When a Gregorian year contains two
+     * occurrences of the same Hijri anniversary, the earlier (chronologically
+     * first) one is returned regardless of walk direction, matching the
+     * convention already documented on {@code EidAlFitr}/{@code EidAlAdha} for
+     * CSV-sourced years.
+     */
+    private static LocalDate monthStartForYear(LocalDate anchorMonthStart, int targetGregorianYear, int dayOffsetForBucketing) {
+        int anchorBucketYear = anchorMonthStart.plusDays(dayOffsetForBucketing).getYear();
+        long approxLunarYearDays = Math.round(MEAN_SYNODIC_MONTH_DAYS * LUNATIONS_PER_HIJRI_YEAR);
+        boolean forward = targetGregorianYear >= anchorBucketYear;
+
+        LocalDate monthStart = anchorMonthStart;
+        LocalDate earliestMatch = null;
+        while (true) {
+            int bucketYear = monthStart.plusDays(dayOffsetForBucketing).getYear();
+            if (bucketYear == targetGregorianYear) {
+                if (earliestMatch == null || monthStart.isBefore(earliestMatch)) {
+                    earliestMatch = monthStart;
+                }
+            } else if (earliestMatch != null) {
+                // Walked past the target year's occurrence(s); the earliest one recorded wins.
+                return earliestMatch;
+            } else if ((forward && bucketYear > targetGregorianYear) || (!forward && bucketYear < targetGregorianYear)) {
+                throw new IllegalArgumentException(
+                        "No ilmi takvim occurrence found for year " + targetGregorianYear
+                                + " (anchor " + anchorMonthStart + " does not reach it)");
+            }
+            LocalDate approxNext = forward
+                    ? monthStart.plusDays(approxLunarYearDays)
+                    : monthStart.minusDays(approxLunarYearDays);
+            monthStart = nextConjunctionMonthStart(approxNext);
+        }
+    }
+
+    /**
+     * Finds the true conjunction nearest (on or after 3 days before)
+     * {@code approxTarget}, then applies the Ankara-sunset visibility rule to
+     * determine the resulting Hijri month's start date.
+     */
+    private static LocalDate nextConjunctionMonthStart(LocalDate approxTarget) {
+        Instant seed = approxTarget.minusDays(3).atStartOfDay(ANKARA_ZONE).toInstant();
+        Moment conjunction = MoonPhase.NEW_MOON.after(Moment.from(seed));
+        LocalDate conjunctionCivilDate = toAnkaraCivilDate(conjunction);
+        Moment sunset = sunsetAt(conjunctionCivilDate);
+        return conjunction.isBefore(sunset) ? conjunctionCivilDate.plusDays(1) : conjunctionCivilDate.plusDays(2);
+    }
+
+    private static LocalDate toAnkaraCivilDate(Moment moment) {
+        long epochMillis = moment.getPosixTime() * 1000L + moment.getNanosecond() / 1_000_000L;
+        return Instant.ofEpochMilli(epochMillis).atZone(ANKARA_ZONE).toLocalDate();
+    }
+
+    private static Moment sunsetAt(LocalDate date) {
+        PlainDate plainDate = PlainDate.of(date.getYear(), date.getMonthValue(), date.getDayOfMonth());
+        return plainDate.get(ANKARA_SOLAR_TIME.sunset())
+                .orElseThrow(() -> new IllegalStateException("No sunset computed for Ankara on " + date));
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.tr;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Borsa İstanbul's (BIST) Republic Day Eve half-day close
+ * (October 28). Unlike the LSE's Christmas Eve convention, BIST does not
+ * shift this session to the preceding Friday when October 28 falls on a
+ * Saturday or Sunday — the market is simply closed for the weekend as usual,
+ * with no early-close adjustment that year (confirmed against BIST's 2023
+ * holiday schedule, where 28-29 October fell on Saturday-Sunday with no
+ * preceding half-day session).
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class RepublicDayEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.OCTOBER, 28);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek dayOfWeek = LocalDate.of(year, Month.OCTOBER, 28).getDayOfWeek();
+        return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
+    }
+
+}

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
@@ -45,7 +45,7 @@ public class RepublicDayEveEarlyClose extends AbstractObservance {
     @Override
     protected boolean isValidYear(int year) {
         DayOfWeek dayOfWeek = LocalDate.of(year, Month.OCTOBER, 28).getDayOfWeek();
-        return dayOfWeek != DayOfWeek.SATURDAY && dayOfWeek != DayOfWeek.SUNDAY;
+        return !dayOfWeek.equals(DayOfWeek.SATURDAY) && !dayOfWeek.equals(DayOfWeek.SUNDAY);
     }
 
 }

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
@@ -8,13 +8,14 @@
 #              of the current year, not just 1–2 years as previously assumed (see
 #              GitHub issue #180 for background). Confirmed against BIST market
 #              calendar publications for 2024–2026.
-#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
-#              Küçük 30-year cycle), used as a best-available approximation because Diyanet
-#              has not yet published religious-day tables this far ahead. Actual Diyanet
-#              dates may differ by ±1–2 days from these Umm al-Qura values — the confirmed
-#              2026 divergence below (both tiers "official") illustrates the magnitude of
-#              this risk. Replace with real Diyanet-published dates or an ilmi takvim
-#              calculation as they become available (see GitHub issue #180).
+#   2036–2055: Computed via IlmiTakvimCalculator (true lunar conjunction + Ankara
+#              sunset visibility rule, calibrated against and exactly reproducing
+#              all 24 Diyanet-published dates 2024–2035 — see
+#              IlmiTakvimCalculatorTest), used as a best-available projection
+#              because Diyanet has not yet published religious-day tables this far
+#              ahead. This remains a best-effort approximation, not a guarantee of
+#              Diyanet's actual future announcements — Diyanet's real process may
+#              involve committee judgment beyond a pure astronomical rule.
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
@@ -42,26 +43,28 @@
 2033,2033-03-11,Diyanet official
 2034,2034-03-01,Diyanet official
 2035,2035-02-18,Diyanet official
-# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
-2036,2036-02-06,Umm al-Qura projection
-2037,2037-01-25,Umm al-Qura projection
-2038,2038-01-15,Umm al-Qura projection
-# 2039: two 10 Dhu al-Hijjah occurrences (~Jan 4 AH 1460; ~Dec 24 AH 1461); Jan 4 recorded
-2039,2039-01-04,Umm al-Qura projection (January occurrence only; December occurrence omitted)
-# 2040: falls in December because January slot was consumed by 2039 double-occurrence
-2040,2040-12-13,Umm al-Qura projection
-2041,2041-12-02,Umm al-Qura projection
-2042,2042-11-21,Umm al-Qura projection
-2043,2043-11-11,Umm al-Qura projection
-2044,2044-10-30,Umm al-Qura projection
-2045,2045-10-20,Umm al-Qura projection
-2046,2046-10-09,Umm al-Qura projection
-2047,2047-09-28,Umm al-Qura projection
-2048,2048-09-17,Umm al-Qura projection
-2049,2049-09-06,Umm al-Qura projection
-2050,2050-08-26,Umm al-Qura projection
-2051,2051-08-16,Umm al-Qura projection
-2052,2052-08-04,Umm al-Qura projection
-2053,2053-07-24,Umm al-Qura projection
-2054,2054-07-14,Umm al-Qura projection
-2055,2055-07-03,Umm al-Qura projection
+# 2036–2055: ilmi takvim calculation; verify against Diyanet announcements as published
+2036,2036-02-07,ilmi takvim calculation
+2037,2037-01-26,ilmi takvim calculation
+2038,2038-01-15,ilmi takvim calculation
+# 2039: two 10 Dhu al-Hijjah occurrences in one Gregorian year (per the underlying
+# astronomical model); only the earlier (January) occurrence is recorded, consistent
+# with the 2033/2034 Eid al-Fitr convention documented in eid-al-fitr-tr.csv
+2039,2039-01-05,ilmi takvim calculation (January occurrence only; December occurrence omitted)
+# 2040: falls in December because the January slot was consumed by 2039's double-occurrence
+2040,2040-12-14,ilmi takvim calculation
+2041,2041-12-04,ilmi takvim calculation
+2042,2042-11-23,ilmi takvim calculation
+2043,2043-11-12,ilmi takvim calculation
+2044,2044-10-31,ilmi takvim calculation
+2045,2045-10-20,ilmi takvim calculation
+2046,2046-10-10,ilmi takvim calculation
+2047,2047-09-30,ilmi takvim calculation
+2048,2048-09-18,ilmi takvim calculation
+2049,2049-09-07,ilmi takvim calculation
+2050,2050-08-27,ilmi takvim calculation
+2051,2051-08-16,ilmi takvim calculation
+2052,2052-08-05,ilmi takvim calculation
+2053,2053-07-26,ilmi takvim calculation
+2054,2054-07-15,ilmi takvim calculation
+2055,2055-07-05,ilmi takvim calculation

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
@@ -2,20 +2,28 @@
 # The Feast of Sacrifice.
 #
 # SOURCE TIERS:
-#   2024–2026: Diyanet (Presidency of Religious Affairs) official announcements,
-#              confirmed against BIST market calendar publications.
-#   2027–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
+#   2024–2035: Diyanet (Presidency of Religious Affairs) official published dates,
+#              sourced directly from vakithesaplama.diyanet.gov.tr's "Dini Günler"
+#              (religious days) tables — Diyanet publishes these several years ahead
+#              of the current year, not just 1–2 years as previously assumed (see
+#              GitHub issue #180 for background). Confirmed against BIST market
+#              calendar publications for 2024–2026.
+#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar,
 #              Küçük 30-year cycle), used as a best-available approximation because Diyanet
-#              does not publish ilmi takvim (scientific calendar) projections beyond 1–2 years
-#              in advance. Actual Diyanet dates may differ by ±1 day from these Umm al-Qura
-#              values — the 2025 divergence below is the canonical confirmed example.
-#              Replace with ilmi takvim calculations when available (see GitHub issue #180).
+#              has not yet published religious-day tables this far ahead. Actual Diyanet
+#              dates may differ by ±1–2 days from these Umm al-Qura values — the confirmed
+#              2026 divergence below (both tiers "official") illustrates the magnitude of
+#              this risk. Replace with real Diyanet-published dates or an ilmi takvim
+#              calculation as they become available (see GitHub issue #180).
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
-# KNOWN DIVERGENCE — 2025: Diyanet declared 10 Dhu al-Hijjah 1446 as 5 June 2025,
-# one day earlier than the Saudi/UAE Umm al-Qura date of 6 June 2025. This is the
-# canonical confirmed example of ilmi takvim vs. Umm al-Qura divergence.
+# KNOWN DIVERGENCE — 2026: Diyanet declared 10 Dhu al-Hijjah 1447 as 27 May 2026,
+# one day later than the UAE SCA-confirmed date of 26 May 2026 (see eid-al-adha-ae.csv).
+# Both tiers are officially confirmed (not projections) — this is the canonical example
+# of ilmi takvim vs. Umm al-Qura / moon-sighting divergence. (A previously-recorded 2025
+# divergence in this file was found to be a data error — 2025-06-05 is Arefe, the eve of
+# Bayram, not the 1st day; Diyanet's own published 1st day is 2025-06-06, matching AE.)
 #
 # NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences
 # (~January 4 AH 1460 and ~December 24 AH 1461). Only the first (January) occurrence
@@ -23,19 +31,18 @@
 #
 # Format: year,YYYY-MM-DD,source
 2024,2024-06-16,Diyanet official
-# 2025: Diyanet = June 5 (1446 AH); differs from Saudi/UAE Umm al-Qura date of June 6
-2025,2025-06-05,Diyanet official
-2026,2026-05-26,Diyanet official
-# 2027–2055: Umm al-Qura tabular projection; verify against Diyanet announcements (±1 day risk)
-2027,2027-05-15,Umm al-Qura projection
-2028,2028-05-04,Umm al-Qura projection
-2029,2029-04-23,Umm al-Qura projection
-2030,2030-04-12,Umm al-Qura projection
-2031,2031-04-01,Umm al-Qura projection
-2032,2032-03-20,Umm al-Qura projection
-2033,2033-03-10,Umm al-Qura projection
-2034,2034-02-27,Umm al-Qura projection
-2035,2035-02-16,Umm al-Qura projection
+2025,2025-06-06,Diyanet official
+2026,2026-05-27,Diyanet official
+2027,2027-05-16,Diyanet official
+2028,2028-05-05,Diyanet official
+2029,2029-04-24,Diyanet official
+2030,2030-04-13,Diyanet official
+2031,2031-04-02,Diyanet official
+2032,2032-03-22,Diyanet official
+2033,2033-03-11,Diyanet official
+2034,2034-03-01,Diyanet official
+2035,2035-02-18,Diyanet official
+# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
 2036,2036-02-06,Umm al-Qura projection
 2037,2037-01-25,Umm al-Qura projection
 2038,2038-01-15,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
@@ -2,36 +2,42 @@
 # Marks the end of Ramadan.
 #
 # SOURCE TIERS:
-#   2024–2026: Diyanet (Presidency of Religious Affairs) official announcements,
-#              confirmed against BIST market calendar publications.
-#   2027–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
-#              used as a best-available approximation because Diyanet does not publish
-#              ilmi takvim (scientific calendar) projections beyond 1–2 years in advance.
-#              Actual Diyanet dates may differ by ±1 day from these Umm al-Qura values.
-#              Replace with ilmi takvim calculations when available (see GitHub issue #180).
+#   2024–2035: Diyanet (Presidency of Religious Affairs) official published dates,
+#              sourced directly from vakithesaplama.diyanet.gov.tr's "Dini Günler"
+#              (religious days) tables — Diyanet publishes these several years ahead
+#              of the current year, not just 1–2 years as previously assumed (see
+#              GitHub issue #180 for background). Confirmed against BIST market
+#              calendar publications for 2024–2026.
+#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
+#              used as a best-available approximation because Diyanet has not yet
+#              published religious-day tables this far ahead. Actual Diyanet dates may
+#              differ from these Umm al-Qura values (see eid-al-adha-tr.csv's 2026
+#              divergence note for a confirmed example of the magnitude of this risk).
+#              Replace with real Diyanet-published dates or an ilmi takvim calculation
+#              as they become available (see GitHub issue #180).
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
-# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences
-# (~January 3 and ~December 22). Only the first (January) occurrence is recorded
-# here. The December occurrence cannot be represented under the single-date-per-
-# year-key design.
+# NOTE — 2033: Gregorian year 2033 contains two Eid al-Fitr occurrences, per Diyanet's
+# own published table: 2 January 2033 and 23 December 2033. Only the first (January)
+# occurrence is recorded here. The December occurrence cannot be represented under the
+# single-date-per-year-key design.
 #
 # Format: year,YYYY-MM-DD,source
 2024,2024-04-10,Diyanet official
 2025,2025-03-30,Diyanet official
-2026,2026-03-19,Diyanet official
-# 2027–2055: Umm al-Qura tabular projection; verify against Diyanet announcements (±1 day risk)
-2027,2027-03-09,Umm al-Qura projection
-2028,2028-02-26,Umm al-Qura projection
-2029,2029-02-15,Umm al-Qura projection
-2030,2030-02-04,Umm al-Qura projection
-2031,2031-01-24,Umm al-Qura projection
-2032,2032-01-14,Umm al-Qura projection
-# 2033: two Eid al-Fitr occurrences (~Jan 3 and ~Dec 22); only January recorded
-2033,2033-01-03,Umm al-Qura projection (January occurrence only; December occurrence omitted)
-2034,2034-12-12,Umm al-Qura projection
-2035,2035-12-01,Umm al-Qura projection
+2026,2026-03-20,Diyanet official
+2027,2027-03-09,Diyanet official
+2028,2028-02-26,Diyanet official
+2029,2029-02-14,Diyanet official
+2030,2030-02-04,Diyanet official
+2031,2031-01-24,Diyanet official
+2032,2032-01-14,Diyanet official
+# 2033: two Eid al-Fitr occurrences (2 January and 23 December); only January recorded
+2033,2033-01-02,Diyanet official (January occurrence only; December occurrence omitted)
+2034,2034-12-12,Diyanet official
+2035,2035-12-01,Diyanet official
+# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
 2036,2036-11-19,Umm al-Qura projection
 2037,2037-11-09,Umm al-Qura projection
 2038,2038-10-29,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-fitr-tr.csv
@@ -8,13 +8,14 @@
 #              of the current year, not just 1–2 years as previously assumed (see
 #              GitHub issue #180 for background). Confirmed against BIST market
 #              calendar publications for 2024–2026.
-#   2036–2055: Umm al-Qura tabular projection (Saudi Arabia's published tabular calendar),
-#              used as a best-available approximation because Diyanet has not yet
-#              published religious-day tables this far ahead. Actual Diyanet dates may
-#              differ from these Umm al-Qura values (see eid-al-adha-tr.csv's 2026
-#              divergence note for a confirmed example of the magnitude of this risk).
-#              Replace with real Diyanet-published dates or an ilmi takvim calculation
-#              as they become available (see GitHub issue #180).
+#   2036–2055: Computed via IlmiTakvimCalculator (true lunar conjunction + Ankara
+#              sunset visibility rule, calibrated against and exactly reproducing
+#              all 24 Diyanet-published dates 2024–2035 — see
+#              IlmiTakvimCalculatorTest), used as a best-available projection
+#              because Diyanet has not yet published religious-day tables this far
+#              ahead. This remains a best-effort approximation, not a guarantee of
+#              Diyanet's actual future announcements — Diyanet's real process may
+#              involve committee judgment beyond a pure astronomical rule.
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
@@ -37,24 +38,24 @@
 2033,2033-01-02,Diyanet official (January occurrence only; December occurrence omitted)
 2034,2034-12-12,Diyanet official
 2035,2035-12-01,Diyanet official
-# 2036–2055: Umm al-Qura tabular projection; verify against Diyanet announcements as published
-2036,2036-11-19,Umm al-Qura projection
-2037,2037-11-09,Umm al-Qura projection
-2038,2038-10-29,Umm al-Qura projection
-2039,2039-10-19,Umm al-Qura projection
-2040,2040-10-08,Umm al-Qura projection
-2041,2041-09-27,Umm al-Qura projection
-2042,2042-09-16,Umm al-Qura projection
-2043,2043-09-05,Umm al-Qura projection
-2044,2044-08-24,Umm al-Qura projection
-2045,2045-08-14,Umm al-Qura projection
-2046,2046-08-04,Umm al-Qura projection
-2047,2047-07-24,Umm al-Qura projection
-2048,2048-07-13,Umm al-Qura projection
-2049,2049-07-02,Umm al-Qura projection
-2050,2050-06-21,Umm al-Qura projection
-2051,2051-06-10,Umm al-Qura projection
-2052,2052-05-30,Umm al-Qura projection
-2053,2053-05-19,Umm al-Qura projection
-2054,2054-05-09,Umm al-Qura projection
-2055,2055-04-28,Umm al-Qura projection
+# 2036–2055: ilmi takvim calculation; verify against Diyanet announcements as published
+2036,2036-11-19,ilmi takvim calculation
+2037,2037-11-08,ilmi takvim calculation
+2038,2038-10-29,ilmi takvim calculation
+2039,2039-10-19,ilmi takvim calculation
+2040,2040-10-07,ilmi takvim calculation
+2041,2041-09-26,ilmi takvim calculation
+2042,2042-09-15,ilmi takvim calculation
+2043,2043-09-04,ilmi takvim calculation
+2044,2044-08-24,ilmi takvim calculation
+2045,2045-08-14,ilmi takvim calculation
+2046,2046-08-03,ilmi takvim calculation
+2047,2047-07-24,ilmi takvim calculation
+2048,2048-07-12,ilmi takvim calculation
+2049,2049-07-01,ilmi takvim calculation
+2050,2050-06-20,ilmi takvim calculation
+2051,2051-06-10,ilmi takvim calculation
+2052,2052-05-29,ilmi takvim calculation
+2053,2053-05-19,ilmi takvim calculation
+2054,2054-05-09,ilmi takvim calculation
+2055,2055-04-28,ilmi takvim calculation

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILSEarlyCloseTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceILSEarlyCloseTest.java
@@ -1,0 +1,213 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.hebrew.ErevPassover;
+import org.holiday.calendar.observance.hebrew.ErevRoshHashanah;
+import org.holiday.calendar.observance.hebrew.ErevShavuot;
+import org.holiday.calendar.observance.hebrew.ErevSukkot;
+import org.holiday.calendar.observance.hebrew.ErevYomKippur;
+import org.holiday.calendar.observance.hebrew.Passover;
+import org.holiday.calendar.observance.hebrew.RoshHashanah;
+import org.holiday.calendar.observance.hebrew.Shavuot;
+import org.holiday.calendar.observance.hebrew.Sukkot;
+import org.holiday.calendar.observance.hebrew.YomKippur;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code ILS} calendar's early-close (TASE half-day closure /
+ * Bank of Israel reduced-hours) holidays, provided by
+ * {@link IsraelHolidays#earlyCloseHolidays()}.
+ */
+public class HolidayCalendarServiceILSEarlyCloseTest {
+
+    private static final int EARLY_CLOSE_COUNT = 6;
+    private static final int FULL_DAY_HOLIDAY_COUNT = 9;
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
+    private static final LocalTime HOSHANA_RABA_CLOSE_TIME = LocalTime.of(13, 15);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Asia/Jerusalem");
+
+    private final HolidayCalendarServiceILS service = new HolidayCalendarServiceILS();
+
+    // -------------------------------------------------------------------------
+    // Count
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEarlyCloseHolidayCount() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+    }
+
+    @Test
+    public void testFullDayHolidayCount_Unchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // Names
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEarlyCloseHolidayNames() {
+        Set<String> expectedNames = Set.of(
+                "Erev Rosh Hashanah",
+                "Erev Yom Kippur",
+                "Erev Passover",
+                "Erev Shavuot",
+                "Erev Sukkot",
+                "Hoshana Raba"
+        );
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        Set<String> actualNames = earlyCloses.stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertEquals(actualNames, expectedNames);
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testAllEarlyCloses_CloseTimeIs13_00() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+        for (HolidayDate hd : earlyCloses) {
+            assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+            EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+            if ("Hoshana Raba".equals(earlyClose.getName())) {
+                // Hoshana Raba has its own distinct close time; verified separately below.
+                continue;
+            }
+            assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                    earlyClose.getName() + " must close at 13:00");
+        }
+    }
+
+    @Test
+    public void testHoshanaRaba_CloseTimeIs13_15() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        HolidayDate hoshanaRaba = earlyCloses.stream()
+                .filter(hd -> "Hoshana Raba".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Hoshana Raba not found in calculateEarlyCloses(2025)"));
+        assertTrue(hoshanaRaba.getHoliday() instanceof EarlyCloseHoliday);
+        EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hoshanaRaba.getHoliday();
+        assertEquals(earlyClose.getCloseTime(), HOSHANA_RABA_CLOSE_TIME,
+                "Hoshana Raba must close at 13:15, distinct from the 13:00 holiday-eve early closes");
+    }
+
+    @Test
+    public void testAllEarlyCloses_ZoneId_IsJerusalem() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+        for (HolidayDate hd : earlyCloses) {
+            EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+            assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                    earlyClose.getName() + " must be expressed in Asia/Jerusalem");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Erev date == main holiday date minus 1 day, cross-checked against
+    // calculateEarlyCloses() output, across multiple years
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "erevDates")
+    public Iterator<Object[]> erevDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Erev Rosh Hashanah", "Rosh Hashanah", 2024},
+                new Object[]{"Erev Rosh Hashanah", "Rosh Hashanah", 2025},
+                new Object[]{"Erev Rosh Hashanah", "Rosh Hashanah", 2026},
+                new Object[]{"Erev Yom Kippur", "Yom Kippur", 2024},
+                new Object[]{"Erev Yom Kippur", "Yom Kippur", 2025},
+                new Object[]{"Erev Yom Kippur", "Yom Kippur", 2026},
+                new Object[]{"Erev Passover", "Passover", 2024},
+                new Object[]{"Erev Passover", "Passover", 2025},
+                new Object[]{"Erev Passover", "Passover", 2026},
+                new Object[]{"Erev Shavuot", "Shavuot", 2024},
+                new Object[]{"Erev Shavuot", "Shavuot", 2025},
+                new Object[]{"Erev Shavuot", "Shavuot", 2026},
+                new Object[]{"Erev Sukkot", "Sukkot", 2024},
+                new Object[]{"Erev Sukkot", "Sukkot", 2025},
+                new Object[]{"Erev Sukkot", "Sukkot", 2026}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "erevDates")
+    public void testErevDateIsOneDayBeforeMainHoliday(String erevName, String mainHolidayName, int year) {
+        LocalDate expected = mainHolidayDate(mainHolidayName, year).minusDays(1);
+        LocalDate erevObservanceDate = erevObservanceDate(erevName, year);
+        assertEquals(erevObservanceDate, expected,
+                erevName + " " + year + " must be exactly 1 day before " + mainHolidayName);
+
+        // Cross-check against calculateEarlyCloses() output
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> erevName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(erevName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                erevName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate mainHolidayDate(String mainHolidayName, int year) {
+        return switch (mainHolidayName) {
+            case "Rosh Hashanah" -> new RoshHashanah().apply(year);
+            case "Yom Kippur" -> new YomKippur().apply(year);
+            case "Passover" -> new Passover().apply(year);
+            case "Shavuot" -> new Shavuot().apply(year);
+            case "Sukkot" -> new Sukkot().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + mainHolidayName);
+        };
+    }
+
+    private LocalDate erevObservanceDate(String erevName, int year) {
+        return switch (erevName) {
+            case "Erev Rosh Hashanah" -> new ErevRoshHashanah().apply(year);
+            case "Erev Yom Kippur" -> new ErevYomKippur().apply(year);
+            case "Erev Passover" -> new ErevPassover().apply(year);
+            case "Erev Shavuot" -> new ErevShavuot().apply(year);
+            case "Erev Sukkot" -> new ErevSukkot().apply(year);
+            default -> throw new IllegalArgumentException("Unknown erev: " + erevName);
+        };
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTREarlyCloseTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTREarlyCloseTest.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.List;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code TR} calendar's early-close (BIST Republic Day Eve
+ * half-day closure) holiday, provided by {@link TurkeyHolidays#earlyCloseHolidays()}.
+ */
+public class HolidayCalendarServiceTREarlyCloseTest {
+
+    private static final int EARLY_CLOSE_COUNT = 1;
+    private static final int FULL_DAY_HOLIDAY_COUNT = 14;
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 30);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/Istanbul");
+
+    private final HolidayCalendarServiceTR service = new HolidayCalendarServiceTR();
+
+    @Test
+    public void testEarlyCloseHolidayCount2025() {
+        // Oct 28, 2025 is a Tuesday
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+    }
+
+    @Test
+    public void testFullDayHolidayCount_Unchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    @Test
+    public void testRepublicDayEve_NameCloseTimeAndZone2025() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        HolidayDate republicDayEve = earlyCloses.stream()
+                .filter(hd -> "Republic Day Eve".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Republic Day Eve not found in calculateEarlyCloses(2025)"));
+        assertEquals(republicDayEve.getDate(), LocalDate.of(2025, Month.OCTOBER, 28));
+        assertTrue(republicDayEve.getHoliday() instanceof EarlyCloseHoliday);
+        EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) republicDayEve.getHoliday();
+        assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME, "Republic Day Eve must close at 12:30");
+        assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE, "Republic Day Eve must be expressed in Europe/Istanbul");
+    }
+
+    @Test
+    public void testRepublicDayEve_SkippedWhenOct28FallsOnWeekend2023() {
+        // Oct 28, 2023 is a Saturday (Oct 29, 2023 is a Sunday)
+        assertEquals(LocalDate.of(2023, Month.OCTOBER, 28).getDayOfWeek(), DayOfWeek.SATURDAY);
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2023);
+        assertTrue(earlyCloses.isEmpty(),
+                "BIST does not shift the half-day close to the preceding Friday when Oct 28 falls on a weekend");
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -314,20 +314,20 @@ public class HolidayCalendarServiceTRTest {
     @Test
     public void testEidAlFitr2026() {
         assertEquals(findFirst("Eid al-Fitr", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MARCH, 19),
-                "Eid al-Fitr 2026 must be 2026-03-19 per Diyanet");
+                LocalDate.of(2026, Month.MARCH, 20),
+                "Eid al-Fitr 2026 must be 2026-03-20 per Diyanet");
     }
 
     @Test
     public void testEidAlFitrDay2_2026() {
         assertEquals(findFirst("Eid al-Fitr (2nd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MARCH, 20));
+                LocalDate.of(2026, Month.MARCH, 21));
     }
 
     @Test
     public void testEidAlFitrDay3_2026() {
         assertEquals(findFirst("Eid al-Fitr (3rd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MARCH, 21));
+                LocalDate.of(2026, Month.MARCH, 22));
     }
 
     // =========================================================================
@@ -361,53 +361,54 @@ public class HolidayCalendarServiceTRTest {
 
     @Test
     public void testEidAlAdha2025() {
-        // Turkey Diyanet = June 5; one day earlier than Saudi/UAE (June 6)
+        // Diyanet's 1st day of Bayram is June 6, matching Saudi/UAE; June 5 is Arefe (the eve)
         assertEquals(findFirst("Eid al-Adha", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 5),
-                "Eid al-Adha 2025 must be 2025-06-05 per Diyanet (one day earlier than Saudi/UAE)");
+                LocalDate.of(2025, Month.JUNE, 6),
+                "Eid al-Adha 2025 must be 2025-06-06 per Diyanet");
     }
 
     @Test
     public void testEidAlAdhaDay2_2025() {
         assertEquals(findFirst("Eid al-Adha (2nd Day)", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 6));
+                LocalDate.of(2025, Month.JUNE, 7));
     }
 
     @Test
     public void testEidAlAdhaDay3_2025() {
         assertEquals(findFirst("Eid al-Adha (3rd Day)", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 7));
+                LocalDate.of(2025, Month.JUNE, 8));
     }
 
     @Test
     public void testEidAlAdhaDay4_2025() {
         assertEquals(findFirst("Eid al-Adha (4th Day)", 2025).orElseThrow().date(),
-                LocalDate.of(2025, Month.JUNE, 8));
+                LocalDate.of(2025, Month.JUNE, 9));
     }
 
     @Test
     public void testEidAlAdha2026() {
+        // Turkey Diyanet = May 27; one day later than Saudi/UAE (May 26) — confirmed divergence
         assertEquals(findFirst("Eid al-Adha", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 26),
-                "Eid al-Adha 2026 must be 2026-05-26 per Diyanet");
+                LocalDate.of(2026, Month.MAY, 27),
+                "Eid al-Adha 2026 must be 2026-05-27 per Diyanet");
     }
 
     @Test
     public void testEidAlAdhaDay2_2026() {
         assertEquals(findFirst("Eid al-Adha (2nd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 27));
+                LocalDate.of(2026, Month.MAY, 28));
     }
 
     @Test
     public void testEidAlAdhaDay3_2026() {
         assertEquals(findFirst("Eid al-Adha (3rd Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 28));
+                LocalDate.of(2026, Month.MAY, 29));
     }
 
     @Test
     public void testEidAlAdhaDay4_2026() {
         assertEquals(findFirst("Eid al-Adha (4th Day)", 2026).orElseThrow().date(),
-                LocalDate.of(2026, Month.MAY, 29));
+                LocalDate.of(2026, Month.MAY, 30));
     }
 
     // =========================================================================
@@ -554,8 +555,8 @@ public class HolidayCalendarServiceTRTest {
                 .toList();
         assertEquals(eidOccurrences.size(), 1,
                 "2033 has two Eid al-Fitr occurrences but only the first is recorded in the CSV");
-        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 3),
-                "The single 2033 Eid al-Fitr occurrence must be January 3");
+        assertEquals(eidOccurrences.getFirst().date(), LocalDate.of(2033, Month.JANUARY, 2),
+                "The single 2033 Eid al-Fitr occurrence must be January 2");
     }
 
     // =========================================================================

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -560,16 +560,17 @@ public class HolidayCalendarServiceTRTest {
     }
 
     // =========================================================================
-    // Republic Day Eve (Oct 28) — confirmed absent; half-day not modelled
+    // Republic Day Eve (Oct 28) — early close, not a full-day holiday
     // =========================================================================
 
     @Test
-    public void testRepublicDayEveAbsent2025() {
+    public void testRepublicDayEveAbsentFromCalculate2025() {
         List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
         boolean oct28Present = holidays.stream()
                 .anyMatch(hd -> hd.date().equals(LocalDate.of(2025, Month.OCTOBER, 28)));
         assertFalse(oct28Present,
-                "Oct 28 (Republic Day Eve) must not be present — half-day closures are not modelled");
+                "Oct 28 (Republic Day Eve) is an EARLY_CLOSE holiday and must not appear in calculate(), "
+                        + "only in calculateEarlyCloses() — see HolidayCalendarServiceTREarlyCloseTest");
     }
 
     // =========================================================================

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/HebrewCalendarDateSanityTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/HebrewCalendarDateSanityTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -83,36 +84,36 @@ public class HebrewCalendarDateSanityTest {
         return List.of(
             // Rosh Hashanah (1 Tishri) — source: Hebcal rosh-hashana-{year} pages,
             // cross-checked against Jerusalem Post / israelhayom.com for 2024.
-            new Object[]{"RoshHashanah", 2024, LocalDate.of(2024, 10, 3)},
-            new Object[]{"RoshHashanah", 2025, LocalDate.of(2025, 9, 23)},
-            new Object[]{"RoshHashanah", 2026, LocalDate.of(2026, 9, 12)},
+            new Object[]{"RoshHashanah", 2024, LocalDate.of(2024, Month.OCTOBER, 3)},
+            new Object[]{"RoshHashanah", 2025, LocalDate.of(2025, Month.SEPTEMBER, 23)},
+            new Object[]{"RoshHashanah", 2026, LocalDate.of(2026, Month.SEPTEMBER, 12)},
 
             // Yom Kippur (10 Tishri) — source: Hebcal yom-kippur-{year} pages.
-            new Object[]{"YomKippur", 2024, LocalDate.of(2024, 10, 12)},
-            new Object[]{"YomKippur", 2025, LocalDate.of(2025, 10, 2)},
-            new Object[]{"YomKippur", 2026, LocalDate.of(2026, 9, 21)},
+            new Object[]{"YomKippur", 2024, LocalDate.of(2024, Month.OCTOBER, 12)},
+            new Object[]{"YomKippur", 2025, LocalDate.of(2025, Month.OCTOBER, 2)},
+            new Object[]{"YomKippur", 2026, LocalDate.of(2026, Month.SEPTEMBER, 21)},
 
             // Sukkot, first day (15 Tishri) — source: Hebcal sukkot-{year} pages.
-            new Object[]{"Sukkot", 2024, LocalDate.of(2024, 10, 17)},
-            new Object[]{"Sukkot", 2025, LocalDate.of(2025, 10, 7)},
-            new Object[]{"Sukkot", 2026, LocalDate.of(2026, 9, 26)},
+            new Object[]{"Sukkot", 2024, LocalDate.of(2024, Month.OCTOBER, 17)},
+            new Object[]{"Sukkot", 2025, LocalDate.of(2025, Month.OCTOBER, 7)},
+            new Object[]{"Sukkot", 2026, LocalDate.of(2026, Month.SEPTEMBER, 26)},
 
             // Passover, first day (15 Nisan) — source: Hebcal pesach-{year}?i=on
             // (Israel, single-day first-day observance) pages.
-            new Object[]{"Passover", 2024, LocalDate.of(2024, 4, 23)},
-            new Object[]{"Passover", 2025, LocalDate.of(2025, 4, 13)},
-            new Object[]{"Passover", 2026, LocalDate.of(2026, 4, 2)},
+            new Object[]{"Passover", 2024, LocalDate.of(2024, Month.APRIL, 23)},
+            new Object[]{"Passover", 2025, LocalDate.of(2025, Month.APRIL, 13)},
+            new Object[]{"Passover", 2026, LocalDate.of(2026, Month.APRIL, 2)},
 
             // Shavuot (6 Sivan) — source: Hebcal shavuot-{year}?i=on (Israel) pages.
-            new Object[]{"Shavuot", 2024, LocalDate.of(2024, 6, 12)},
-            new Object[]{"Shavuot", 2025, LocalDate.of(2025, 6, 2)},
-            new Object[]{"Shavuot", 2026, LocalDate.of(2026, 5, 22)},
+            new Object[]{"Shavuot", 2024, LocalDate.of(2024, Month.JUNE, 12)},
+            new Object[]{"Shavuot", 2025, LocalDate.of(2025, Month.JUNE, 2)},
+            new Object[]{"Shavuot", 2026, LocalDate.of(2026, Month.MAY, 22)},
 
             // Hoshana Raba (21 Tishri) — source: Sukkot first day (above) + 6 days,
             // cross-checked directly against independent Hoshana Raba listings.
-            new Object[]{"HoshanaRaba", 2024, LocalDate.of(2024, 10, 23)},
-            new Object[]{"HoshanaRaba", 2025, LocalDate.of(2025, 10, 13)},
-            new Object[]{"HoshanaRaba", 2026, LocalDate.of(2026, 10, 2)}
+            new Object[]{"HoshanaRaba", 2024, LocalDate.of(2024, Month.OCTOBER, 23)},
+            new Object[]{"HoshanaRaba", 2025, LocalDate.of(2025, Month.OCTOBER, 13)},
+            new Object[]{"HoshanaRaba", 2026, LocalDate.of(2026, Month.OCTOBER, 2)}
         ).iterator();
     }
 
@@ -144,29 +145,29 @@ public class HebrewCalendarDateSanityTest {
         return List.of(
             // Erev Rosh Hashanah — directly-sourced eve date (Hebcal: "began at
             // sunset" on this date) = independently confirmed as 1 Tishri minus 1.
-            new Object[]{"ErevRoshHashanah", 2024, LocalDate.of(2024, 10, 2)},
-            new Object[]{"ErevRoshHashanah", 2025, LocalDate.of(2025, 9, 22)},
-            new Object[]{"ErevRoshHashanah", 2026, LocalDate.of(2026, 9, 11)},
+            new Object[]{"ErevRoshHashanah", 2024, LocalDate.of(2024, Month.OCTOBER, 2)},
+            new Object[]{"ErevRoshHashanah", 2025, LocalDate.of(2025, Month.SEPTEMBER, 22)},
+            new Object[]{"ErevRoshHashanah", 2026, LocalDate.of(2026, Month.SEPTEMBER, 11)},
 
             // Erev Yom Kippur — directly-sourced eve date (Hebcal sunset-start).
-            new Object[]{"ErevYomKippur", 2024, LocalDate.of(2024, 10, 11)},
-            new Object[]{"ErevYomKippur", 2025, LocalDate.of(2025, 10, 1)},
-            new Object[]{"ErevYomKippur", 2026, LocalDate.of(2026, 9, 20)},
+            new Object[]{"ErevYomKippur", 2024, LocalDate.of(2024, Month.OCTOBER, 11)},
+            new Object[]{"ErevYomKippur", 2025, LocalDate.of(2025, Month.OCTOBER, 1)},
+            new Object[]{"ErevYomKippur", 2026, LocalDate.of(2026, Month.SEPTEMBER, 20)},
 
             // Erev Sukkot — directly-sourced eve date (Hebcal sunset-start).
-            new Object[]{"ErevSukkot", 2024, LocalDate.of(2024, 10, 16)},
-            new Object[]{"ErevSukkot", 2025, LocalDate.of(2025, 10, 6)},
-            new Object[]{"ErevSukkot", 2026, LocalDate.of(2026, 9, 25)},
+            new Object[]{"ErevSukkot", 2024, LocalDate.of(2024, Month.OCTOBER, 16)},
+            new Object[]{"ErevSukkot", 2025, LocalDate.of(2025, Month.OCTOBER, 6)},
+            new Object[]{"ErevSukkot", 2026, LocalDate.of(2026, Month.SEPTEMBER, 25)},
 
             // Erev Passover — directly-sourced eve date (Hebcal sunset-start).
-            new Object[]{"ErevPassover", 2024, LocalDate.of(2024, 4, 22)},
-            new Object[]{"ErevPassover", 2025, LocalDate.of(2025, 4, 12)},
-            new Object[]{"ErevPassover", 2026, LocalDate.of(2026, 4, 1)},
+            new Object[]{"ErevPassover", 2024, LocalDate.of(2024, Month.APRIL, 22)},
+            new Object[]{"ErevPassover", 2025, LocalDate.of(2025, Month.APRIL, 12)},
+            new Object[]{"ErevPassover", 2026, LocalDate.of(2026, Month.APRIL, 1)},
 
             // Erev Shavuot — directly-sourced eve date (Hebcal sunset-start).
-            new Object[]{"ErevShavuot", 2024, LocalDate.of(2024, 6, 11)},
-            new Object[]{"ErevShavuot", 2025, LocalDate.of(2025, 6, 1)},
-            new Object[]{"ErevShavuot", 2026, LocalDate.of(2026, 5, 21)}
+            new Object[]{"ErevShavuot", 2024, LocalDate.of(2024, Month.JUNE, 11)},
+            new Object[]{"ErevShavuot", 2025, LocalDate.of(2025, Month.JUNE, 1)},
+            new Object[]{"ErevShavuot", 2026, LocalDate.of(2026, Month.MAY, 21)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/HebrewCalendarDateSanityTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/hebrew/HebrewCalendarDateSanityTest.java
@@ -1,0 +1,187 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.hebrew;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Independent domain-fact sanity check for the Hebrew-calendar {@code Observance}
+ * classes, for 2024-2026.
+ *
+ * <p><strong>Why this test exists:</strong> the other tests in this module (e.g.
+ * {@link org.holiday.calendar.impl.HolidayCalendarServiceILSEarlyCloseTest}) verify
+ * internal consistency — that {@code Erev X} is exactly one day before {@code X}, that
+ * {@code calculateEarlyCloses()} agrees with the raw {@code Observance}, etc. Those
+ * checks can never catch a case where the underlying Hebrew→Gregorian conversion
+ * (via {@code net.time4j.calendar.HebrewCalendar}) is systematically wrong, because
+ * both sides of the comparison are derived from the same production code path.
+ *
+ * <p>This test instead hardcodes real-world Gregorian dates that were independently
+ * looked up (not computed from, or derived by calling, any class under test) and
+ * asserts the production {@code Observance} classes return exactly those dates.
+ * The {@code Erev} (eve) expectations are computed by literally subtracting one day
+ * from the hardcoded main-holiday literal in this test file — they never flow through
+ * {@code RoshHashanah#apply}, {@code YomKippur#apply}, etc. Where an authoritative
+ * source published the eve date directly (rather than this test deriving it), that
+ * directly-sourced date is used and is noted below; it happens to always agree with
+ * "main date minus 1", which is itself a useful independent confirmation.
+ *
+ * <p><strong>Sources (cross-referenced against at least two independent providers):</strong>
+ * <ul>
+ *   <li>Hebcal.com per-holiday pages for Israel (single-day observance), e.g.
+ *       {@code https://www.hebcal.com/holidays/rosh-hashana-2024},
+ *       {@code https://www.hebcal.com/holidays/pesach-2024?i=on}, etc. Hebcal
+ *       expresses each holiday as beginning "at sunset" on a given Gregorian date;
+ *       the Gregorian calendar date of the corresponding Hebrew day (as returned by
+ *       {@code HebrewCalendar...transform(PlainDate.axis())}, which is what every
+ *       production {@code Observance} in this package uses) is the day <em>after</em>
+ *       that sunset-start date, i.e. the day whose daylight hours the holiday falls
+ *       during. The sunset-start date itself is, independently, the real-world
+ *       civil date of "Erev [Holiday]" (the eve).</li>
+ *   <li>Cross-check: Jerusalem Post ("Rosh Hashanah 2024: Frequently asked questions
+ *       and answers") and israelhayom.com confirm Rosh Hashanah 2024 in Israel ran
+ *       from the evening of Wed 2 Oct 2024 through the evening of Thu 3 Oct 2024 —
+ *       i.e. 1 Tishri 5785 = Thursday, 3 October 2024.</li>
+ *   <li>Cross-check: Hoshana Raba (21 Tishri) dates were independently confirmed via
+ *       separate search results (porthope.ca event calendar and chabad.org calendar
+ *       views) giving "October 22 to 23" for 2024, "sunset 12 October" (day itself:
+ *       13 October) for 2025, and "sunset 1 October" (day itself: 2 October) for
+ *       2026 — each consistent with Sukkot's first day (15 Tishri) plus 6 days.</li>
+ * </ul>
+ */
+public class HebrewCalendarDateSanityTest {
+
+    // -------------------------------------------------------------------------
+    // Main holidays: hardcoded, independently-sourced Gregorian dates.
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> mainHolidayDates() {
+        return List.of(
+            // Rosh Hashanah (1 Tishri) — source: Hebcal rosh-hashana-{year} pages,
+            // cross-checked against Jerusalem Post / israelhayom.com for 2024.
+            new Object[]{"RoshHashanah", 2024, LocalDate.of(2024, 10, 3)},
+            new Object[]{"RoshHashanah", 2025, LocalDate.of(2025, 9, 23)},
+            new Object[]{"RoshHashanah", 2026, LocalDate.of(2026, 9, 12)},
+
+            // Yom Kippur (10 Tishri) — source: Hebcal yom-kippur-{year} pages.
+            new Object[]{"YomKippur", 2024, LocalDate.of(2024, 10, 12)},
+            new Object[]{"YomKippur", 2025, LocalDate.of(2025, 10, 2)},
+            new Object[]{"YomKippur", 2026, LocalDate.of(2026, 9, 21)},
+
+            // Sukkot, first day (15 Tishri) — source: Hebcal sukkot-{year} pages.
+            new Object[]{"Sukkot", 2024, LocalDate.of(2024, 10, 17)},
+            new Object[]{"Sukkot", 2025, LocalDate.of(2025, 10, 7)},
+            new Object[]{"Sukkot", 2026, LocalDate.of(2026, 9, 26)},
+
+            // Passover, first day (15 Nisan) — source: Hebcal pesach-{year}?i=on
+            // (Israel, single-day first-day observance) pages.
+            new Object[]{"Passover", 2024, LocalDate.of(2024, 4, 23)},
+            new Object[]{"Passover", 2025, LocalDate.of(2025, 4, 13)},
+            new Object[]{"Passover", 2026, LocalDate.of(2026, 4, 2)},
+
+            // Shavuot (6 Sivan) — source: Hebcal shavuot-{year}?i=on (Israel) pages.
+            new Object[]{"Shavuot", 2024, LocalDate.of(2024, 6, 12)},
+            new Object[]{"Shavuot", 2025, LocalDate.of(2025, 6, 2)},
+            new Object[]{"Shavuot", 2026, LocalDate.of(2026, 5, 22)},
+
+            // Hoshana Raba (21 Tishri) — source: Sukkot first day (above) + 6 days,
+            // cross-checked directly against independent Hoshana Raba listings.
+            new Object[]{"HoshanaRaba", 2024, LocalDate.of(2024, 10, 23)},
+            new Object[]{"HoshanaRaba", 2025, LocalDate.of(2025, 10, 13)},
+            new Object[]{"HoshanaRaba", 2026, LocalDate.of(2026, 10, 2)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "mainHolidayDates")
+    public void testMainHolidayMatchesIndependentlySourcedDate(String holidayName, int year, LocalDate expected) {
+        LocalDate actual = switch (holidayName) {
+            case "RoshHashanah" -> new RoshHashanah().apply(year);
+            case "YomKippur" -> new YomKippur().apply(year);
+            case "Sukkot" -> new Sukkot().apply(year);
+            case "Passover" -> new Passover().apply(year);
+            case "Shavuot" -> new Shavuot().apply(year);
+            case "HoshanaRaba" -> new HoshanaRaba().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+        assertEquals(actual, expected,
+                holidayName + " " + year + " must match the independently-sourced real-world date");
+    }
+
+    // -------------------------------------------------------------------------
+    // Erev (eve) holidays: expected value is the hardcoded main-holiday literal
+    // above, minus one day, computed here in the test — never by calling the
+    // production main-holiday Observance and subtracting from its output. These
+    // eve dates also happen to be directly the "begins at sunset on" date
+    // published by Hebcal, an independent confirmation in its own right.
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> erevHolidayDates() {
+        return List.of(
+            // Erev Rosh Hashanah — directly-sourced eve date (Hebcal: "began at
+            // sunset" on this date) = independently confirmed as 1 Tishri minus 1.
+            new Object[]{"ErevRoshHashanah", 2024, LocalDate.of(2024, 10, 2)},
+            new Object[]{"ErevRoshHashanah", 2025, LocalDate.of(2025, 9, 22)},
+            new Object[]{"ErevRoshHashanah", 2026, LocalDate.of(2026, 9, 11)},
+
+            // Erev Yom Kippur — directly-sourced eve date (Hebcal sunset-start).
+            new Object[]{"ErevYomKippur", 2024, LocalDate.of(2024, 10, 11)},
+            new Object[]{"ErevYomKippur", 2025, LocalDate.of(2025, 10, 1)},
+            new Object[]{"ErevYomKippur", 2026, LocalDate.of(2026, 9, 20)},
+
+            // Erev Sukkot — directly-sourced eve date (Hebcal sunset-start).
+            new Object[]{"ErevSukkot", 2024, LocalDate.of(2024, 10, 16)},
+            new Object[]{"ErevSukkot", 2025, LocalDate.of(2025, 10, 6)},
+            new Object[]{"ErevSukkot", 2026, LocalDate.of(2026, 9, 25)},
+
+            // Erev Passover — directly-sourced eve date (Hebcal sunset-start).
+            new Object[]{"ErevPassover", 2024, LocalDate.of(2024, 4, 22)},
+            new Object[]{"ErevPassover", 2025, LocalDate.of(2025, 4, 12)},
+            new Object[]{"ErevPassover", 2026, LocalDate.of(2026, 4, 1)},
+
+            // Erev Shavuot — directly-sourced eve date (Hebcal sunset-start).
+            new Object[]{"ErevShavuot", 2024, LocalDate.of(2024, 6, 11)},
+            new Object[]{"ErevShavuot", 2025, LocalDate.of(2025, 6, 1)},
+            new Object[]{"ErevShavuot", 2026, LocalDate.of(2026, 5, 21)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "erevHolidayDates")
+    public void testErevHolidayMatchesIndependentlySourcedEveDate(String erevName, int year, LocalDate expected) {
+        LocalDate actual = switch (erevName) {
+            case "ErevRoshHashanah" -> new ErevRoshHashanah().apply(year);
+            case "ErevYomKippur" -> new ErevYomKippur().apply(year);
+            case "ErevSukkot" -> new ErevSukkot().apply(year);
+            case "ErevPassover" -> new ErevPassover().apply(year);
+            case "ErevShavuot" -> new ErevShavuot().apply(year);
+            default -> throw new IllegalArgumentException("Unknown erev: " + erevName);
+        };
+        assertEquals(actual, expected,
+                erevName + " " + year + " must match the independently-sourced real-world eve date");
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -33,8 +33,8 @@ public class EidAlAdhaDay4Test {
     Iterator<Object[]> knownDatesTR() {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, 6, 19)},
-            new Object[]{2025, LocalDate.of(2025, 6, 8)},
-            new Object[]{2026, LocalDate.of(2026, 5, 29)},
+            new Object[]{2025, LocalDate.of(2025, 6, 9)},
+            new Object[]{2026, LocalDate.of(2026, 5, 30)},
             new Object[]{2055, LocalDate.of(2055, 7, 6)}
         ).iterator();
     }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -35,7 +35,7 @@ public class EidAlAdhaDay4Test {
             new Object[]{2024, LocalDate.of(2024, 6, 19)},
             new Object[]{2025, LocalDate.of(2025, 6, 9)},
             new Object[]{2026, LocalDate.of(2026, 5, 30)},
-            new Object[]{2055, LocalDate.of(2055, 7, 6)}
+            new Object[]{2055, LocalDate.of(2055, 7, 8)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaDay4Test.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -32,10 +33,10 @@ public class EidAlAdhaDay4Test {
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 19)},
-            new Object[]{2025, LocalDate.of(2025, 6, 9)},
-            new Object[]{2026, LocalDate.of(2026, 5, 30)},
-            new Object[]{2055, LocalDate.of(2055, 7, 8)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 19)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 9)},
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 8)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -55,9 +56,9 @@ public class EidAlAdhaTest {
     @DataProvider
     Iterator<Object[]> knownDatesAE() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 3)}
         ).iterator();
     }
 
@@ -102,17 +103,17 @@ public class EidAlAdhaTest {
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2026, LocalDate.of(2026, 5, 27)},  // one day later than AE/SA — see below
-            new Object[]{2027, LocalDate.of(2027, 5, 16)},
-            new Object[]{2035, LocalDate.of(2035, 2, 18)},
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 27)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, Month.MAY, 16)},
+            new Object[]{2035, LocalDate.of(2035, Month.FEBRUARY, 18)},
             // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
             // published this far ahead) — not independently verified against a
             // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
-            new Object[]{2040, LocalDate.of(2040, 12, 14)},
-            new Object[]{2050, LocalDate.of(2050, 8, 27)},
-            new Object[]{2055, LocalDate.of(2055, 7, 5)}
+            new Object[]{2040, LocalDate.of(2040, Month.DECEMBER, 14)},
+            new Object[]{2050, LocalDate.of(2050, Month.AUGUST, 27)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 5)}
         ).iterator();
     }
 
@@ -130,9 +131,9 @@ public class EidAlAdhaTest {
     public void testTR2026DiffersFromAE() {
         LocalDate trDate = new EidAlAdha("TR").apply(2026);
         LocalDate aeDate = new EidAlAdha("AE").apply(2026);
-        assertEquals(trDate, LocalDate.of(2026, 5, 27),
+        assertEquals(trDate, LocalDate.of(2026, Month.MAY, 27),
                 "Diyanet Eid al-Adha 2026 must be May 27");
-        assertEquals(aeDate, LocalDate.of(2026, 5, 26),
+        assertEquals(aeDate, LocalDate.of(2026, Month.MAY, 26),
                 "UAE SCA Eid al-Adha 2026 must be May 26");
         assertNotEquals(trDate, aeDate,
                 "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
@@ -152,9 +153,9 @@ public class EidAlAdhaTest {
     @DataProvider
     Iterator<Object[]> knownDatesQA() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2055, LocalDate.of(2055, Month.JULY, 3)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -107,9 +107,12 @@ public class EidAlAdhaTest {
             new Object[]{2026, LocalDate.of(2026, 5, 27)},  // one day later than AE/SA — see below
             new Object[]{2027, LocalDate.of(2027, 5, 16)},
             new Object[]{2035, LocalDate.of(2035, 2, 18)},
-            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
-            // far ahead) — not independently verified against a Diyanet source.
-            new Object[]{2055, LocalDate.of(2055, 7, 3)}
+            // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
+            // published this far ahead) — not independently verified against a
+            // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
+            new Object[]{2040, LocalDate.of(2040, 12, 14)},
+            new Object[]{2050, LocalDate.of(2050, 8, 27)},
+            new Object[]{2055, LocalDate.of(2055, 7, 5)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -96,16 +96,19 @@ public class EidAlAdhaTest {
     }
 
     // -------------------------------------------------------------------------
-    // Known dates — TR (Diyanet ilmi takvim)
-    // 2025 divergence: Diyanet = June 5; Saudi/UAE Umm al-Qura = June 6
+    // Known dates — TR (Diyanet ilmi takvim, official published dates 2024-2035)
     // -------------------------------------------------------------------------
 
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 5)},   // one day earlier than AE/SA
-            new Object[]{2026, LocalDate.of(2026, 5, 26)},
+            new Object[]{2025, LocalDate.of(2025, 6, 6)},
+            new Object[]{2026, LocalDate.of(2026, 5, 27)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, 5, 16)},
+            new Object[]{2035, LocalDate.of(2035, 2, 18)},
+            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
+            // far ahead) — not independently verified against a Diyanet source.
             new Object[]{2055, LocalDate.of(2055, 7, 3)}
         ).iterator();
     }
@@ -116,17 +119,27 @@ public class EidAlAdhaTest {
                 "Eid al-Adha " + year + " per Diyanet must be " + expected);
     }
 
-    // Canonical Diyanet vs. Umm al-Qura divergence: 2025 Eid al-Adha
+    // Canonical Diyanet vs. Umm al-Qura/UAE divergence: 2026 Eid al-Adha.
+    // (A previously-recorded 2025 divergence was a data error: 2025-06-05 is Arefe,
+    // the eve of Bayram, not the actual 1st day — Diyanet's published 1st day is
+    // 2025-06-06, matching AE/SA. No divergence exists in 2025.)
     @Test
-    public void testTR2025DiffersFromAE() {
-        LocalDate trDate = new EidAlAdha("TR").apply(2025);
-        LocalDate aeDate = new EidAlAdha("AE").apply(2025);
-        assertEquals(trDate, LocalDate.of(2025, 6, 5),
-                "Diyanet Eid al-Adha 2025 must be June 5");
-        assertEquals(aeDate, LocalDate.of(2025, 6, 6),
-                "UAE SCA Eid al-Adha 2025 must be June 6");
+    public void testTR2026DiffersFromAE() {
+        LocalDate trDate = new EidAlAdha("TR").apply(2026);
+        LocalDate aeDate = new EidAlAdha("AE").apply(2026);
+        assertEquals(trDate, LocalDate.of(2026, 5, 27),
+                "Diyanet Eid al-Adha 2026 must be May 27");
+        assertEquals(aeDate, LocalDate.of(2026, 5, 26),
+                "UAE SCA Eid al-Adha 2026 must be May 26");
         assertNotEquals(trDate, aeDate,
-                "Diyanet and Umm al-Qura Eid al-Adha 2025 must differ by one day");
+                "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
+    }
+
+    // 2025 no longer diverges once the Arefe/Bayram-day data error is corrected
+    @Test
+    public void testTR2025MatchesAE() {
+        assertEquals(new EidAlAdha("TR").apply(2025), new EidAlAdha("AE").apply(2025),
+                "Eid al-Adha 2025: Diyanet (TR) and UAE SCA (AE) must agree on June 6");
     }
 
     // -------------------------------------------------------------------------

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -170,4 +170,37 @@ public class EidAlAdhaTest {
         assertEquals(new EidAlAdha("QA").apply(2025), new EidAlAdha("AE").apply(2025),
                 "Eid al-Adha 2025: Qatar (QCB) and UAE (SCA) must agree on June 6");
     }
+
+    // -------------------------------------------------------------------------
+    // Runtime fallback to IlmiTakvimCalculator (TR only, when the CSV has no row
+    // for an in-range year — all tr CSV rows are currently populated through
+    // DATA_VALID_THROUGH, so these tests exercise computeDate() directly for years
+    // outside the CSV's own range to prove the fallback path itself is correct.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void computeDateFallsBackToCalculatorForTrWhenCsvHasNoRow() {
+        int year = 2100; // beyond DATA_VALID_THROUGH; no CSV row for any country
+        EidAlAdha tr = new EidAlAdha("tr");
+        assertEquals(tr.computeDate(year),
+                org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator.eidAlAdha(year),
+                "computeDate must fall back to IlmiTakvimCalculator for tr when the CSV lacks a row");
+    }
+
+    @Test
+    public void computeDateReturnsNullWhenCalculatorFailsForTr() {
+        // Year 3050 is beyond Time4J's supported astronomical range, forcing
+        // IlmiTakvimCalculator to throw; computeDate must catch it and return null.
+        assertNull(new EidAlAdha("tr").computeDate(3050),
+                "computeDate must return null when the ilmi takvim calculation itself fails");
+        assertTrue(listAppender.list.stream().anyMatch(e -> e.getLevel() == Level.WARN),
+                "Expected a WARN log when the ilmi takvim calculation fails");
+    }
+
+    @Test
+    public void computeDateReturnsNullForNonTrCountryWhenCsvHasNoRow() {
+        assertNull(new EidAlAdha("ae").computeDate(2100),
+                "computeDate must return null for non-tr countries when the CSV lacks a row "
+                        + "(no calculator fallback exists for them)");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -29,6 +29,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -59,9 +60,9 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesAE() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 
@@ -77,9 +78,9 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesSA() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 
@@ -156,17 +157,17 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesTR() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2026, LocalDate.of(2026, 3, 20)},  // one day later than AE/SA — see below
-            new Object[]{2027, LocalDate.of(2027, 3, 9)},
-            new Object[]{2035, LocalDate.of(2035, 12, 1)},
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 20)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 9)},
+            new Object[]{2035, LocalDate.of(2035, Month.DECEMBER, 1)},
             // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
             // published this far ahead) — not independently verified against a
             // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
-            new Object[]{2040, LocalDate.of(2040, 10, 7)},
-            new Object[]{2050, LocalDate.of(2050, 6, 20)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2040, LocalDate.of(2040, Month.OCTOBER, 7)},
+            new Object[]{2050, LocalDate.of(2050, Month.JUNE, 20)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 
@@ -188,9 +189,9 @@ public class EidAlFitrTest {
     public void testTR2026DiffersFromAE() {
         LocalDate trDate = new EidAlFitr("TR").apply(2026);
         LocalDate aeDate = new EidAlFitr("AE").apply(2026);
-        assertEquals(trDate, LocalDate.of(2026, 3, 20),
+        assertEquals(trDate, LocalDate.of(2026, Month.MARCH, 20),
                 "Diyanet Eid al-Fitr 2026 must be March 20");
-        assertEquals(aeDate, LocalDate.of(2026, 3, 19),
+        assertEquals(aeDate, LocalDate.of(2026, Month.MARCH, 19),
                 "UAE SCA Eid al-Fitr 2026 must be March 19");
         assertNotEquals(trDate, aeDate,
                 "Diyanet and UAE SCA Eid al-Fitr 2026 must differ by one day");
@@ -203,9 +204,9 @@ public class EidAlFitrTest {
     @DataProvider
     Iterator<Object[]> knownDatesQA() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2055, LocalDate.of(2055, 4, 28)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2055, LocalDate.of(2055, Month.APRIL, 28)}
         ).iterator();
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -161,8 +161,11 @@ public class EidAlFitrTest {
             new Object[]{2026, LocalDate.of(2026, 3, 20)},  // one day later than AE/SA — see below
             new Object[]{2027, LocalDate.of(2027, 3, 9)},
             new Object[]{2035, LocalDate.of(2035, 12, 1)},
-            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
-            // far ahead) — not independently verified against a Diyanet source.
+            // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
+            // published this far ahead) — not independently verified against a
+            // Diyanet source; see CsvCalculatorParityTest for CSV/calculator consistency.
+            new Object[]{2040, LocalDate.of(2040, 10, 7)},
+            new Object[]{2050, LocalDate.of(2050, 6, 20)},
             new Object[]{2055, LocalDate.of(2055, 4, 28)}
         ).iterator();
     }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -221,4 +221,37 @@ public class EidAlFitrTest {
         assertEquals(new EidAlFitr("QA").apply(2025), new EidAlFitr("AE").apply(2025),
                 "Eid al-Fitr 2025: Qatar (QCB) and UAE (SCA) must agree on March 30");
     }
+
+    // -------------------------------------------------------------------------
+    // Runtime fallback to IlmiTakvimCalculator (TR only, when the CSV has no row
+    // for an in-range year — all tr CSV rows are currently populated through
+    // DATA_VALID_THROUGH, so these tests exercise computeDate() directly for years
+    // outside the CSV's own range to prove the fallback path itself is correct.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void computeDateFallsBackToCalculatorForTrWhenCsvHasNoRow() {
+        int year = 2100; // beyond DATA_VALID_THROUGH; no CSV row for any country
+        EidAlFitr tr = new EidAlFitr("tr");
+        assertEquals(tr.computeDate(year),
+                org.holiday.calendar.observance.islamic.mena.ilmitakvim.IlmiTakvimCalculator.eidAlFitr(year),
+                "computeDate must fall back to IlmiTakvimCalculator for tr when the CSV lacks a row");
+    }
+
+    @Test
+    public void computeDateReturnsNullWhenCalculatorFailsForTr() {
+        // Year 3050 is beyond Time4J's supported astronomical range, forcing
+        // IlmiTakvimCalculator to throw; computeDate must catch it and return null.
+        assertNull(new EidAlFitr("tr").computeDate(3050),
+                "computeDate must return null when the ilmi takvim calculation itself fails");
+        assertTrue(listAppender.list.stream().anyMatch(e -> e.getLevel() == Level.WARN),
+                "Expected a WARN log when the ilmi takvim calculation fails");
+    }
+
+    @Test
+    public void computeDateReturnsNullForNonTrCountryWhenCsvHasNoRow() {
+        assertNull(new EidAlFitr("ae").computeDate(2100),
+                "computeDate must return null for non-tr countries when the CSV lacks a row "
+                        + "(no calculator fallback exists for them)");
+    }
 }

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlFitrTest.java
@@ -150,7 +150,7 @@ public class EidAlFitrTest {
     }
 
     // -------------------------------------------------------------------------
-    // Known dates — TR (Diyanet ilmi takvim)
+    // Known dates — TR (Diyanet ilmi takvim, official published dates 2024-2035)
     // -------------------------------------------------------------------------
 
     @DataProvider
@@ -158,7 +158,11 @@ public class EidAlFitrTest {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, 4, 10)},
             new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2026, LocalDate.of(2026, 3, 19)},
+            new Object[]{2026, LocalDate.of(2026, 3, 20)},  // one day later than AE/SA — see below
+            new Object[]{2027, LocalDate.of(2027, 3, 9)},
+            new Object[]{2035, LocalDate.of(2035, 12, 1)},
+            // 2055 remains an Umm al-Qura projection (Diyanet has not yet published this
+            // far ahead) — not independently verified against a Diyanet source.
             new Object[]{2055, LocalDate.of(2055, 4, 28)}
         ).iterator();
     }
@@ -174,6 +178,19 @@ public class EidAlFitrTest {
     public void testTR2025MatchesAE() {
         assertEquals(new EidAlFitr("TR").apply(2025), new EidAlFitr("AE").apply(2025),
                 "Eid al-Fitr 2025: Diyanet (TR) and UAE SCA (AE) must agree on March 30");
+    }
+
+    // TR 2026 diverges from AE by one day: Diyanet (ilmi takvim) vs UAE SCA
+    @Test
+    public void testTR2026DiffersFromAE() {
+        LocalDate trDate = new EidAlFitr("TR").apply(2026);
+        LocalDate aeDate = new EidAlFitr("AE").apply(2026);
+        assertEquals(trDate, LocalDate.of(2026, 3, 20),
+                "Diyanet Eid al-Fitr 2026 must be March 20");
+        assertEquals(aeDate, LocalDate.of(2026, 3, 19),
+                "UAE SCA Eid al-Fitr 2026 must be March 19");
+        assertNotEquals(trDate, aeDate,
+                "Diyanet and UAE SCA Eid al-Fitr 2026 must differ by one day");
     }
 
     // -------------------------------------------------------------------------

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/CsvCalculatorParityTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/CsvCalculatorParityTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena.ilmitakvim;
+
+import org.holiday.calendar.observance.islamic.mena.EidAlAdha;
+import org.holiday.calendar.observance.islamic.mena.EidAlFitr;
+import org.holiday.calendar.util.CsvObservanceLoader;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.testng.Assert.assertEquals;
+
+/**
+ * Guards against drift between the checked-in {@code eid-al-fitr-tr.csv} /
+ * {@code eid-al-adha-tr.csv} rows for 2036-2055 and {@link IlmiTakvimCalculator}'s
+ * own live output — both currently encode the same values (the CSV rows were
+ * generated from the calculator), but nothing prevents them from silently
+ * diverging if either is edited independently in the future.
+ */
+public class CsvCalculatorParityTest {
+
+    // 2039 has a documented double-occurrence in Gregorian terms (see
+    // eid-al-adha-tr.csv comments); the CSV records only the earlier occurrence,
+    // exactly as the calculator does, so no exclusion is actually needed — but
+    // years with day1 exactly on 31 December / 1 January carry a small extra risk
+    // of calendar-boundary edge cases, so this suite does not special-case any
+    // year and instead lets a real mismatch fail loudly.
+
+    @DataProvider
+    Object[][] projectedYears() {
+        Object[][] years = new Object[20][1];
+        for (int i = 0; i < 20; i++) {
+            years[i][0] = 2036 + i;
+        }
+        return years;
+    }
+
+    @Test(dataProvider = "projectedYears")
+    public void fitrCsvRowMatchesCalculatorOutput(int year) {
+        Map<Integer, LocalDate> csv = CsvObservanceLoader.loadSingle(EidAlFitr.class, "eid-al-fitr-tr.csv");
+        assertEquals(csv.get(year), IlmiTakvimCalculator.eidAlFitr(year),
+                "eid-al-fitr-tr.csv row for " + year + " has drifted from IlmiTakvimCalculator's own output");
+    }
+
+    @Test(dataProvider = "projectedYears")
+    public void adhaCsvRowMatchesCalculatorOutput(int year) {
+        Map<Integer, LocalDate> csv = CsvObservanceLoader.loadSingle(EidAlAdha.class, "eid-al-adha-tr.csv");
+        assertEquals(csv.get(year), IlmiTakvimCalculator.eidAlAdha(year),
+                "eid-al-adha-tr.csv row for " + year + " has drifted from IlmiTakvimCalculator's own output");
+    }
+
+}

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
@@ -22,6 +22,7 @@ import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 
@@ -46,18 +47,18 @@ public class IlmiTakvimCalculatorTest {
     @DataProvider
     Iterator<Object[]> verifiedEidAlFitrDates() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 4, 10)},
-            new Object[]{2025, LocalDate.of(2025, 3, 30)},
-            new Object[]{2026, LocalDate.of(2026, 3, 20)},
-            new Object[]{2027, LocalDate.of(2027, 3, 9)},
-            new Object[]{2028, LocalDate.of(2028, 2, 26)},
-            new Object[]{2029, LocalDate.of(2029, 2, 14)},
-            new Object[]{2030, LocalDate.of(2030, 2, 4)},
-            new Object[]{2031, LocalDate.of(2031, 1, 24)},
-            new Object[]{2032, LocalDate.of(2032, 1, 14)},
-            new Object[]{2033, LocalDate.of(2033, 1, 2)}, // double-occurrence year; January recorded
-            new Object[]{2034, LocalDate.of(2034, 12, 12)},
-            new Object[]{2035, LocalDate.of(2035, 12, 1)}
+            new Object[]{2024, LocalDate.of(2024, Month.APRIL, 10)},
+            new Object[]{2025, LocalDate.of(2025, Month.MARCH, 30)},
+            new Object[]{2026, LocalDate.of(2026, Month.MARCH, 20)},
+            new Object[]{2027, LocalDate.of(2027, Month.MARCH, 9)},
+            new Object[]{2028, LocalDate.of(2028, Month.FEBRUARY, 26)},
+            new Object[]{2029, LocalDate.of(2029, Month.FEBRUARY, 14)},
+            new Object[]{2030, LocalDate.of(2030, Month.FEBRUARY, 4)},
+            new Object[]{2031, LocalDate.of(2031, Month.JANUARY, 24)},
+            new Object[]{2032, LocalDate.of(2032, Month.JANUARY, 14)},
+            new Object[]{2033, LocalDate.of(2033, Month.JANUARY, 2)}, // double-occurrence year; January recorded
+            new Object[]{2034, LocalDate.of(2034, Month.DECEMBER, 12)},
+            new Object[]{2035, LocalDate.of(2035, Month.DECEMBER, 1)}
         ).iterator();
     }
 
@@ -74,18 +75,18 @@ public class IlmiTakvimCalculatorTest {
     @DataProvider
     Iterator<Object[]> verifiedEidAlAdhaDates() {
         return List.of(
-            new Object[]{2024, LocalDate.of(2024, 6, 16)},
-            new Object[]{2025, LocalDate.of(2025, 6, 6)},
-            new Object[]{2026, LocalDate.of(2026, 5, 27)},
-            new Object[]{2027, LocalDate.of(2027, 5, 16)},
-            new Object[]{2028, LocalDate.of(2028, 5, 5)},
-            new Object[]{2029, LocalDate.of(2029, 4, 24)},
-            new Object[]{2030, LocalDate.of(2030, 4, 13)},
-            new Object[]{2031, LocalDate.of(2031, 4, 2)},
-            new Object[]{2032, LocalDate.of(2032, 3, 22)},
-            new Object[]{2033, LocalDate.of(2033, 3, 11)},
-            new Object[]{2034, LocalDate.of(2034, 3, 1)},
-            new Object[]{2035, LocalDate.of(2035, 2, 18)}
+            new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
+            new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 27)},
+            new Object[]{2027, LocalDate.of(2027, Month.MAY, 16)},
+            new Object[]{2028, LocalDate.of(2028, Month.MAY, 5)},
+            new Object[]{2029, LocalDate.of(2029, Month.APRIL, 24)},
+            new Object[]{2030, LocalDate.of(2030, Month.APRIL, 13)},
+            new Object[]{2031, LocalDate.of(2031, Month.APRIL, 2)},
+            new Object[]{2032, LocalDate.of(2032, Month.MARCH, 22)},
+            new Object[]{2033, LocalDate.of(2033, Month.MARCH, 11)},
+            new Object[]{2034, LocalDate.of(2034, Month.MARCH, 1)},
+            new Object[]{2035, LocalDate.of(2035, Month.FEBRUARY, 18)}
         ).iterator();
     }
 
@@ -98,8 +99,8 @@ public class IlmiTakvimCalculatorTest {
     // Canonical divergence: Diyanet vs UAE SCA / Umm al-Qura, 2026 Eid al-Adha
     @Test
     public void reproducesCanonical2026AdhaDivergence() {
-        assertEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 27));
-        assertNotEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 26),
+        assertEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, Month.MAY, 27));
+        assertNotEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, Month.MAY, 26),
                 "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
     }
 

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/ilmitakvim/IlmiTakvimCalculatorTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.islamic.mena.ilmitakvim;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.util.Iterator;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+/**
+ * Verifies {@link IlmiTakvimCalculator} against all 24 dates (2024-2035, Eid
+ * al-Fitr and Eid al-Adha) fetched directly from Diyanet's own published
+ * "Dini Günler" tables at vakithesaplama.diyanet.gov.tr (icerik.php?icerik=N /
+ * dinigunler.php?yil=N for the respective years) — not the CSV files, so this
+ * is an independent check of the calculator's logic in isolation.
+ */
+public class IlmiTakvimCalculatorTest {
+
+    // -------------------------------------------------------------------------
+    // Verified Eid al-Fitr dates (1 Shawwal), 2024-2035, Diyanet official
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> verifiedEidAlFitrDates() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 4, 10)},
+            new Object[]{2025, LocalDate.of(2025, 3, 30)},
+            new Object[]{2026, LocalDate.of(2026, 3, 20)},
+            new Object[]{2027, LocalDate.of(2027, 3, 9)},
+            new Object[]{2028, LocalDate.of(2028, 2, 26)},
+            new Object[]{2029, LocalDate.of(2029, 2, 14)},
+            new Object[]{2030, LocalDate.of(2030, 2, 4)},
+            new Object[]{2031, LocalDate.of(2031, 1, 24)},
+            new Object[]{2032, LocalDate.of(2032, 1, 14)},
+            new Object[]{2033, LocalDate.of(2033, 1, 2)}, // double-occurrence year; January recorded
+            new Object[]{2034, LocalDate.of(2034, 12, 12)},
+            new Object[]{2035, LocalDate.of(2035, 12, 1)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "verifiedEidAlFitrDates")
+    public void computesEidAlFitrAgainstDiyanetPublishedDate(int year, LocalDate expected) {
+        assertEquals(IlmiTakvimCalculator.eidAlFitr(year), expected,
+                "Eid al-Fitr " + year + " must match Diyanet's published ilmi takvim date");
+    }
+
+    // -------------------------------------------------------------------------
+    // Verified Eid al-Adha dates (10 Dhu al-Hijjah), 2024-2035, Diyanet official
+    // -------------------------------------------------------------------------
+
+    @DataProvider
+    Iterator<Object[]> verifiedEidAlAdhaDates() {
+        return List.of(
+            new Object[]{2024, LocalDate.of(2024, 6, 16)},
+            new Object[]{2025, LocalDate.of(2025, 6, 6)},
+            new Object[]{2026, LocalDate.of(2026, 5, 27)},
+            new Object[]{2027, LocalDate.of(2027, 5, 16)},
+            new Object[]{2028, LocalDate.of(2028, 5, 5)},
+            new Object[]{2029, LocalDate.of(2029, 4, 24)},
+            new Object[]{2030, LocalDate.of(2030, 4, 13)},
+            new Object[]{2031, LocalDate.of(2031, 4, 2)},
+            new Object[]{2032, LocalDate.of(2032, 3, 22)},
+            new Object[]{2033, LocalDate.of(2033, 3, 11)},
+            new Object[]{2034, LocalDate.of(2034, 3, 1)},
+            new Object[]{2035, LocalDate.of(2035, 2, 18)}
+        ).iterator();
+    }
+
+    @Test(dataProvider = "verifiedEidAlAdhaDates")
+    public void computesEidAlAdhaAgainstDiyanetPublishedDate(int year, LocalDate expected) {
+        assertEquals(IlmiTakvimCalculator.eidAlAdha(year), expected,
+                "Eid al-Adha " + year + " must match Diyanet's published ilmi takvim date");
+    }
+
+    // Canonical divergence: Diyanet vs UAE SCA / Umm al-Qura, 2026 Eid al-Adha
+    @Test
+    public void reproducesCanonical2026AdhaDivergence() {
+        assertEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 27));
+        assertNotEquals(IlmiTakvimCalculator.eidAlAdha(2026), LocalDate.of(2026, 5, 26),
+                "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
+    }
+
+    // -------------------------------------------------------------------------
+    // Residual projection range (2036-2055) — internal consistency checks only;
+    // Diyanet has not yet published these, so there is no independent source to
+    // verify against. These checks guard against gross errors (wrong direction,
+    // duplicate dates, out-of-range results), not exact-date correctness.
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void projectedFitrDatesRegressPlausibly() {
+        for (int year = 2036; year <= 2054; year++) {
+            LocalDate current = IlmiTakvimCalculator.eidAlFitr(year);
+            LocalDate next = IlmiTakvimCalculator.eidAlFitr(year + 1);
+            assertPlausibleGap("Eid al-Fitr", year, current, next);
+        }
+    }
+
+    @Test
+    public void projectedAdhaDatesRegressPlausibly() {
+        for (int year = 2036; year <= 2054; year++) {
+            LocalDate current = IlmiTakvimCalculator.eidAlAdha(year);
+            LocalDate next = IlmiTakvimCalculator.eidAlAdha(year + 1);
+            assertPlausibleGap("Eid al-Adha", year, current, next);
+        }
+    }
+
+    /**
+     * A Hijri year is ~354-355 days; against a ~365-366 day Gregorian year, the
+     * anniversary regresses by ~10-12 days most years. When a double-occurrence
+     * year (two anniversaries in one Gregorian year, only the first recorded per
+     * the documented convention) is involved, the recorded gap to the following
+     * year can look like roughly two lunar years instead of one.
+     */
+    private static void assertPlausibleGap(String label, int year, LocalDate current, LocalDate next) {
+        long daysBetween = java.time.temporal.ChronoUnit.DAYS.between(current, next);
+        boolean oneLunarYear = daysBetween >= 353 && daysBetween <= 357;
+        boolean twoLunarYears = daysBetween >= 700 && daysBetween <= 712;
+        assertTrue(oneLunarYear || twoLunarYears,
+                label + " " + year + "->" + (year + 1) + " gap of " + daysBetween
+                        + " days is outside the plausible range");
+    }
+
+    @Test
+    public void adhaIsAlwaysComputableAcrossTheResidualProjectionRange() {
+        for (int year = 2036; year <= 2055; year++) {
+            assertNotNull(IlmiTakvimCalculator.eidAlAdha(year), "Eid al-Adha " + year + " must resolve to a date");
+        }
+    }
+
+}

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -29,6 +29,7 @@ module org.holiday.calendar.western {
     exports org.holiday.calendar.observance.christian;
     exports org.holiday.calendar.observance.au;
     exports org.holiday.calendar.observance.ca;
+    exports org.holiday.calendar.observance.de;
     exports org.holiday.calendar.observance.eu;
     exports org.holiday.calendar.observance.uk;
     exports org.holiday.calendar.observance.us;

--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -31,6 +31,7 @@ module org.holiday.calendar.western {
     exports org.holiday.calendar.observance.ca;
     exports org.holiday.calendar.observance.de;
     exports org.holiday.calendar.observance.eu;
+    exports org.holiday.calendar.observance.fr;
     exports org.holiday.calendar.observance.uk;
     exports org.holiday.calendar.observance.us;
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
@@ -22,13 +22,17 @@ import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.au.ChristmasEveEarlyClose;
 import org.holiday.calendar.observance.au.KingsBirthday;
+import org.holiday.calendar.observance.au.NewYearsEveEarlyClose;
 import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
 
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
@@ -114,6 +118,26 @@ public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("ASX half-day close; suppressed entirely (not shifted) " +
+                             "when December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(14, 10))
+                .zoneId(ZoneId.of("Australia/Sydney"))
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("ASX half-day close; suppressed entirely (not shifted) " +
+                             "when December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(14, 10))
+                .zoneId(ZoneId.of("Australia/Sydney"))
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -129,6 +153,8 @@ public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
                 .holiday(kingsBirthday)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
@@ -172,7 +172,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                     final boolean isNewYearsDay = newYearsDayDate.isPresent() && dateToRoll.equals(newYearsDayDate.get());
                     final boolean isCanadaDay = canadaDayDate.isPresent() && dateToRoll.equals(canadaDayDate.get());
                     final boolean isRemembranceDay = remembranceDayDate.isPresent() && dateToRoll.equals(remembranceDayDate.get());
-                    if (dateToRoll.getDayOfWeek() == DayOfWeek.SUNDAY) {
+                    if (DayOfWeek.SUNDAY.equals(dateToRoll.getDayOfWeek())) {
                         return (isNewYearsDay || isCanadaDay || isRemembranceDay) ? dateToRoll.plusDays(1L) : dateToRoll;
                     }
                     return dateToRoll;

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
@@ -25,6 +25,7 @@ import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.ca.ChristmasEveEarlyClose;
 import org.holiday.calendar.observance.ca.CivicHoliday;
 import org.holiday.calendar.observance.ca.FamilyDay;
 import org.holiday.calendar.observance.ca.LabourDay;
@@ -33,7 +34,9 @@ import org.holiday.calendar.observance.ca.VictoriaDay;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
@@ -47,6 +50,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
 
     private static final String CODE = "CA";
     private static final String NAME = "Canada National Holidays";
+    private static final ZoneId TSX_ZONE = ZoneId.of("America/Toronto");
 
     public HolidayCalendarServiceCA() {
         super(CODE, NAME);
@@ -133,6 +137,16 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .monthDay(Month.NOVEMBER, 11)
                 .rollable(true)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("TSX 1:00pm local early close; occurs whenever "
+                             + "December 24 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(13, 0))
+                .zoneId(TSX_ZONE)
+                .build();
         final Holiday christmas = Holiday.builder()
                 .name("Christmas Day")
                 .description("Christmas Day")
@@ -175,6 +189,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .holiday(nationalDayForTruthAndReconciliation)
                 .holiday(thanksgiving)
                 .holiday(remembranceDay)
+                .holiday(christmasEveEarlyClose)
                 .holiday(christmas)
                 .holiday(boxingDay)
                 .build();

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCH.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCH.java
@@ -100,6 +100,13 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.AUGUST, 1)
                 .build();
+        final Holiday christmasEve = Holiday.builder()
+                .name("Christmas Eve")
+                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 24)
+                .build();
         final Holiday christmasDay = Holiday.builder()
                 .name("Christmas Day")
                 .description("Celebration of traditional Christmas holiday")
@@ -114,6 +121,13 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday newYearsEve = Holiday.builder()
+                .name("New Year's Eve")
+                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 31)
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -127,8 +141,10 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
                 .holiday(ascensionDay)
                 .holiday(whitMonday)
                 .holiday(swissNationalDay)
+                .holiday(christmasEve)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(newYearsEve)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceDE.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceDE.java
@@ -28,6 +28,8 @@ import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.christian.WhitMonday;
+import org.holiday.calendar.observance.de.ChristmasEve;
+import org.holiday.calendar.observance.de.NewYearsEve;
 
 import java.time.Month;
 
@@ -100,6 +102,14 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.OCTOBER, 3)
                 .build();
+        final Holiday christmasEve = Holiday.builder()
+                .name("Christmas Eve")
+                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
+                        + "Exchange; omitted (not shifted) when it falls on a weekend")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ChristmasEve())
+                .build();
         final Holiday christmasDay = Holiday.builder()
                 .name("Christmas Day")
                 .description("Celebration of traditional Christmas holiday")
@@ -114,6 +124,14 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday newYearsEve = Holiday.builder()
+                .name("New Year's Eve")
+                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
+                        + "Exchange; omitted (not shifted) when it falls on a weekend")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new NewYearsEve())
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -127,8 +145,10 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
                 .holiday(ascensionDay)
                 .holiday(whitMonday)
                 .holiday(germanUnityDay)
+                .holiday(christmasEve)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(newYearsEve)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceFR.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceFR.java
@@ -27,8 +27,12 @@ import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.christian.WhitMonday;
+import org.holiday.calendar.observance.fr.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.fr.NewYearsEveEarlyClose;
 
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
@@ -127,6 +131,26 @@ public class HolidayCalendarServiceFR extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 25)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("Euronext Paris half-day close; suppressed entirely (not shifted) " +
+                             "when December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(14, 5))
+                .zoneId(ZoneId.of("Europe/Paris"))
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("Euronext Paris half-day close; suppressed entirely (not shifted) " +
+                             "when December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(14, 5))
+                .zoneId(ZoneId.of("Europe/Paris"))
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -144,6 +168,8 @@ public class HolidayCalendarServiceFR extends AbstractHolidayCalendarService {
                 .holiday(allSaintsDay)
                 .holiday(armisticeDay)
                 .holiday(christmasDay)
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUK.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUK.java
@@ -25,16 +25,27 @@ import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.uk.ChristmasEveEarlyClose;
 import org.holiday.calendar.observance.uk.EarlyMayBankHoliday;
+import org.holiday.calendar.observance.uk.NewYearsEveEarlyClose;
 import org.holiday.calendar.observance.uk.SpringBankHoliday;
 import org.holiday.calendar.observance.uk.SummerBankHoliday;
 import org.holiday.calendar.observance.uk.UKDateRolls;
 
 import java.time.LocalDate;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 /**
  * Service for provision of UK national holiday calendar.
+ *
+ * <p>Includes two {@code EARLY_CLOSE} holidays representing the London Stock
+ * Exchange's Christmas Eve and New Year's Eve half-day closes. The CHAPS
+ * settlement calendar ({@link HolidayCalendarServiceGBP}) does not currently
+ * include these — CHAPS payment settlement and LSE equities trading are
+ * distinct systems, and adding early closes there would need its own
+ * Bank of England-sourced verification.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -134,6 +145,26 @@ public class HolidayCalendarServiceUK extends AbstractHolidayCalendarService {
                 .rollable(true)
                 .monthDay(Month.DECEMBER, 26)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("LSE half-day close; shifts to the preceding Friday when " +
+                             "December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(12, 30))
+                .zoneId(ZoneId.of("Europe/London"))
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("LSE half-day close; shifts to the preceding Friday when " +
+                             "December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(12, 30))
+                .zoneId(ZoneId.of("Europe/London"))
+                .build();
 
         return HolidayCalendar.builder()
                 .code(CODE)
@@ -152,6 +183,8 @@ public class HolidayCalendarServiceUK extends AbstractHolidayCalendarService {
                 .holiday(summerBankHoliday)
                 .holiday(christmasDay)
                 .holiday(boxingDay)
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
@@ -27,7 +27,9 @@ import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.us.*;
 
 import java.time.DayOfWeek;
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 /**
  * Service for provision of US national holiday calendar.
@@ -126,11 +128,33 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                             .build();
         final Holiday dayAfterThanksgiving = Holiday.builder()
                                                      .name("Day After Thanksgiving")
-                                                     .description("Day after Thanksgiving (NYSE market closure by convention)")
-                                                     .type(Holiday.Type.FLOATING)
+                                                     .description("NYSE 1:00pm ET early close, the day after Thanksgiving")
+                                                     .type(Holiday.Type.EARLY_CLOSE)
                                                      .rollable(false)
                                                      .observance(new DayAfterThanksgiving())
+                                                     .closeTime(LocalTime.of(13, 0))
+                                                     .zoneId(ZoneId.of("America/New_York"))
                                                      .build();
+        final Holiday julyThirdEarlyClose = Holiday.builder()
+                                                    .name("July 3rd")
+                                                    .description("NYSE 1:00pm ET early close; occurs only when " +
+                                                                 "July 4 falls Tuesday through Friday")
+                                                    .type(Holiday.Type.EARLY_CLOSE)
+                                                    .rollable(false)
+                                                    .observance(new JulyThirdEarlyClose())
+                                                    .closeTime(LocalTime.of(13, 0))
+                                                    .zoneId(ZoneId.of("America/New_York"))
+                                                    .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                                                       .name("Christmas Eve")
+                                                       .description("NYSE 1:00pm ET early close; occurs only when " +
+                                                                    "December 25 falls Tuesday through Friday")
+                                                       .type(Holiday.Type.EARLY_CLOSE)
+                                                       .rollable(false)
+                                                       .observance(new ChristmasEveEarlyClose())
+                                                       .closeTime(LocalTime.of(13, 0))
+                                                       .zoneId(ZoneId.of("America/New_York"))
+                                                       .build();
         final Holiday christmasDay = Holiday.builder()
                                             .name("Christmas Day")
                                             .description("Celebration of traditional Christmas holiday")
@@ -154,11 +178,13 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                 .holiday(memorialDay)
                 .holiday(juneteenth)
                 .holiday(independenceDay)
+                .holiday(julyThirdEarlyClose)
                 .holiday(laborDay)
                 .holiday(columbusDay)
                 .holiday(veteransDay)
                 .holiday(thanksgiving)
                 .holiday(dayAfterThanksgiving)
+                .holiday(christmasEveEarlyClose)
                 .holiday(christmasDay)
                 .build();
     }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUS.java
@@ -40,6 +40,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
 
     private static final String CODE = "US";
     private static final String NAME = "United States National Holidays";
+    private static final ZoneId NYSE_ZONE = ZoneId.of("America/New_York");
 
     public HolidayCalendarServiceUS() {
         super(CODE, NAME);
@@ -133,7 +134,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                                      .rollable(false)
                                                      .observance(new DayAfterThanksgiving())
                                                      .closeTime(LocalTime.of(13, 0))
-                                                     .zoneId(ZoneId.of("America/New_York"))
+                                                     .zoneId(NYSE_ZONE)
                                                      .build();
         final Holiday julyThirdEarlyClose = Holiday.builder()
                                                     .name("July 3rd")
@@ -143,7 +144,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                                     .rollable(false)
                                                     .observance(new JulyThirdEarlyClose())
                                                     .closeTime(LocalTime.of(13, 0))
-                                                    .zoneId(ZoneId.of("America/New_York"))
+                                                    .zoneId(NYSE_ZONE)
                                                     .build();
         final Holiday christmasEveEarlyClose = Holiday.builder()
                                                        .name("Christmas Eve")
@@ -153,7 +154,7 @@ public class HolidayCalendarServiceUS extends AbstractHolidayCalendarService {
                                                        .rollable(false)
                                                        .observance(new ChristmasEveEarlyClose())
                                                        .closeTime(LocalTime.of(13, 0))
-                                                       .zoneId(ZoneId.of("America/New_York"))
+                                                       .zoneId(NYSE_ZONE)
                                                        .build();
         final Holiday christmasDay = Holiday.builder()
                                             .name("Christmas Day")

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/AsxEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/AsxEveEarlyClose.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Package-private template for the Australian Securities Exchange's
+ * Christmas Eve / New Year's Eve half-day close Observances: the early close
+ * occurs on the fixed date whenever that date falls on a weekday, and is
+ * suppressed entirely (not shifted, unlike the London Stock Exchange) when
+ * the date falls on a Saturday or Sunday.
+ *
+ * <p>Other calendars in this codebase (e.g. {@code observance.ca},
+ * {@code observance.sg}) intentionally keep their Christmas Eve/New Year's
+ * Eve Observances as separate, non-sharing classes despite near-identical
+ * bodies. This package deviates from that convention with a package-private
+ * shared base, scoped only to {@code observance.au}, purely to avoid
+ * duplicating that same body a second time (SonarCloud's new-code
+ * duplication gate flags the repeated {@code computeDate}/{@code isValidYear}
+ * pattern, same as it did for {@code observance.fr}'s
+ * {@code EuronextEveEarlyClose}).
+ */
+abstract class AsxEveEarlyClose extends AbstractObservance {
+
+    private final Month month;
+    private final int dayOfMonth;
+
+    AsxEveEarlyClose(Month month, int dayOfMonth) {
+        this.month = month;
+        this.dayOfMonth = dayOfMonth;
+    }
+
+    @Override
+    protected final LocalDate computeDate(int year) {
+        return LocalDate.of(year, month, dayOfMonth);
+    }
+
+    @Override
+    protected final boolean isValidYear(int year) {
+        DayOfWeek dayOfWeek = computeDate(year).getDayOfWeek();
+        return switch (dayOfWeek) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Australian Securities Exchange's Christmas Eve half-day
+ * close (December 24). ASX runs a shortened trading session (normal trading
+ * ceasing at 14:10 Sydney time) on December 24 whenever that date falls on a
+ * weekday; when December 24 falls on a Saturday or Sunday, the half-day close
+ * is not observed that year at all — unlike the London Stock Exchange (see
+ * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose}), ASX
+ * does not shift the half-day session to the preceding Friday. This is why
+ * {@link #isValidYear(int)} is overridden here to signal absence in
+ * ineligible years, rather than {@link #computeDate(int)} shifting to a
+ * different day.
+ *
+ * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
+ * New Year" notices (asxonline.com): the 2025/2026 notice confirms the 14:10
+ * Sydney close, and the 2022/2023 notice confirms suppression — with
+ * December 24, 2022 falling on a Saturday, that notice designates Friday
+ * December 23, 2022 as a normal, full-hours trading day rather than shifting
+ * the half-day session to it.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/ChristmasEveEarlyClose.java
@@ -18,10 +18,6 @@
 
 package org.holiday.calendar.observance.au;
 
-import org.holiday.calendar.observance.AbstractObservance;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.Month;
 
 /**
@@ -31,10 +27,12 @@ import java.time.Month;
  * weekday; when December 24 falls on a Saturday or Sunday, the half-day close
  * is not observed that year at all — unlike the London Stock Exchange (see
  * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose}), ASX
- * does not shift the half-day session to the preceding Friday. This is why
- * {@link #isValidYear(int)} is overridden here to signal absence in
- * ineligible years, rather than {@link #computeDate(int)} shifting to a
- * different day.
+ * does not shift the half-day session to the preceding Friday. See
+ * {@link AsxEveEarlyClose} for the shared eligibility logic (a different
+ * use of {@code isValidYear} than its algorithm-validity use in
+ * {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
+ * for the same note).
  *
  * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
  * New Year" notices (asxonline.com): the 2025/2026 notice confirms the 14:10
@@ -45,20 +43,10 @@ import java.time.Month;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class ChristmasEveEarlyClose extends AbstractObservance {
+public class ChristmasEveEarlyClose extends AsxEveEarlyClose {
 
-    @Override
-    protected LocalDate computeDate(int year) {
-        return LocalDate.of(year, Month.DECEMBER, 24);
-    }
-
-    @Override
-    protected boolean isValidYear(int year) {
-        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
-        return switch (christmasEve) {
-            case SATURDAY, SUNDAY -> false;
-            default -> true;
-        };
+    public ChristmasEveEarlyClose() {
+        super(Month.DECEMBER, 24);
     }
 
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
@@ -18,10 +18,6 @@
 
 package org.holiday.calendar.observance.au;
 
-import org.holiday.calendar.observance.AbstractObservance;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.Month;
 
 /**
@@ -31,10 +27,12 @@ import java.time.Month;
  * weekday; when December 31 falls on a Saturday or Sunday, the half-day close
  * is not observed that year at all — unlike the London Stock Exchange (see
  * {@code org.holiday.calendar.observance.uk.NewYearsEveEarlyClose}), ASX does
- * not shift the half-day session to the preceding Friday. This is why
- * {@link #isValidYear(int)} is overridden here to signal absence in
- * ineligible years, rather than {@link #computeDate(int)} shifting to a
- * different day.
+ * not shift the half-day session to the preceding Friday. See
+ * {@link AsxEveEarlyClose} for the shared eligibility logic (a different
+ * use of {@code isValidYear} than its algorithm-validity use in
+ * {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
+ * for the same note).
  *
  * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
  * New Year" notices (asxonline.com): the 2025/2026 notice confirms the same
@@ -42,20 +40,10 @@ import java.time.Month;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class NewYearsEveEarlyClose extends AbstractObservance {
+public class NewYearsEveEarlyClose extends AsxEveEarlyClose {
 
-    @Override
-    protected LocalDate computeDate(int year) {
-        return LocalDate.of(year, Month.DECEMBER, 31);
-    }
-
-    @Override
-    protected boolean isValidYear(int year) {
-        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
-        return switch (newYearsEve) {
-            case SATURDAY, SUNDAY -> false;
-            default -> true;
-        };
+    public NewYearsEveEarlyClose() {
+        super(Month.DECEMBER, 31);
     }
 
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/au/NewYearsEveEarlyClose.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Australian Securities Exchange's New Year's Eve half-day
+ * close (December 31). ASX runs a shortened trading session (normal trading
+ * ceasing at 14:10 Sydney time) on December 31 whenever that date falls on a
+ * weekday; when December 31 falls on a Saturday or Sunday, the half-day close
+ * is not observed that year at all — unlike the London Stock Exchange (see
+ * {@code org.holiday.calendar.observance.uk.NewYearsEveEarlyClose}), ASX does
+ * not shift the half-day session to the preceding Friday. This is why
+ * {@link #isValidYear(int)} is overridden here to signal absence in
+ * ineligible years, rather than {@link #computeDate(int)} shifting to a
+ * different day.
+ *
+ * <p>Verified against ASX's own "ASX Trade trading hours for Christmas and
+ * New Year" notices (asxonline.com): the 2025/2026 notice confirms the same
+ * 14:10 Sydney close applies to both December 24 and December 31.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyClose.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the Toronto Stock Exchange's Christmas Eve half-day close
+ * (December 24). Unlike {@code org.holiday.calendar.observance.us.ChristmasEveEarlyClose}
+ * — whose eligibility is keyed off December 25's day of week — TSX's rule is
+ * keyed directly off December 24 itself: the early close applies whenever
+ * December 24 falls Monday through Friday, and is suppressed entirely (not
+ * shifted, unlike {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose})
+ * when December 24 falls on a weekend. This is why {@link #isValidYear(int)}
+ * is overridden here to signal absence in ineligible years, rather than
+ * {@link #computeDate(int)} shifting to a different day.
+ *
+ * <p>Note this differs from the only other pre-existing use of
+ * {@link #isValidYear(int)} in this codebase ({@code WesternEaster} /
+ * {@code OrthodoxEaster}), where it bounds algorithm validity rather than
+ * encoding a business-calendar exclusion — the same mechanism, two different
+ * purposes.
+ *
+ * <p>Verified against TMX Group's official Holiday Operating Schedule
+ * (tsx.com trading calendar / TMX PDF schedules), 2017-2026. Confirmed
+ * divergence from NYSE convention in 2021: December 25, 2021 fell on a
+ * Saturday (which would suppress NYSE's Dec 24 early close), yet December 24,
+ * 2021 fell on a Friday and TSX held its early close that day.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/ChristmasEve.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/ChristmasEve.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Xetra/Frankfurt Stock Exchange's Christmas Eve full non-trading
+ * day (December 24, an "Erfüllungstag"/settlement day). Unlike
+ * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose} — which
+ * always occurs, shifting to the preceding Friday on a weekend — Xetra/FWB is
+ * simply not a trading day at all on weekends, so December 24 is omitted
+ * entirely (not shifted) in years it falls on a Saturday or Sunday. This
+ * mirrors {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s
+ * suppression semantics, applied here to a {@code FLOATING} full-day holiday
+ * rather than an {@code EARLY_CLOSE}.
+ *
+ * <p>Verified against Deutsche Börse's official Xetra-Handelskalender
+ * (cashmarket.deutsche-boerse.com), 2023-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEve extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/NewYearsEve.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/de/NewYearsEve.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Xetra/Frankfurt Stock Exchange's New Year's Eve full non-trading
+ * day (December 31, an "Erfüllungstag"/settlement day). Mirrors {@link ChristmasEve}'s
+ * suppression semantics: omitted entirely (not shifted) in years December 31 falls
+ * on a Saturday or Sunday, since Xetra/FWB is simply not a trading day at all on
+ * weekends.
+ *
+ * <p>Verified against Deutsche Börse's official Xetra-Handelskalender
+ * (cashmarket.deutsche-boerse.com), 2023-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEve extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/ChristmasEveEarlyClose.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.fr;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Euronext Paris's Christmas Eve half-day close (December 24).
+ * Euronext runs a shortened trading session (closing 14:05 CET) on December 24
+ * whenever that date falls on a weekday; when December 24 falls on a Saturday
+ * or Sunday, the half-day close is not observed that year at all — unlike the
+ * London Stock Exchange (see {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose}),
+ * Euronext does not shift the half-day session to the preceding Friday.
+ * {@link #isValidYear(int)} is overridden here to signal that business-rule
+ * absence (a different use of {@code isValidYear} than its algorithm-validity
+ * use in {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
+ * for the same note), while {@link #computeDate(int)} unconditionally returns
+ * December 24.
+ *
+ * <p>Verified against Euronext's official trading calendar / half-day-close
+ * notices, including the 2016 and 2017 press releases confirming the
+ * preceding Friday traded full hours in both weekend years, cross-checked
+ * 2014-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+        return switch (christmasEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/ChristmasEveEarlyClose.java
@@ -18,10 +18,6 @@
 
 package org.holiday.calendar.observance.fr;
 
-import org.holiday.calendar.observance.AbstractObservance;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.Month;
 
 /**
@@ -30,13 +26,12 @@ import java.time.Month;
  * whenever that date falls on a weekday; when December 24 falls on a Saturday
  * or Sunday, the half-day close is not observed that year at all — unlike the
  * London Stock Exchange (see {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose}),
- * Euronext does not shift the half-day session to the preceding Friday.
- * {@link #isValidYear(int)} is overridden here to signal that business-rule
- * absence (a different use of {@code isValidYear} than its algorithm-validity
- * use in {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * Euronext does not shift the half-day session to the preceding Friday. See
+ * {@link EuronextEveEarlyClose} for the shared eligibility logic (a different
+ * use of {@code isValidYear} than its algorithm-validity use in
+ * {@code WesternEaster}/{@code OrthodoxEaster} — see
  * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
- * for the same note), while {@link #computeDate(int)} unconditionally returns
- * December 24.
+ * for the same note).
  *
  * <p>Verified against Euronext's official trading calendar / half-day-close
  * notices, including the 2016 and 2017 press releases confirming the
@@ -45,20 +40,10 @@ import java.time.Month;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class ChristmasEveEarlyClose extends AbstractObservance {
+public class ChristmasEveEarlyClose extends EuronextEveEarlyClose {
 
-    @Override
-    protected LocalDate computeDate(int year) {
-        return LocalDate.of(year, Month.DECEMBER, 24);
-    }
-
-    @Override
-    protected boolean isValidYear(int year) {
-        DayOfWeek christmasEve = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
-        return switch (christmasEve) {
-            case SATURDAY, SUNDAY -> false;
-            default -> true;
-        };
+    public ChristmasEveEarlyClose() {
+        super(Month.DECEMBER, 24);
     }
 
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/EuronextEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/EuronextEveEarlyClose.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.fr;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Package-private template for Euronext Paris's Christmas Eve / New Year's
+ * Eve half-day close Observances: the early close occurs on the fixed date
+ * whenever that date falls on a weekday, and is suppressed entirely (not
+ * shifted, unlike the London Stock Exchange) when the date falls on a
+ * Saturday or Sunday.
+ *
+ * <p>Other calendars in this codebase (e.g. {@code observance.ca},
+ * {@code observance.sg}) intentionally keep their Christmas Eve/New Year's
+ * Eve Observances as separate, non-sharing classes despite near-identical
+ * bodies. This package deviates from that convention with a package-private
+ * shared base, scoped only to {@code observance.fr}, purely to avoid
+ * duplicating that same body a third and fourth time (SonarCloud's new-code
+ * duplication gate flags the repeated {@code computeDate}/{@code isValidYear}
+ * pattern against the pre-existing {@code ca}/{@code sg} classes).
+ */
+abstract class EuronextEveEarlyClose extends AbstractObservance {
+
+    private final Month month;
+    private final int dayOfMonth;
+
+    EuronextEveEarlyClose(Month month, int dayOfMonth) {
+        this.month = month;
+        this.dayOfMonth = dayOfMonth;
+    }
+
+    @Override
+    protected final LocalDate computeDate(int year) {
+        return LocalDate.of(year, month, dayOfMonth);
+    }
+
+    @Override
+    protected final boolean isValidYear(int year) {
+        DayOfWeek dayOfWeek = computeDate(year).getDayOfWeek();
+        return switch (dayOfWeek) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/NewYearsEveEarlyClose.java
@@ -18,10 +18,6 @@
 
 package org.holiday.calendar.observance.fr;
 
-import org.holiday.calendar.observance.AbstractObservance;
-
-import java.time.DayOfWeek;
-import java.time.LocalDate;
 import java.time.Month;
 
 /**
@@ -30,13 +26,12 @@ import java.time.Month;
  * whenever that date falls on a weekday; when December 31 falls on a Saturday
  * or Sunday, the half-day close is not observed that year at all — unlike the
  * London Stock Exchange (see {@code org.holiday.calendar.observance.uk.NewYearsEveEarlyClose}),
- * Euronext does not shift the half-day session to the preceding Friday.
- * {@link #isValidYear(int)} is overridden here to signal that business-rule
- * absence (a different use of {@code isValidYear} than its algorithm-validity
- * use in {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * Euronext does not shift the half-day session to the preceding Friday. See
+ * {@link EuronextEveEarlyClose} for the shared eligibility logic (a different
+ * use of {@code isValidYear} than its algorithm-validity use in
+ * {@code WesternEaster}/{@code OrthodoxEaster} — see
  * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
- * for the same note), while {@link #computeDate(int)} unconditionally returns
- * December 31.
+ * for the same note).
  *
  * <p>Verified against Euronext's official trading calendar / half-day-close
  * notices, including the 2016 and 2017 press releases confirming the
@@ -45,20 +40,10 @@ import java.time.Month;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class NewYearsEveEarlyClose extends AbstractObservance {
+public class NewYearsEveEarlyClose extends EuronextEveEarlyClose {
 
-    @Override
-    protected LocalDate computeDate(int year) {
-        return LocalDate.of(year, Month.DECEMBER, 31);
-    }
-
-    @Override
-    protected boolean isValidYear(int year) {
-        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
-        return switch (newYearsEve) {
-            case SATURDAY, SUNDAY -> false;
-            default -> true;
-        };
+    public NewYearsEveEarlyClose() {
+        super(Month.DECEMBER, 31);
     }
 
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/fr/NewYearsEveEarlyClose.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.fr;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of Euronext Paris's New Year's Eve half-day close (December 31).
+ * Euronext runs a shortened trading session (closing 14:05 CET) on December 31
+ * whenever that date falls on a weekday; when December 31 falls on a Saturday
+ * or Sunday, the half-day close is not observed that year at all — unlike the
+ * London Stock Exchange (see {@code org.holiday.calendar.observance.uk.NewYearsEveEarlyClose}),
+ * Euronext does not shift the half-day session to the preceding Friday.
+ * {@link #isValidYear(int)} is overridden here to signal that business-rule
+ * absence (a different use of {@code isValidYear} than its algorithm-validity
+ * use in {@code WesternEaster}/{@code OrthodoxEaster} — see
+ * {@code org.holiday.calendar.observance.ca.ChristmasEveEarlyClose}'s javadoc
+ * for the same note), while {@link #computeDate(int)} unconditionally returns
+ * December 31.
+ *
+ * <p>Verified against Euronext's official trading calendar / half-day-close
+ * notices, including the 2016 and 2017 press releases confirming the
+ * preceding Friday traded full hours in both weekend years, cross-checked
+ * 2014-2026.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 31);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek newYearsEve = LocalDate.of(year, Month.DECEMBER, 31).getDayOfWeek();
+        return switch (newYearsEve) {
+            case SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/ChristmasEveEarlyClose.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.uk;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the London Stock Exchange's Christmas Eve half-day close
+ * (December 24). When December 24 falls on a Saturday or Sunday, the
+ * half-day session is shifted to the preceding Friday, since the market is
+ * already closed on the natural date.
+ *
+ * <p>Verified against the LSE's official business days notice
+ * (londonstockexchange.com/equities-trading/business-days), which lists e.g.
+ * Friday 22 December 2028 as a "Christmas Holiday half day" (markets closing
+ * process commencing from 12:30 London time) — December 24, 2028 itself falls
+ * on a Sunday, confirming the shift-to-preceding-Friday rule.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        LocalDate date = LocalDate.of(year, Month.DECEMBER, 24);
+        return switch (date.getDayOfWeek()) {
+            case SATURDAY -> date.minusDays(1);
+            case SUNDAY -> date.minusDays(2);
+            default -> date;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/ChristmasEveEarlyClose.java
@@ -20,7 +20,6 @@ package org.holiday.calendar.observance.uk;
 
 import org.holiday.calendar.observance.AbstractObservance;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Month;
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/NewYearsEveEarlyClose.java
@@ -20,7 +20,6 @@ package org.holiday.calendar.observance.uk;
 
 import org.holiday.calendar.observance.AbstractObservance;
 
-import java.time.DayOfWeek;
 import java.time.LocalDate;
 import java.time.Month;
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/NewYearsEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/uk/NewYearsEveEarlyClose.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.uk;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the London Stock Exchange's New Year's Eve half-day close
+ * (December 31). When December 31 falls on a Saturday or Sunday, the
+ * half-day session is shifted to the preceding Friday, since the market is
+ * already closed on the natural date.
+ *
+ * <p>Verified against the LSE's official business days notice
+ * (londonstockexchange.com/equities-trading/business-days), which lists e.g.
+ * Friday 29 December 2028 as a "New Year's Holiday half day" (markets closing
+ * process commencing from 12:30 London time) — December 31, 2028 itself falls
+ * on a Sunday, confirming the shift-to-preceding-Friday rule.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class NewYearsEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        LocalDate date = LocalDate.of(year, Month.DECEMBER, 31);
+        return switch (date.getDayOfWeek()) {
+            case SATURDAY -> date.minusDays(1);
+            case SUNDAY -> date.minusDays(2);
+            default -> date;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/ChristmasEveEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/ChristmasEveEarlyClose.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the NYSE's Christmas Eve half-day close (December 24). Unlike
+ * a weekend-shifting observance, this early close does not occur at all in
+ * years where December 25 falls on a Monday, Saturday, or Sunday — it is
+ * suppressed for that year rather than moved to an adjacent date. This is why
+ * {@link #isValidYear(int)} is overridden here to signal absence, rather than
+ * {@link #computeDate(int)} shifting to a different day as
+ * {@code org.holiday.calendar.observance.uk.ChristmasEveEarlyClose} does.
+ *
+ * <p>Verified against NYSE Group's official Holiday and Early Closings
+ * Calendar press releases (ir.theice.com): December 24 is an early close only
+ * when December 25 falls Tuesday through Friday.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class ChristmasEveEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.DECEMBER, 24);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek christmasDay = LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek();
+        return switch (christmasDay) {
+            case MONDAY, SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/JulyThirdEarlyClose.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/us/JulyThirdEarlyClose.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.observance.AbstractObservance;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.Month;
+
+/**
+ * Observance of the NYSE's July 3rd half-day close, ahead of Independence
+ * Day. This early close does not occur at all in years where July 4 falls on
+ * a Monday, Saturday, or Sunday — it is suppressed for that year rather than
+ * moved to an adjacent date. Note in particular that a Monday July 4 also
+ * suppresses this early close (July 3 would be a Sunday, not a trading day),
+ * not just Saturday/Sunday.
+ *
+ * <p>Verified against NYSE Group's official Holiday and Early Closings
+ * Calendar press releases (ir.theice.com): July 3 is an early close only when
+ * July 4 falls Tuesday through Friday.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class JulyThirdEarlyClose extends AbstractObservance {
+
+    @Override
+    protected LocalDate computeDate(int year) {
+        return LocalDate.of(year, Month.JULY, 3);
+    }
+
+    @Override
+    protected boolean isValidYear(int year) {
+        DayOfWeek independenceDay = LocalDate.of(year, Month.JULY, 4).getDayOfWeek();
+        return switch (independenceDay) {
+            case MONDAY, SATURDAY, SUNDAY -> false;
+            default -> true;
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
@@ -193,8 +193,9 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
     }
 
     // -------------------------------------------------------------------------
-    // Cross-list date collision: empty in ordinary years, exactly {Dec 24}
-    // in Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve)
+    // Cross-list date collision: empty in ordinary years, exactly one date
+    // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
+    // onto Christmas Eve
     // -------------------------------------------------------------------------
 
     @Test(dataProvider = "auEarlyCloseFixture")

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceAUEarlyCloseTest.java
@@ -1,0 +1,313 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.au.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.au.NewYearsEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code AU} calendar's early-close (ASX half-day closure)
+ * holidays: Christmas Eve and New Year's Eve. Because December 24 and
+ * December 31 are always exactly 7 days apart, they always share the same
+ * day-of-week within a given year — both early closes are always present
+ * together or absent together, never one without the other, same shape as
+ * FR.
+ *
+ * <p>AU's Christmas Day and New Year's Day are both {@code rollable(true)}
+ * under {@code previousFridayOrFollowingMonday} (the same roll rule FR
+ * uses), producing the same two genuine date collisions with the early
+ * closes that FR's test suite covers, both verified explicitly below:
+ * <ul>
+ *     <li>Christmas Day rolls back onto December 24 whenever December 25
+ *     falls on a Saturday (e.g. 2021, 2027) — the same date Christmas Eve's
+ *     early close independently occupies that year.</li>
+ *     <li>New Year's Day rolls back onto December 31 of the <em>prior</em>
+ *     year whenever January 1 falls on a Saturday (e.g. January 1, 2028
+ *     rolls to December 31, 2027) — the same date New Year's Eve's early
+ *     close independently occupies in that prior year. This crosses a
+ *     {@code calculate(year)} year boundary, so it is not caught by a
+ *     same-year intersection check alone.</li>
+ * </ul>
+ */
+public class HolidayCalendarServiceAUEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(14, 10);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Australia/Sydney");
+
+    // 9 full-day holidays registered in HolidayCalendarServiceAU; the two Eve
+    // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 9.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 9;
+
+    private final HolidayCalendarServiceAU service = new HolidayCalendarServiceAU();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2020-2029 ASX cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "auEarlyCloseFixture")
+    public Iterator<Object[]> auEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2020, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true},
+                new Object[]{2027, true},
+                new Object[]{2028, false},
+                new Object[]{2029, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "AU " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "AU " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testNewYearsEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
+                "AU " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testEarlyCloseCountAlwaysZeroOrTwo(int year, boolean present) {
+        int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
+        assertNotEquals(count, 1, "AU " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+    }
+
+    // -------------------------------------------------------------------------
+    // Suppressed-year sanity checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasEveSuppressedIn2022() {
+        // 2022: December 24 = Saturday.
+        assertFalse(earlyCloseNames(2022).contains("Christmas Eve"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedIn2023() {
+        // 2023: December 24 = Sunday.
+        assertFalse(earlyCloseNames(2023).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs14_10() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 14:10");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsAustraliaSydney() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in Australia/Sydney");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyClosesNotRollable() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate() -- checked
+    // in both a non-collision year and a Dec-24-collision year
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        for (int year : List.of(2024, 2027)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            assertNotNull(holidays);
+            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "AU " + year + ": unexpected full-day holiday count");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-list date collision: empty in ordinary years, exactly {Dec 24}
+    // in Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve)
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "auEarlyCloseFixture")
+    public void testCrossListDateOverlapOnlyOnKnownChristmasDayRollYears(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+
+        boolean isChristmasDaySaturdayRollYear =
+                DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
+        if (isChristmasDaySaturdayRollYear) {
+            assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
+                    "AU " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+        } else {
+            assertTrue(intersection.isEmpty(), "AU " + year + ": unexpected cross-list date collision: " + intersection);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Named regression: Christmas Day (rolled) and Christmas Eve (early close)
+    // both legitimately appear on the same date in a Dec-25-Saturday year
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasDayAndChristmasEveCoexistOn24Dec2027() {
+        // December 25, 2027 is a Saturday and rolls to Friday December 24 under AU's
+        // previousFridayOrFollowingMonday roll rule -- the same date the non-rolling
+        // Christmas Eve EARLY_CLOSE independently occupies (December 24, 2027 is a
+        // Friday, a valid early-close weekday). Both facts are true simultaneously and
+        // must both surface, across calculate() and calculateEarlyCloses() respectively.
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        LocalDate dec24 = LocalDate.of(2027, Month.DECEMBER, 24);
+
+        boolean christmasDayPresent = calendar.calculate(2027).stream()
+                .anyMatch(hd -> "Christmas Day".equals(hd.getHoliday().getName()) && dec24.equals(hd.getDate()));
+        boolean christmasEvePresent = calendar.calculateEarlyCloses(2027).stream()
+                .anyMatch(hd -> "Christmas Eve".equals(hd.getHoliday().getName()) && dec24.equals(hd.getDate()));
+
+        assertTrue(christmasDayPresent, "Christmas Day (rolled) must appear on Dec 24, 2027");
+        assertTrue(christmasEvePresent, "Christmas Eve early close must independently appear on Dec 24, 2027");
+    }
+
+    // -------------------------------------------------------------------------
+    // Named regression: New Year's Day (rolled back onto the prior Dec 31) and
+    // New Year's Eve (early close) both legitimately appear on the same date --
+    // this crosses a calculate(year) year boundary and is not caught by the
+    // same-year cross-list check above
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testNewYearsDayAndNewYearsEveCoexistOn31Dec2027() {
+        // January 1, 2028 is a Saturday and rolls back to Friday December 31, 2027
+        // under AU's previousFridayOrFollowingMonday roll rule -- the same date the
+        // non-rolling New Year's Eve EARLY_CLOSE independently occupies in 2027
+        // (December 31, 2027 is a Friday, a valid early-close weekday). This is a
+        // genuine same-date coexistence spanning two different year arguments:
+        // calculate(2028) and calculateEarlyCloses(2027).
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        LocalDate dec31 = LocalDate.of(2027, Month.DECEMBER, 31);
+
+        boolean newYearsDayPresent = calendar.calculate(2028).stream()
+                .anyMatch(hd -> "New Year's Day".equals(hd.getHoliday().getName()) && dec31.equals(hd.getDate()));
+        boolean newYearsEvePresent = calendar.calculateEarlyCloses(2027).stream()
+                .anyMatch(hd -> "New Year's Eve".equals(hd.getHoliday().getName()) && dec31.equals(hd.getDate()));
+
+        assertTrue(newYearsDayPresent, "New Year's Day (rolled back from Jan 1, 2028) must appear on Dec 31, 2027");
+        assertTrue(newYearsEvePresent, "New Year's Eve early close must independently appear on Dec 31, 2027");
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2026},
+                new Object[]{"Christmas Eve", 2027},
+                new Object[]{"New Year's Eve", 2024},
+                new Object[]{"New Year's Eve", 2026},
+                new Object[]{"New Year's Eve", 2027}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            case "New Year's Eve" -> new NewYearsEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCAEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCAEarlyCloseTest.java
@@ -1,0 +1,210 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.ca.ChristmasEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code CA} calendar's early-close (TSX half-day closure)
+ * holiday: Christmas Eve. Unlike US's Christmas Eve early close (keyed off
+ * December 25's day of week), CA registers exactly one EARLY_CLOSE holiday,
+ * so the count per year is either 0 or 1 — never more than one.
+ */
+public class HolidayCalendarServiceCAEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("America/Toronto");
+
+    // 13 full-day holidays registered in HolidayCalendarServiceCA; Christmas Eve is the
+    // only EARLY_CLOSE holiday and is excluded by calculate(), so calculate() sees 13.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 13;
+
+    private final HolidayCalendarServiceCA service = new HolidayCalendarServiceCA();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2017-2026 TSX cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "caEarlyCloseFixture")
+    public Iterator<Object[]> caEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2017, false},
+                new Object[]{2018, true},
+                new Object[]{2019, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 1 : 0, "CA " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "CA " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    // -------------------------------------------------------------------------
+    // Suppressed-year sanity checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasEveSuppressedIn2022() {
+        // 2022: December 25 = Sunday, December 24 = Saturday.
+        assertFalse(earlyCloseNames(2022).contains("Christmas Eve"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedIn2023() {
+        // 2023: December 25 = Monday, December 24 = Sunday.
+        assertFalse(earlyCloseNames(2023).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // NYSE-divergence regression case
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testTsxClosesEarlyIn2021DespiteNyseStyleRuleSuppressing() {
+        // 2021: December 25 = Saturday, December 24 = Friday. NYSE's rule (keyed off
+        // Dec 25) would suppress this year; TSX's rule (keyed off Dec 24) does not.
+        assertTrue(earlyCloseNames(2021).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs13_00() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 13:00");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsAmericaToronto() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in America/Toronto");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyCloseNotRollable() {
+        for (int year : List.of(2018, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // No date appears in both calculate() and calculateEarlyCloses() for the same year
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+        assertTrue(intersection.isEmpty(),
+                "CA " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "caEarlyCloseFixture")
+    public void testEarlyCloseDateMatchesRawObservance(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        if (!present) {
+            assertTrue(earlyCloses.isEmpty(), "CA " + year + ": expected no early closes");
+            return;
+        }
+        LocalDate expected = new ChristmasEveEarlyClose().apply(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> "Christmas Eve".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Christmas Eve not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                "Christmas Eve via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCATest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCATest.java
@@ -20,7 +20,8 @@ public class HolidayCalendarServiceCATest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] familyDay = {"Family Day"};
         final Object[] victoriaDay = {"Victoria Day"};
-        return Arrays.asList(familyDay, victoriaDay).listIterator();
+        final Object[] christmasEve = {"Christmas Eve"};
+        return Arrays.asList(familyDay, victoriaDay, christmasEve).listIterator();
     }
 
     @DataProvider

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHTest.java
@@ -18,12 +18,20 @@
 
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.*;
 
 public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarServiceTest {
 
@@ -37,8 +45,10 @@ public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarService
     @Override
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
+        final Object[] christmasEve = new Object[]{"Christmas Eve"};
         final Object[] boxingDay = new Object[]{"Boxing Day"};
-        return Arrays.asList(swissNationalDay, boxingDay).listIterator();
+        final Object[] newYearsEve = new Object[]{"New Year's Eve"};
+        return Arrays.asList(swissNationalDay, christmasEve, boxingDay, newYearsEve).listIterator();
     }
 
     @DataProvider
@@ -57,8 +67,72 @@ public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarService
         final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // Christmas Day 2023: Dec 25 is Monday -> no roll
         final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // Christmas Eve: Dec 24
+        // 2021: Dec 24 is Friday -> no roll
+        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
+        // 2022: Dec 24 is Saturday -> rolls to Friday Dec 23
+        final Object[] christmasEve22 = {2022, "Christmas Eve", LocalDate.of(2022, Month.DECEMBER, 23)};
+        // 2023: Dec 24 is Sunday -> rolls to Monday Dec 25
+        final Object[] christmasEve23 = {2023, "Christmas Eve", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // New Year's Eve: Dec 31
+        // 2021: Dec 31 is Friday -> no roll
+        final Object[] newYearsEve21 = {2021, "New Year's Eve", LocalDate.of(2021, Month.DECEMBER, 31)};
+        // 2022: Dec 31 is Saturday -> rolls to Friday Dec 30
+        final Object[] newYearsEve22 = {2022, "New Year's Eve", LocalDate.of(2022, Month.DECEMBER, 30)};
+        // 2023: Dec 31 is Sunday -> rolls to Monday Jan 1, 2024
+        final Object[] newYearsEve23 = {2023, "New Year's Eve", LocalDate.of(2024, Month.JANUARY, 1)};
         return Arrays.asList(swissNationalDay21, swissNationalDay22, swissNationalDay23,
-                             christmas21, christmas22, christmas23).listIterator();
+                             christmas21, christmas22, christmas23,
+                             christmasEve21, christmasEve22, christmasEve23,
+                             newYearsEve21, newYearsEve22, newYearsEve23).listIterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Same-resolved-date collisions between independently-rolled fixed holidays
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCollision_ChristmasDayRollAndChristmasEveShareDec24_2021() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        List<HolidayDate> holidays2021 = calendar.calculate(2021);
+
+        Optional<HolidayDate> christmasDay = holidays2021.stream()
+                .filter(hd -> "Christmas Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        Optional<HolidayDate> christmasEve = holidays2021.stream()
+                .filter(hd -> "Christmas Eve".equals(hd.getHoliday().getName()))
+                .findFirst();
+
+        assertTrue(christmasDay.isPresent());
+        assertTrue(christmasEve.isPresent());
+        assertEquals(christmasDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+        assertEquals(christmasEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+    }
+
+    @Test
+    public void testCollision_NewYearsDayRollAndNewYearsEveShareDec31_2021() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        // 2022: Jan 1 is Saturday -> New Year's Day rolls back to Friday Dec 31, 2021
+        List<HolidayDate> holidays2022 = calendar.calculate(2022);
+        Optional<HolidayDate> newYearsDay = holidays2022.stream()
+                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(newYearsDay.isPresent());
+        assertEquals(newYearsDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
+
+        // 2021: Dec 31 is Friday -> New Year's Eve stays on Dec 31, 2021
+        List<HolidayDate> holidays2021 = calendar.calculate(2021);
+        Optional<HolidayDate> newYearsEve = holidays2021.stream()
+                .filter(hd -> "New Year's Eve".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(newYearsEve.isPresent());
+        assertEquals(newYearsEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceDETest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceDETest.java
@@ -18,12 +18,22 @@
 
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarServiceTest {
 
@@ -38,7 +48,9 @@ public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] germanUnityDay = {"German Unity Day"};
         final Object[] labourDay = {"Labour Day"};
-        return Arrays.asList(germanUnityDay, labourDay).listIterator();
+        final Object[] christmasEve = {"Christmas Eve"};
+        final Object[] newYearsEve = {"New Year's Eve"};
+        return Arrays.asList(germanUnityDay, labourDay, christmasEve, newYearsEve).listIterator();
     }
 
     @DataProvider
@@ -56,8 +68,45 @@ public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarService
         final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // Boxing Day 2023: Dec 26 is Tuesday -> no roll
         final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        // Christmas Eve 2024: Dec 24 is Tuesday -> present, unrolled (primary-sourced)
+        final Object[] christmasEve24 = {2024, "Christmas Eve", LocalDate.of(2024, Month.DECEMBER, 24)};
+        // New Year's Eve 2025: Dec 31 is Wednesday -> present, unrolled (primary-sourced)
+        final Object[] newYearsEve25 = {2025, "New Year's Eve", LocalDate.of(2025, Month.DECEMBER, 31)};
+        // Christmas Eve 2021: Dec 24 is Friday -> present, unrolled (collision year, see
+        // testChristmasEveAndChristmasDayCoexistOn24Dec2021 below)
+        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
         return Arrays.asList(christmas21, christmas22, christmas23,
-                             boxingDay21, boxingDay22, boxingDay23).listIterator();
+                             boxingDay21, boxingDay22, boxingDay23,
+                             christmasEve24, newYearsEve25, christmasEve21).listIterator();
+    }
+
+    @Test
+    public void testChristmasEveAndNewYearsEveOmittedOnWeekend() {
+        // 2023: Dec 24 and Dec 31 both fall on a Sunday, so Xetra/FWB simply doesn't
+        // list an exception day at all -- no shift, no entry.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Set<String> names = calendar.calculate(2023).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertFalse(names.contains("Christmas Eve"), "Christmas Eve must be omitted in 2023 (Sunday)");
+        assertFalse(names.contains("New Year's Eve"), "New Year's Eve must be omitted in 2023 (Sunday)");
+    }
+
+    @Test
+    public void testChristmasEveAndChristmasDayCoexistOn24Dec2021() {
+        // Dec 25, 2021 is a Saturday and rolls to Friday Dec 24 under DE's
+        // previousFridayOrFollowingMonday roll rule, landing on the same calendar date
+        // as the new non-rolling Christmas Eve holiday. Both facts are independently
+        // true and must both appear -- no accidental de-duplication.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final List<HolidayDate> dec24 = calendar.calculate(2021).stream()
+                .filter(hd -> LocalDate.of(2021, Month.DECEMBER, 24).equals(hd.getDate()))
+                .toList();
+
+        assertEquals(dec24.size(), 2, "Expected both Christmas Day (rolled) and Christmas Eve on 2021-12-24");
+        final Set<String> names = dec24.stream().map(hd -> hd.getHoliday().getName()).collect(Collectors.toSet());
+        assertTrue(names.contains("Christmas Day"));
+        assertTrue(names.contains("Christmas Eve"));
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceFREarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceFREarlyCloseTest.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.fr.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.fr.NewYearsEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.Month;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code FR} calendar's early-close (Euronext Paris half-day
+ * closure) holidays: Christmas Eve and New Year's Eve. Because December 24
+ * and December 31 are always exactly 7 days apart, they always share the
+ * same day-of-week within a given year — both early closes are always
+ * present together or absent together, never one without the other, same
+ * shape as SG.
+ *
+ * <p>Unlike CA (Christmas Day {@code rollable(false)}) and SG (no rollable
+ * holiday ever lands on Dec 24/31), FR's Christmas Day and New Year's Day are
+ * both {@code rollable(true)} under {@code previousFridayOrFollowingMonday}.
+ * This produces two genuine, independently-verified date collisions with the
+ * early closes, both covered explicitly below rather than relying on a naive
+ * "always empty intersection" assertion:
+ * <ul>
+ *     <li>Christmas Day rolls back onto December 24 whenever December 25
+ *     falls on a Saturday (e.g. 2027) — the same date Christmas Eve's early
+ *     close independently occupies that year.</li>
+ *     <li>New Year's Day rolls back onto December 31 of the <em>prior</em>
+ *     year whenever January 1 falls on a Saturday (e.g. January 1, 2028 rolls
+ *     to December 31, 2027) — the same date New Year's Eve's early close
+ *     independently occupies in that prior year. This crosses a
+ *     {@code calculate(year)} year boundary, so it is not caught by a
+ *     same-year intersection check alone.</li>
+ * </ul>
+ */
+public class HolidayCalendarServiceFREarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(14, 5);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/Paris");
+
+    // 11 full-day holidays registered in HolidayCalendarServiceFR; the two Eve
+    // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 11.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 11;
+
+    private final HolidayCalendarServiceFR service = new HolidayCalendarServiceFR();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2020-2029 Euronext cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "frEarlyCloseFixture")
+    public Iterator<Object[]> frEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2020, true},
+                new Object[]{2021, true},
+                new Object[]{2022, false},
+                new Object[]{2023, false},
+                new Object[]{2024, true},
+                new Object[]{2025, true},
+                new Object[]{2026, true},
+                new Object[]{2027, true},
+                new Object[]{2028, false},
+                new Object[]{2029, true}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "frEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean present) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "FR " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "frEarlyCloseFixture")
+    public void testChristmasEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
+                "FR " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+    }
+
+    @Test(dataProvider = "frEarlyCloseFixture")
+    public void testNewYearsEvePresenceForYear(int year, boolean present) {
+        assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
+                "FR " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    @Test(dataProvider = "frEarlyCloseFixture")
+    public void testEarlyCloseCountAlwaysZeroOrTwo(int year, boolean present) {
+        int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
+        assertNotEquals(count, 1, "FR " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+    }
+
+    // -------------------------------------------------------------------------
+    // Suppressed-year sanity checks
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasEveSuppressedIn2022() {
+        // 2022: December 24 = Saturday.
+        assertFalse(earlyCloseNames(2022).contains("Christmas Eve"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedIn2023() {
+        // 2023: December 24 = Sunday.
+        assertFalse(earlyCloseNames(2023).contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCloseTimeIs14_05() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 14:05");
+            }
+        }
+    }
+
+    @Test
+    public void testZoneIdIsEuropeParis() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in Europe/Paris");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyClosesNotRollable() {
+        for (int year : List.of(2024, 2027)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate() -- checked
+    // in both a non-collision year and a Dec-24-collision year
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCountUnchanged() {
+        for (int year : List.of(2024, 2027)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            assertNotNull(holidays);
+            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "FR " + year + ": unexpected full-day holiday count");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-list date collision: empty in ordinary years, exactly {Dec 24}
+    // in Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve)
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "frEarlyCloseFixture")
+    public void testCrossListDateOverlapOnlyOnKnownChristmasDayRollYears(int year, boolean present) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+
+        boolean isChristmasDaySaturdayRollYear =
+                DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
+        if (isChristmasDaySaturdayRollYear) {
+            assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
+                    "FR " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+        } else {
+            assertTrue(intersection.isEmpty(), "FR " + year + ": unexpected cross-list date collision: " + intersection);
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Named regression: Christmas Day (rolled) and Christmas Eve (early close)
+    // both legitimately appear on the same date in a Dec-25-Saturday year
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testChristmasDayAndChristmasEveCoexistOn24Dec2027() {
+        // December 25, 2027 is a Saturday and rolls to Friday December 24 under FR's
+        // previousFridayOrFollowingMonday roll rule -- the same date the non-rolling
+        // Christmas Eve EARLY_CLOSE independently occupies (December 24, 2027 is a
+        // Friday, a valid early-close weekday). Both facts are true simultaneously and
+        // must both surface, across calculate() and calculateEarlyCloses() respectively.
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        LocalDate dec24 = LocalDate.of(2027, Month.DECEMBER, 24);
+
+        boolean christmasDayPresent = calendar.calculate(2027).stream()
+                .anyMatch(hd -> "Christmas Day".equals(hd.getHoliday().getName()) && dec24.equals(hd.getDate()));
+        boolean christmasEvePresent = calendar.calculateEarlyCloses(2027).stream()
+                .anyMatch(hd -> "Christmas Eve".equals(hd.getHoliday().getName()) && dec24.equals(hd.getDate()));
+
+        assertTrue(christmasDayPresent, "Christmas Day (rolled) must appear on Dec 24, 2027");
+        assertTrue(christmasEvePresent, "Christmas Eve early close must independently appear on Dec 24, 2027");
+    }
+
+    // -------------------------------------------------------------------------
+    // Named regression: New Year's Day (rolled back onto the prior Dec 31) and
+    // New Year's Eve (early close) both legitimately appear on the same date --
+    // this crosses a calculate(year) year boundary and is not caught by the
+    // same-year cross-list check above
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testNewYearsDayAndNewYearsEveCoexistOn31Dec2027() {
+        // January 1, 2028 is a Saturday and rolls back to Friday December 31, 2027
+        // under FR's previousFridayOrFollowingMonday roll rule -- the same date the
+        // non-rolling New Year's Eve EARLY_CLOSE independently occupies in 2027
+        // (December 31, 2027 is a Friday, a valid early-close weekday). This is a
+        // genuine same-date coexistence spanning two different year arguments:
+        // calculate(2028) and calculateEarlyCloses(2027).
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        LocalDate dec31 = LocalDate.of(2027, Month.DECEMBER, 31);
+
+        boolean newYearsDayPresent = calendar.calculate(2028).stream()
+                .anyMatch(hd -> "New Year's Day".equals(hd.getHoliday().getName()) && dec31.equals(hd.getDate()));
+        boolean newYearsEvePresent = calendar.calculateEarlyCloses(2027).stream()
+                .anyMatch(hd -> "New Year's Eve".equals(hd.getHoliday().getName()) && dec31.equals(hd.getDate()));
+
+        assertTrue(newYearsDayPresent, "New Year's Day (rolled back from Jan 1, 2028) must appear on Dec 31, 2027");
+        assertTrue(newYearsEvePresent, "New Year's Eve early close must independently appear on Dec 31, 2027");
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2026},
+                new Object[]{"Christmas Eve", 2027},
+                new Object[]{"New Year's Eve", 2024},
+                new Object[]{"New Year's Eve", 2026},
+                new Object[]{"New Year's Eve", 2027}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            case "New Year's Eve" -> new NewYearsEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceFREarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceFREarlyCloseTest.java
@@ -195,8 +195,9 @@ public class HolidayCalendarServiceFREarlyCloseTest {
     }
 
     // -------------------------------------------------------------------------
-    // Cross-list date collision: empty in ordinary years, exactly {Dec 24}
-    // in Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve)
+    // Cross-list date collision: empty in ordinary years, exactly one date
+    // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
+    // onto Christmas Eve
     // -------------------------------------------------------------------------
 
     @Test(dataProvider = "frEarlyCloseFixture")

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUKEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUKEarlyCloseTest.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.uk.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.uk.NewYearsEveEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code UK} calendar's early-close (LSE half-day closure)
+ * holidays: Christmas Eve and New Year's Eve.
+ */
+public class HolidayCalendarServiceUKEarlyCloseTest {
+
+    private static final int EARLY_CLOSE_COUNT = 2;
+    // 8 full-day holidays apply in 2025: the 4 Jubilee SPECIAL_ANNIVERSARY
+    // holidays only occur in their specific anniversary years (1977/2002/2012/2022).
+    private static final int FULL_DAY_HOLIDAY_COUNT = 8;
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 30);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/London");
+
+    private final HolidayCalendarServiceUK service = new HolidayCalendarServiceUK();
+
+    // -------------------------------------------------------------------------
+    // Count
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEarlyCloseHolidayCount() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+    }
+
+    @Test
+    public void testFullDayHolidayCount_Unchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2025);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // Names
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEarlyCloseHolidayNames() {
+        Set<String> expectedNames = Set.of("Christmas Eve", "New Year's Eve");
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        Set<String> actualNames = earlyCloses.stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertEquals(actualNames, expectedNames);
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testAllEarlyCloses_CloseTimeIs12_30() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+        for (HolidayDate hd : earlyCloses) {
+            assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+            EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+            assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                    earlyClose.getName() + " must close at 12:30");
+        }
+    }
+
+    @Test
+    public void testAllEarlyCloses_ZoneId_IsLondon() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+        for (HolidayDate hd : earlyCloses) {
+            EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+            assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                    earlyClose.getName() + " must be expressed in Europe/London");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testEarlyCloses_NotRollable() {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(2025);
+        assertEquals(earlyCloses.size(), EARLY_CLOSE_COUNT);
+        for (HolidayDate hd : earlyCloses) {
+            assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output,
+    // across weekday and weekend-shift years
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Christmas Eve", 2022},
+                new Object[]{"Christmas Eve", 2023},
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2025},
+                new Object[]{"Christmas Eve", 2026},
+                new Object[]{"Christmas Eve", 2028},
+                new Object[]{"New Year's Eve", 2022},
+                new Object[]{"New Year's Eve", 2023},
+                new Object[]{"New Year's Eve", 2024},
+                new Object[]{"New Year's Eve", 2025},
+                new Object[]{"New Year's Eve", 2026},
+                new Object[]{"New Year's Eve", 2028}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            case "New Year's Eve" -> new NewYearsEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUKTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUKTest.java
@@ -12,6 +12,8 @@ import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.*;
 
@@ -77,6 +79,22 @@ public class HolidayCalendarServiceUKTest extends AbstractHolidayCalendarService
                                                                .findFirst();
         assertTrue(foundNewYearsDay.isPresent());
         assertEquals(foundNewYearsDay.get().getDate(), LocalDate.of(2020, Month.JANUARY, 1));
+    }
+
+    @Test
+    public void testEarlyCloseHolidaysAbsentFromCalculate() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        List<HolidayDate> ukHolidays2025 = calendar.calculate(2025);
+        Set<String> names = ukHolidays2025.stream()
+                                           .map(hd -> hd.getHoliday().getName())
+                                           .collect(Collectors.toSet());
+        assertFalse(names.contains("Christmas Eve"),
+                "Christmas Eve is an EARLY_CLOSE holiday and must not appear in calculate()");
+        assertFalse(names.contains("New Year's Eve"),
+                "New Year's Eve is an EARLY_CLOSE holiday and must not appear in calculate()");
     }
 
     @DataProvider

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSEarlyCloseTest.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.EarlyCloseHoliday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.holiday.calendar.observance.us.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.us.DayAfterThanksgiving;
+import org.holiday.calendar.observance.us.JulyThirdEarlyClose;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.*;
+
+/**
+ * Tests for the {@code US} calendar's early-close (NYSE half-day closure)
+ * holidays: Day After Thanksgiving (unconditional), Christmas Eve, and July
+ * 3rd (both conditional on the day-of-week of their anchor holiday). Unlike
+ * the UK's early closes, which always occur exactly twice per year, the US
+ * count varies from 1 to 3 depending on where Dec 25 / Jul 4 fall — so this
+ * test asserts explicit per-holiday presence/absence per year, not just a
+ * fixed count.
+ */
+public class HolidayCalendarServiceUSEarlyCloseTest {
+
+    private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
+    private static final ZoneId EXPECTED_ZONE = ZoneId.of("America/New_York");
+
+    // 12 full-day holidays in calculate() once Day After Thanksgiving moves to EARLY_CLOSE
+    // (13 holidays registered total, minus 1 EarlyCloseHoliday excluded by calculate()).
+    private static final int FULL_DAY_HOLIDAY_COUNT = 12;
+
+    private final HolidayCalendarServiceUS service = new HolidayCalendarServiceUS();
+
+    // -------------------------------------------------------------------------
+    // Count / presence per year (verified 2019-2027 NYSE cycle)
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "usEarlyCloseFixture")
+    public Iterator<Object[]> usEarlyCloseFixture() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{2019, true, true, 3},
+                new Object[]{2020, false, true, 2},
+                new Object[]{2021, false, false, 1},
+                new Object[]{2022, false, false, 1},
+                new Object[]{2023, true, false, 2},
+                new Object[]{2024, true, true, 3},
+                new Object[]{2025, true, true, 3},
+                new Object[]{2026, false, true, 2},
+                new Object[]{2027, false, false, 1}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testEarlyCloseCountForYear(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
+        assertNotNull(earlyCloses);
+        assertEquals(earlyCloses.size(), expectedCount, "US " + year + ": unexpected early-close count");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testJulyThirdPresenceForYear(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        Set<String> names = earlyCloseNames(year);
+        assertEquals(names.contains("July 3rd"), july3Present,
+                "US " + year + ": July 3rd presence must match July 4 day-of-week rule");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testChristmasEveEarlyClosePresenceForYear(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        Set<String> names = earlyCloseNames(year);
+        assertEquals(names.contains("Christmas Eve"), dec24Present,
+                "US " + year + ": Christmas Eve presence must match December 25 day-of-week rule");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testDayAfterThanksgivingAlwaysPresent(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        assertTrue(earlyCloseNames(year).contains("Day After Thanksgiving"),
+                "US " + year + ": Day After Thanksgiving must always be present");
+    }
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testDayAfterThanksgivingCloseIsAlwaysFriday(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        HolidayDate matched = service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .filter(hd -> "Day After Thanksgiving".equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Day After Thanksgiving not found in " + year));
+        assertEquals(matched.getDate().getDayOfWeek(), DayOfWeek.FRIDAY);
+    }
+
+    private Set<String> earlyCloseNames(int year) {
+        return service.getHolidayCalendar().calculateEarlyCloses(year).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+    }
+
+    // -------------------------------------------------------------------------
+    // Monday-exclusion regression cases (issue text incorrectly said "Monday-Friday")
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testJulyThirdSuppressedWhenJuly4IsMonday() {
+        // 2022: July 4 = Monday.
+        Set<String> names = earlyCloseNames(2022);
+        assertFalse(names.contains("July 3rd"));
+    }
+
+    @Test
+    public void testChristmasEveSuppressedWhenDecember25IsMonday() {
+        // 2023: December 25 = Monday.
+        Set<String> names = earlyCloseNames(2023);
+        assertFalse(names.contains("Christmas Eve"));
+    }
+
+    // -------------------------------------------------------------------------
+    // Close time / zone / rollability
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testAllEarlyCloses_CloseTimeIs13_00() {
+        for (int year : List.of(2021, 2024)) { // one 1-count year, one 3-count year
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertTrue(hd.getHoliday() instanceof EarlyCloseHoliday);
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getCloseTime(), EXPECTED_CLOSE_TIME,
+                        earlyClose.getName() + " must close at 13:00");
+            }
+        }
+    }
+
+    @Test
+    public void testAllEarlyCloses_ZoneId_IsNewYork() {
+        for (int year : List.of(2021, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+                assertEquals(earlyClose.getZoneId(), EXPECTED_ZONE,
+                        earlyClose.getName() + " must be expressed in America/New_York");
+            }
+        }
+    }
+
+    @Test
+    public void testEarlyCloses_NotRollable() {
+        for (int year : List.of(2021, 2024)) {
+            for (HolidayDate hd : service.getHolidayCalendar().calculateEarlyCloses(year)) {
+                assertFalse(hd.getHoliday().isRollable(), hd.getHoliday().getName() + " must not be rollable");
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // Full-day holiday count unchanged / no leakage into calculate()
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testFullDayHolidayCount_Unchanged() {
+        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
+        assertNotNull(holidays);
+        assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT);
+    }
+
+    // -------------------------------------------------------------------------
+    // No date appears in both calculate() and calculateEarlyCloses() for the same year
+    // -------------------------------------------------------------------------
+
+    @Test(dataProvider = "usEarlyCloseFixture")
+    public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean july3Present, boolean dec24Present, int expectedCount) {
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> earlyCloseDates = calendar.calculateEarlyCloses(year).stream()
+                .map(HolidayDate::getDate)
+                .collect(Collectors.toSet());
+        Set<LocalDate> intersection = fullDayDates.stream()
+                .filter(earlyCloseDates::contains)
+                .collect(Collectors.toSet());
+        assertTrue(intersection.isEmpty(),
+                "US " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+    }
+
+    // -------------------------------------------------------------------------
+    // Cross-check calculateEarlyCloses() dates against raw Observance output
+    // -------------------------------------------------------------------------
+
+    @DataProvider(name = "earlyCloseDates")
+    public Iterator<Object[]> earlyCloseDates() {
+        List<Object[]> data = Arrays.asList(
+                new Object[]{"Day After Thanksgiving", 2021},
+                new Object[]{"Day After Thanksgiving", 2024},
+                new Object[]{"July 3rd", 2019},
+                new Object[]{"July 3rd", 2023},
+                new Object[]{"July 3rd", 2024},
+                new Object[]{"Christmas Eve", 2019},
+                new Object[]{"Christmas Eve", 2024},
+                new Object[]{"Christmas Eve", 2025}
+        );
+        return data.iterator();
+    }
+
+    @Test(dataProvider = "earlyCloseDates")
+    public void testEarlyCloseDateMatchesRawObservance(String holidayName, int year) {
+        LocalDate expected = rawObservanceDate(holidayName, year);
+
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+        HolidayDate matched = earlyCloses.stream()
+                .filter(hd -> holidayName.equals(hd.getHoliday().getName()))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(holidayName + " not found in calculateEarlyCloses(" + year + ")"));
+        assertEquals(matched.getDate(), expected,
+                holidayName + " via calculateEarlyCloses(" + year + ") must match production Observance");
+    }
+
+    private LocalDate rawObservanceDate(String holidayName, int year) {
+        return switch (holidayName) {
+            case "Day After Thanksgiving" -> new DayAfterThanksgiving().apply(year);
+            case "July 3rd" -> new JulyThirdEarlyClose().apply(year);
+            case "Christmas Eve" -> new ChristmasEveEarlyClose().apply(year);
+            default -> throw new IllegalArgumentException("Unknown holiday: " + holidayName);
+        };
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceUSTest.java
@@ -1,11 +1,19 @@
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendarService;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertFalse;
 
 public class HolidayCalendarServiceUSTest extends AbstractHolidayCalendarServiceTest {
 
@@ -40,6 +48,22 @@ public class HolidayCalendarServiceUSTest extends AbstractHolidayCalendarService
         final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
         return Arrays.asList(veteransDay18, veteransDay19, veteransDay20, veteransDay21, veteransDay22, veteransDay23,
                              christmas18, christmas19, christmas20, christmas21, christmas22, christmas23).listIterator();
+    }
+
+    @Test
+    public void testEarlyCloseHolidaysAbsentFromCalculate() {
+        HolidayCalendarService service = factory.getService(CODE);
+        Set<String> earlyCloseNames = Set.of("Day After Thanksgiving", "Christmas Eve", "July 3rd");
+        for (int year : List.of(2021, 2023, 2024, 2025)) { // mix of 1/2/3-count early-close years
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            Set<String> actualNames = holidays.stream()
+                    .map(hd -> hd.getHoliday().getName())
+                    .collect(Collectors.toSet());
+            for (String earlyCloseName : earlyCloseNames) {
+                assertFalse(actualNames.contains(earlyCloseName),
+                        earlyCloseName + " must not appear in calculate(" + year + ")");
+            }
+        }
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2011, null });                                   // Dec 24 Sat -> suppressed, pre-cycle edge year
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 24 Thu -> present
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> present
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> suppressed
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> suppressed
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> present
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> present
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> present, confirmed by ASX's 2025/2026 notice
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 24) }); // Dec 24 Fri -> present
+        data.add(new Object[]{ 2028, null });                                   // Dec 24 Sun -> suppressed
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 24) }); // Dec 24 Mon -> present, boundary check adjacent to 2028
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> suppressed
+        return data;
+    }
+
+    @Test
+    public void testApplyNullYear() {
+        assertNull(observance.apply(null));
+    }
+
+    @Test
+    public void testTestNullYear() {
+        assertEquals(observance.test(null), false);
+    }
+
+    @Test
+    public void testDivergesFromUkShiftRuleIn2022() {
+        LocalDate ukShifted = new org.holiday.calendar.observance.uk.ChristmasEveEarlyClose().apply(2022);
+        assertEquals(ukShifted, LocalDate.of(2022, Month.DECEMBER, 23),
+                "UK rule shifts to the preceding Friday and must not be null");
+        assertNull(observance.apply(2022), "ASX rule must suppress entirely, not shift like UK");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/NewYearsEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/au/NewYearsEveEarlyCloseTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.au;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class NewYearsEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public NewYearsEveEarlyCloseTest() {
+        super(new NewYearsEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2011, null });                                   // Dec 31 Sat -> suppressed, pre-cycle edge year
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 31) }); // Dec 31 Thu -> present
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> present
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> suppressed
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> suppressed
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> present
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> present
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> present, confirmed by ASX's 2025/2026 notice
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 31) }); // Dec 31 Fri -> present
+        data.add(new Object[]{ 2028, null });                                   // Dec 31 Sun -> suppressed
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 31) }); // Dec 31 Mon -> present, boundary check adjacent to 2028
+        data.add(new Object[]{ 2033, null });                                   // Dec 31 Sat -> suppressed
+        return data;
+    }
+
+    @Test
+    public void testApplyNullYear() {
+        assertNull(observance.apply(null));
+    }
+
+    @Test
+    public void testTestNullYear() {
+        assertEquals(observance.test(null), false);
+    }
+
+    @Test
+    public void testDivergesFromUkShiftRuleIn2022() {
+        LocalDate ukShifted = new org.holiday.calendar.observance.uk.NewYearsEveEarlyClose().apply(2022);
+        assertEquals(ukShifted, LocalDate.of(2022, Month.DECEMBER, 30),
+                "UK rule shifts to the preceding Friday and must not be null");
+        assertNull(observance.apply(2022), "ASX rule must suppress entirely, not shift like UK");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/ca/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.ca;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2017, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2018, LocalDate.of(2018, Month.DECEMBER, 24) }); // Dec 24 Mon -> eligible
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> eligible (NYSE-divergence year)
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible
+        // Edge years outside the sampled 2017-2026 cycle
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> ineligible
+        data.add(new Object[]{ 2034, null });                                   // Dec 24 Sun -> ineligible
+        data.add(new Object[]{ 2099, LocalDate.of(2099, Month.DECEMBER, 24) }); // Dec 24 Thu -> eligible, far-future edge
+        return data;
+    }
+
+    @Test
+    public void testTsxClosesEarlyIn2021EvenThoughNyseRuleWouldSuppress() {
+        // 2021: December 25 = Saturday, December 24 = Friday. NYSE's rule keys off
+        // December 25 and would suppress when December 25 falls on Sat/Sun/Mon. TSX's
+        // rule keys off December 24 directly: Friday is a valid weekday, so TSX still
+        // closes early. This is the key behavioral divergence justifying a CA-specific
+        // Observance rather than reusing the US one.
+        assertEquals(observance.apply(2021), LocalDate.of(2021, Month.DECEMBER, 24));
+    }
+
+    @Test
+    public void testDivergesFromUsRuleIn2021() {
+        assertNull(new org.holiday.calendar.observance.us.ChristmasEveEarlyClose().apply(2021),
+                "US rule (keyed off Dec 25) must suppress in 2021");
+        assertEquals(observance.apply(2021), LocalDate.of(2021, Month.DECEMBER, 24),
+                "CA/TSX rule (keyed off Dec 24) must NOT suppress in 2021");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/ChristmasEveTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/ChristmasEveTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChristmasEveTest extends AbstractObservanceTest {
+
+    public ChristmasEveTest() {
+        super(new ChristmasEve());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        // Primary-sourced against Deutsche Börse's Xetra-Handelskalender PDFs (2023-2026)
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> omitted
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> full holiday
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> full holiday
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> full holiday
+        // Arithmetic-inferred (stable rule applied to day-of-week, not independently
+        // confirmed against an archived PDF for these specific years)
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> full holiday
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> omitted
+        return data;
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/NewYearsEveTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/de/NewYearsEveTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.de;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewYearsEveTest extends AbstractObservanceTest {
+
+    public NewYearsEveTest() {
+        super(new NewYearsEve());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        // Primary-sourced against Deutsche Börse's Xetra-Handelskalender PDFs (2023-2026)
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> omitted
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> full holiday
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> full holiday
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> full holiday
+        // Arithmetic-inferred (stable rule applied to day-of-week, not independently
+        // confirmed against an archived PDF for these specific years)
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> full holiday
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> omitted
+        return data;
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/fr/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/fr/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.fr;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2011, null });                                   // Dec 24 Sat -> suppressed, pre-cycle edge year
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 24 Thu -> present
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 24) }); // Dec 24 Fri -> present
+        data.add(new Object[]{ 2022, null });                                   // Dec 24 Sat -> suppressed
+        data.add(new Object[]{ 2023, null });                                   // Dec 24 Sun -> suppressed
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 24 Tue -> present
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 24 Wed -> present
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 24 Thu -> present, confirmed by Euronext's 2026 calendar PDF
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 24) }); // Dec 24 Fri -> present
+        data.add(new Object[]{ 2028, null });                                   // Dec 24 Sun -> suppressed
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 24) }); // Dec 24 Mon -> present, boundary check adjacent to 2028
+        data.add(new Object[]{ 2033, null });                                   // Dec 24 Sat -> suppressed
+        return data;
+    }
+
+    @Test
+    public void testApplyNullYear() {
+        assertNull(observance.apply(null));
+    }
+
+    @Test
+    public void testTestNullYear() {
+        assertEquals(observance.test(null), false);
+    }
+
+    @Test
+    public void testDivergesFromUkShiftRuleIn2022() {
+        LocalDate ukShifted = new org.holiday.calendar.observance.uk.ChristmasEveEarlyClose().apply(2022);
+        assertEquals(ukShifted, LocalDate.of(2022, Month.DECEMBER, 23),
+                "UK rule shifts to the preceding Friday and must not be null");
+        assertNull(observance.apply(2022), "FR rule must suppress entirely, not shift like UK");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/fr/NewYearsEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/fr/NewYearsEveEarlyCloseTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.fr;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+public class NewYearsEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public NewYearsEveEarlyCloseTest() {
+        super(new NewYearsEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2011, null });                                   // Dec 31 Sat -> suppressed, pre-cycle edge year
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 31) }); // Dec 31 Thu -> present
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.DECEMBER, 31) }); // Dec 31 Fri -> present
+        data.add(new Object[]{ 2022, null });                                   // Dec 31 Sat -> suppressed
+        data.add(new Object[]{ 2023, null });                                   // Dec 31 Sun -> suppressed
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Dec 31 Tue -> present
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Dec 31 Wed -> present
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Dec 31 Thu -> present, confirmed by Euronext's 2026 calendar PDF
+        data.add(new Object[]{ 2027, LocalDate.of(2027, Month.DECEMBER, 31) }); // Dec 31 Fri -> present
+        data.add(new Object[]{ 2028, null });                                   // Dec 31 Sun -> suppressed
+        data.add(new Object[]{ 2029, LocalDate.of(2029, Month.DECEMBER, 31) }); // Dec 31 Mon -> present, boundary check adjacent to 2028
+        data.add(new Object[]{ 2033, null });                                   // Dec 31 Sat -> suppressed
+        return data;
+    }
+
+    @Test
+    public void testApplyNullYear() {
+        assertNull(observance.apply(null));
+    }
+
+    @Test
+    public void testTestNullYear() {
+        assertEquals(observance.test(null), false);
+    }
+
+    @Test
+    public void testDivergesFromUkShiftRuleIn2022() {
+        LocalDate ukShifted = new org.holiday.calendar.observance.uk.NewYearsEveEarlyClose().apply(2022);
+        assertEquals(ukShifted, LocalDate.of(2022, Month.DECEMBER, 30),
+                "UK rule shifts to the preceding Friday and must not be null");
+        assertNull(observance.apply(2022), "FR rule must suppress entirely, not shift like UK");
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/uk/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/uk/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.uk;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        // Weekday years: December 24 falls Mon-Fri, date unchanged.
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Tuesday
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Wednesday
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Thursday
+        // Weekend years: shift to the preceding Friday.
+        data.add(new Object[]{ 2022, LocalDate.of(2022, Month.DECEMBER, 23) }); // Dec 24 is Saturday
+        data.add(new Object[]{ 2023, LocalDate.of(2023, Month.DECEMBER, 22) }); // Dec 24 is Sunday
+        // 2028: directly confirmed against LSE's official business days notice
+        // (londonstockexchange.com/equities-trading/business-days), which lists
+        // Friday 22 December 2028 as a "Christmas Holiday half day."
+        data.add(new Object[]{ 2028, LocalDate.of(2028, Month.DECEMBER, 22) }); // Dec 24 is Sunday
+
+        return data;
+    }
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/uk/NewYearsEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/uk/NewYearsEveEarlyCloseTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.uk;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class NewYearsEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public NewYearsEveEarlyCloseTest() {
+        super(new NewYearsEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        // Weekday years: December 31 falls Mon-Fri, date unchanged.
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 31) }); // Tuesday
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 31) }); // Wednesday
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 31) }); // Thursday
+        // Weekend years: shift to the preceding Friday.
+        data.add(new Object[]{ 2022, LocalDate.of(2022, Month.DECEMBER, 30) }); // Dec 31 is Saturday
+        data.add(new Object[]{ 2023, LocalDate.of(2023, Month.DECEMBER, 29) }); // Dec 31 is Sunday
+        // 2028: directly confirmed against LSE's official business days notice
+        // (londonstockexchange.com/equities-trading/business-days), which lists
+        // Friday 29 December 2028 as a "New Year's Holiday half day."
+        data.add(new Object[]{ 2028, LocalDate.of(2028, Month.DECEMBER, 29) }); // Dec 31 is Sunday
+
+        return data;
+    }
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/ChristmasEveEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/ChristmasEveEarlyCloseTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNull;
+
+public class ChristmasEveEarlyCloseTest extends AbstractObservanceTest {
+
+    public ChristmasEveEarlyCloseTest() {
+        super(new ChristmasEveEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.DECEMBER, 24) }); // Dec 25 Wed -> eligible
+        data.add(new Object[]{ 2020, LocalDate.of(2020, Month.DECEMBER, 24) }); // Dec 25 Fri -> eligible
+        data.add(new Object[]{ 2021, null });                                   // Dec 25 Sat -> ineligible
+        data.add(new Object[]{ 2022, null });                                   // Dec 25 Sun -> ineligible
+        data.add(new Object[]{ 2023, null });                                   // Dec 25 Mon -> ineligible (Monday-exclusion case)
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.DECEMBER, 24) }); // Dec 25 Wed -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.DECEMBER, 24) }); // Dec 25 Thu -> eligible
+        data.add(new Object[]{ 2026, LocalDate.of(2026, Month.DECEMBER, 24) }); // Dec 25 Fri -> eligible
+        data.add(new Object[]{ 2027, null });                                   // Dec 25 Sat -> ineligible
+        data.add(new Object[]{ 2000, null });                                   // Dec 25 2000 Mon -> ineligible, edge year
+        data.add(new Object[]{ 2099, LocalDate.of(2099, Month.DECEMBER, 24) }); // Dec 25 2099 Fri -> eligible, edge year
+        return data;
+    }
+
+    @Test
+    public void testSuppressedWhenChristmasDayIsMonday() {
+        // 2023: December 25 falls on a Monday. Must be ineligible — the issue text's
+        // "Monday through Friday" claim was incorrect; the verified NYSE rule excludes Monday.
+        assertNull(observance.apply(2023));
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/DayAfterThanksgivingTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/DayAfterThanksgivingTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+public class DayAfterThanksgivingTest extends AbstractObservanceTest {
+
+    public DayAfterThanksgivingTest() {
+        super(new DayAfterThanksgiving());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 1978, LocalDate.of(1978, Month.NOVEMBER, 24) });
+        data.add(new Object[]{ 2021, LocalDate.of(2021, Month.NOVEMBER, 26) });
+        data.add(new Object[]{ 2022, LocalDate.of(2022, Month.NOVEMBER, 25) });
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.NOVEMBER, 29) });
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.NOVEMBER, 28) });
+
+        return data;
+    }
+
+}

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/JulyThirdEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/us/JulyThirdEarlyCloseTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.observance.us;
+
+import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.testng.Assert.assertNull;
+
+public class JulyThirdEarlyCloseTest extends AbstractObservanceTest {
+
+    public JulyThirdEarlyCloseTest() {
+        super(new JulyThirdEarlyClose());
+    }
+
+    @Override
+    protected List<Object[]> createData() {
+        List<Object[]> data = new ArrayList<>();
+        data.add(new Object[]{ 2019, LocalDate.of(2019, Month.JULY, 3) });  // Jul 4 Thu -> eligible
+        data.add(new Object[]{ 2020, null });                                // Jul 4 Sat -> ineligible
+        data.add(new Object[]{ 2021, null });                                // Jul 4 Sun -> ineligible
+        data.add(new Object[]{ 2022, null });                                // Jul 4 Mon -> ineligible (Monday-exclusion case)
+        data.add(new Object[]{ 2023, LocalDate.of(2023, Month.JULY, 3) });   // Jul 4 Tue -> eligible
+        data.add(new Object[]{ 2024, LocalDate.of(2024, Month.JULY, 3) });   // Jul 4 Thu -> eligible
+        data.add(new Object[]{ 2025, LocalDate.of(2025, Month.JULY, 3) });   // Jul 4 Fri -> eligible
+        data.add(new Object[]{ 2026, null });                                // Jul 4 Sat -> ineligible
+        data.add(new Object[]{ 2027, null });                                // Jul 4 Sun -> ineligible
+        data.add(new Object[]{ 2000, LocalDate.of(2000, Month.JULY, 3) });   // Jul 4 2000 Tue -> eligible, edge year
+        data.add(new Object[]{ 2099, null });                                // Jul 4 2099 Sat -> ineligible, edge year
+        return data;
+    }
+
+    @Test
+    public void testSuppressedWhenIndependenceDayIsMonday() {
+        // 2022: July 4 falls on a Monday. Must be ineligible — the issue text's
+        // "Monday through Friday" claim was incorrect; the verified NYSE rule excludes Monday.
+        assertNull(observance.apply(2022));
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -97,7 +97,7 @@
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
         <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
-        <sonar-maven-plugin.version>5.6.0.6792</sonar-maven-plugin.version>
+        <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
-        <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
+        <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-jacoco-plugin.version>0.8.14</maven-jacoco-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -89,7 +89,7 @@
 
         <!-- Plugin versions -->
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
-        <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
+        <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
         <maven-jacoco-plugin.version>0.8.14</maven-jacoco-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>1.4.0</version>
+    <version>1.5.0-SNAPSHOT</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <maven-compiler-plugin.version>3.15.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>3.6.2</maven-enforcer-plugin.version>
         <maven-surefire-plugin.version>3.5.5</maven-surefire-plugin.version>
-        <maven-jacoco-plugin.version>0.8.14</maven-jacoco-plugin.version>
+        <maven-jacoco-plugin.version>0.8.15</maven-jacoco-plugin.version>
         <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>2.0.0-SNAPSHOT</version>
+    <version>2.0.0</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>1.5.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/pom.xml
+++ b/pom.xml
@@ -92,7 +92,7 @@
         <maven-enforcer-plugin.version>3.6.3</maven-enforcer-plugin.version>
         <maven-surefire-plugin.version>3.5.6</maven-surefire-plugin.version>
         <maven-jacoco-plugin.version>0.8.15</maven-jacoco-plugin.version>
-        <maven-jar-plugin.version>3.5.0</maven-jar-plugin.version>
+        <maven-jar-plugin.version>3.5.1</maven-jar-plugin.version>
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>

--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <maven-javadoc-plugin.version>3.12.0</maven-javadoc-plugin.version>
         <maven-source-plugin.version>3.4.0</maven-source-plugin.version>
         <maven-project-info-reports-plugin.version>3.9.0</maven-project-info-reports-plugin.version>
-        <maven-site-plugin.version>3.21.0</maven-site-plugin.version>
+        <maven-site-plugin.version>3.22.0</maven-site-plugin.version>
         <sonar-maven-plugin.version>5.7.0.6970</sonar-maven-plugin.version>
         <maven-resources-plugin.version>3.5.0</maven-resources-plugin.version>
     </properties>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.4.0</version>
+        <version>1.5.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.0.0-SNAPSHOT</version>
+        <version>2.0.0</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>1.5.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -459,4 +459,98 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 11. FR EARLY CLOSES (Euronext Paris Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Both Euronext Eve early closes are suppressed (not shifted) when their date falls on a
+    // weekend; since December 24 and December 31 are always exactly 7 days apart, they always
+    // share the same day-of-week within a year, so count is always 0 or 2, never 1. Expected
+    // presence is re-derived from December 24's day-of-week rule for every year rather than
+    // hand-fixtured.
+    //
+    // FR's Christmas Day and New Year's Day are both rollable under
+    // previousFridayOrFollowingMonday, unlike SG, so this section additionally verifies the two
+    // genuine cross-list date collisions this produces: Christmas Day rolling back onto
+    // December 24 in Dec-25-Saturday years, and New Year's Day rolling back onto the prior
+    // December 31 in Jan-1-Saturday years (a year-boundary-crossing collision that a same-year
+    // intersection check alone would miss).
+    @Test(description = "FR calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
+            + "and always co-occur, no nulls, chronological order, and known Christmas Day/New Year's "
+            + "Day roll collisions are accounted for")
+    public void testFREarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("FR");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "FR: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 2,
+                    "FR " + year + ": expected count in {0,2}, got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), expected,
+                    "FR " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+            assertEquals(names.contains("New Year's Eve"), expected,
+                    "FR " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            // Cross-list date collision: empty in ordinary years, exactly {Dec 24} in
+            // Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve).
+            List<HolidayDate> fullDay = calendar.calculate(year);
+            Set<LocalDate> fullDayDates = fullDay.stream().map(HolidayDate::date).collect(Collectors.toSet());
+            Set<LocalDate> earlyCloseDates = earlyCloses.stream().map(HolidayDate::date).collect(Collectors.toSet());
+            Set<LocalDate> intersection = fullDayDates.stream()
+                    .filter(earlyCloseDates::contains)
+                    .collect(Collectors.toSet());
+            boolean isChristmasDaySaturdayRollYear =
+                    DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
+            if (isChristmasDaySaturdayRollYear) {
+                assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
+                        "FR " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+            } else {
+                assertTrue(intersection.isEmpty(), "FR " + year + ": unexpected cross-list date collision: " + intersection);
+            }
+
+            // Cross-year collision: New Year's Day rolling back onto this year's December 31
+            // whenever January 1 of the following year falls on a Saturday.
+            boolean isNewYearsDaySaturdayRollYear =
+                    DayOfWeek.SATURDAY.equals(LocalDate.of(year + 1, Month.JANUARY, 1).getDayOfWeek());
+            if (isNewYearsDaySaturdayRollYear) {
+                LocalDate dec31 = LocalDate.of(year, Month.DECEMBER, 31);
+                boolean newYearsDayPresent = calendar.calculate(year + 1).stream()
+                        .anyMatch(hd -> "New Year's Day".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
+                boolean newYearsEvePresent = names.contains("New Year's Eve");
+                assertTrue(newYearsDayPresent,
+                        "FR " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
+                assertTrue(newYearsEvePresent,
+                        "FR " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
+            }
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "FR: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "FR: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "FR: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "FR: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -402,7 +402,10 @@ public class HolidayCalendar30YearIT {
                     "New Year's Eve".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
             assertEquals(dec31Present, dec31Expected,
                     "DE " + year + ": New Year's Eve presence/date must match December 31 dow rule (dow=" + dec31Dow + ")");
+        }
+    }
 
+    // =========================================================================
     // 10. SG EARLY CLOSES (SGX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
     // =========================================================================
 

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -554,4 +554,98 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 12. AU EARLY CLOSES (ASX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Both ASX Eve early closes are suppressed (not shifted) when their date falls on a
+    // weekend; since December 24 and December 31 are always exactly 7 days apart, they always
+    // share the same day-of-week within a year, so count is always 0 or 2, never 1. Expected
+    // presence is re-derived from December 24's day-of-week rule for every year rather than
+    // hand-fixtured.
+    //
+    // AU's Christmas Day and New Year's Day are both rollable under
+    // previousFridayOrFollowingMonday, same as FR, so this section additionally verifies the
+    // two genuine cross-list date collisions this produces: Christmas Day rolling back onto
+    // December 24 in Dec-25-Saturday years, and New Year's Day rolling back onto the prior
+    // December 31 in Jan-1-Saturday years (a year-boundary-crossing collision that a same-year
+    // intersection check alone would miss).
+    @Test(description = "AU calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
+            + "and always co-occur, no nulls, chronological order, and known Christmas Day/New Year's "
+            + "Day roll collisions are accounted for")
+    public void testAUEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("AU");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "AU: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 2,
+                    "AU " + year + ": expected count in {0,2}, got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), expected,
+                    "AU " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+            assertEquals(names.contains("New Year's Eve"), expected,
+                    "AU " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            // Cross-list date collision: empty in ordinary years, exactly {Dec 24} in
+            // Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve).
+            List<HolidayDate> fullDay = calendar.calculate(year);
+            Set<LocalDate> fullDayDates = fullDay.stream().map(HolidayDate::date).collect(Collectors.toSet());
+            Set<LocalDate> earlyCloseDates = earlyCloses.stream().map(HolidayDate::date).collect(Collectors.toSet());
+            Set<LocalDate> intersection = fullDayDates.stream()
+                    .filter(earlyCloseDates::contains)
+                    .collect(Collectors.toSet());
+            boolean isChristmasDaySaturdayRollYear =
+                    DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
+            if (isChristmasDaySaturdayRollYear) {
+                assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
+                        "AU " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+            } else {
+                assertTrue(intersection.isEmpty(), "AU " + year + ": unexpected cross-list date collision: " + intersection);
+            }
+
+            // Cross-year collision: New Year's Day rolling back onto this year's December 31
+            // whenever January 1 of the following year falls on a Saturday.
+            boolean isNewYearsDaySaturdayRollYear =
+                    DayOfWeek.SATURDAY.equals(LocalDate.of(year + 1, Month.JANUARY, 1).getDayOfWeek());
+            if (isNewYearsDaySaturdayRollYear) {
+                LocalDate dec31 = LocalDate.of(year, Month.DECEMBER, 31);
+                boolean newYearsDayPresent = calendar.calculate(year + 1).stream()
+                        .anyMatch(hd -> "New Year's Day".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
+                boolean newYearsEvePresent = names.contains("New Year's Eve");
+                assertTrue(newYearsDayPresent,
+                        "AU " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
+                assertTrue(newYearsEvePresent,
+                        "AU " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
+            }
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "AU: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "AU: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "AU: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "AU: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -367,4 +367,42 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 9. DE CHRISTMAS EVE / NEW YEAR'S EVE (Xetra/FWB full non-trading days) OVER 30 YEARS
+    // =========================================================================
+
+    // Xetra/FWB's Christmas Eve and New Year's Eve are full non-trading days, not
+    // half-day early closes, so they're asserted via calculate() rather than
+    // calculateEarlyCloses(). Each is omitted (not shifted) when its date falls on a
+    // weekend; expected presence is re-derived from each date's day-of-week rule for
+    // every year rather than hand-fixtured.
+    @Test(description = "DE calculate() across 2026-2055: Christmas Eve/New Year's Eve present "
+            + "unrolled whenever not Sat/Sun, absent (not shifted) when Sat/Sun, no nulls")
+    public void testDEChristmasEveAndNewYearsEveOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("DE");
+
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> all = calendar.calculate(year);
+            assertNotNull(all, "DE: calculate(" + year + ") must not be null");
+
+            LocalDate dec24 = LocalDate.of(year, Month.DECEMBER, 24);
+            DayOfWeek dec24Dow = dec24.getDayOfWeek();
+            boolean dec24Expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            boolean dec24Present = all.stream().anyMatch(hd ->
+                    "Christmas Eve".equals(hd.holiday().getName()) && dec24.equals(hd.date()));
+            assertEquals(dec24Present, dec24Expected,
+                    "DE " + year + ": Christmas Eve presence/date must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            LocalDate dec31 = LocalDate.of(year, Month.DECEMBER, 31);
+            DayOfWeek dec31Dow = dec31.getDayOfWeek();
+            boolean dec31Expected = !DayOfWeek.SATURDAY.equals(dec31Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec31Dow);
+            boolean dec31Present = all.stream().anyMatch(hd ->
+                    "New Year's Eve".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
+            assertEquals(dec31Present, dec31Expected,
+                    "DE " + year + ": New Year's Eve presence/date must match December 31 dow rule (dow=" + dec31Dow + ")");
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -316,4 +316,55 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 8. CA EARLY CLOSES (TSX Christmas Eve half-day closure) OVER 30 YEARS
+    // =========================================================================
+
+    // TSX's Christmas Eve early close is suppressed (not shifted) when December 24
+    // falls on a weekend, so count is either 0 or 1 per year; expected presence is
+    // re-derived from December 24's day-of-week rule for every year rather than
+    // hand-fixtured.
+    @Test(description = "CA calculateEarlyCloses across 2026-2055: count always in [0,1], "
+            + "Christmas Eve presence matches December 24 dow rule (excludes Sat/Sun), "
+            + "no nulls, chronological order")
+    public void testCAEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("CA");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "CA: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 1,
+                    "CA " + year + ": expected count in [0,1], got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean dec24Expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), dec24Expected,
+                    "CA " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "CA: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "CA: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "CA: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "CA: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -597,8 +597,9 @@ public class HolidayCalendar30YearIT {
             assertEquals(names.contains("New Year's Eve"), expected,
                     "AU " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
 
-            // Cross-list date collision: empty in ordinary years, exactly {Dec 24} in
-            // Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve).
+            // Cross-list date collision: empty in ordinary years, exactly one date
+            // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
+            // onto Christmas Eve.
             List<HolidayDate> fullDay = calendar.calculate(year);
             Set<LocalDate> fullDayDates = fullDay.stream().map(HolidayDate::date).collect(Collectors.toSet());
             Set<LocalDate> earlyCloseDates = earlyCloses.stream().map(HolidayDate::date).collect(Collectors.toSet());

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -502,8 +502,9 @@ public class HolidayCalendar30YearIT {
             assertEquals(names.contains("New Year's Eve"), expected,
                     "FR " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
 
-            // Cross-list date collision: empty in ordinary years, exactly {Dec 24} in
-            // Dec-25-Saturday years (Christmas Day rolls back onto Christmas Eve).
+            // Cross-list date collision: empty in ordinary years, exactly one date
+            // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
+            // onto Christmas Eve.
             List<HolidayDate> fullDay = calendar.calculate(year);
             Set<LocalDate> fullDayDates = fullDay.stream().map(HolidayDate::date).collect(Collectors.toSet());
             Set<LocalDate> earlyCloseDates = earlyCloses.stream().map(HolidayDate::date).collect(Collectors.toSet());

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -367,4 +367,58 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 9. SG EARLY CLOSES (SGX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Both SGX Eve early closes are suppressed (not shifted) when their date falls on a
+    // weekend; since December 24 and December 31 are always exactly 7 days apart, they
+    // always share the same day-of-week within a year, so count is always 0 or 2, never 1.
+    // Expected presence is re-derived from December 24's day-of-week rule for every year
+    // rather than hand-fixtured.
+    @Test(description = "SG calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
+            + "and always co-occur, no nulls, chronological order")
+    public void testSGEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("SG");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "SG: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 2,
+                    "SG " + year + ": expected count in {0,2}, got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), expected,
+                    "SG " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+            assertEquals(names.contains("New Year's Eve"), expected,
+                    "SG " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "SG: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "SG: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "SG: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "SG: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -284,16 +284,16 @@ public class HolidayCalendar30YearIT {
                     "US " + year + ": Day After Thanksgiving must always be present");
 
             DayOfWeek july4Dow = LocalDate.of(year, Month.JULY, 4).getDayOfWeek();
-            boolean july3Expected = july4Dow != DayOfWeek.MONDAY
-                    && july4Dow != DayOfWeek.SATURDAY
-                    && july4Dow != DayOfWeek.SUNDAY;
+            boolean july3Expected = !DayOfWeek.MONDAY.equals(july4Dow)
+                    && !DayOfWeek.SATURDAY.equals(july4Dow)
+                    && !DayOfWeek.SUNDAY.equals(july4Dow);
             assertEquals(names.contains("July 3rd"), july3Expected,
                     "US " + year + ": July 3rd presence must match July 4 dow rule (dow=" + july4Dow + ")");
 
             DayOfWeek dec25Dow = LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek();
-            boolean dec24Expected = dec25Dow != DayOfWeek.MONDAY
-                    && dec25Dow != DayOfWeek.SATURDAY
-                    && dec25Dow != DayOfWeek.SUNDAY;
+            boolean dec24Expected = !DayOfWeek.MONDAY.equals(dec25Dow)
+                    && !DayOfWeek.SATURDAY.equals(dec25Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec25Dow);
             assertEquals(names.contains("Christmas Eve"), dec24Expected,
                     "US " + year + ": Christmas Eve presence must match December 25 dow rule (dow=" + dec25Dow + ")");
 

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -170,4 +170,42 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 5. ILS EARLY CLOSES (TASE half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    private static final int MIN_EARLY_CLOSES = 6 * RANGE_SIZE; // 6/year * 30 years
+
+    @Test(description = "ILS calculateEarlyCloses across 2026-2055 must yield >= 180 entries, "
+            + "no nulls, and be chronologically ordered")
+    public void testILSEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("ILS");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "ILS: calculateEarlyCloses(" + year + ") must not be null");
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        assertTrue(allEarlyCloses.size() >= MIN_EARLY_CLOSES,
+                "ILS: expected >= " + MIN_EARLY_CLOSES + " early-close entries over "
+                        + RANGE_SIZE + " years, got " + allEarlyCloses.size());
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "ILS: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "ILS: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "ILS: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "ILS: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -21,10 +21,14 @@ package org.holiday.calendar;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.time.Month;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.testng.Assert.*;
 
@@ -246,6 +250,68 @@ public class HolidayCalendar30YearIT {
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
                     "UK: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
+    // =========================================================================
+    // 7. US EARLY CLOSES (NYSE half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Day After Thanksgiving is unconditional; Christmas Eve / July 3rd are suppressed
+    // (not shifted) when their anchor holiday falls Monday, Saturday, or Sunday. Count
+    // therefore varies 1-3 per year, so expected presence is re-derived from the
+    // day-of-week rule for every year rather than hand-fixtured.
+    @Test(description = "US calculateEarlyCloses across 2026-2055: count always in [1,3], "
+            + "Day After Thanksgiving always present, July 3rd/Christmas Eve presence "
+            + "correlates exactly with July 4/December 25 day-of-week, no nulls, chronological order")
+    public void testUSEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("US");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "US: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count >= 1 && count <= 3,
+                    "US " + year + ": expected count in [1,3], got " + count);
+
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertTrue(names.contains("Day After Thanksgiving"),
+                    "US " + year + ": Day After Thanksgiving must always be present");
+
+            DayOfWeek july4Dow = LocalDate.of(year, Month.JULY, 4).getDayOfWeek();
+            boolean july3Expected = july4Dow != DayOfWeek.MONDAY
+                    && july4Dow != DayOfWeek.SATURDAY
+                    && july4Dow != DayOfWeek.SUNDAY;
+            assertEquals(names.contains("July 3rd"), july3Expected,
+                    "US " + year + ": July 3rd presence must match July 4 dow rule (dow=" + july4Dow + ")");
+
+            DayOfWeek dec25Dow = LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek();
+            boolean dec24Expected = dec25Dow != DayOfWeek.MONDAY
+                    && dec25Dow != DayOfWeek.SATURDAY
+                    && dec25Dow != DayOfWeek.SUNDAY;
+            assertEquals(names.contains("Christmas Eve"), dec24Expected,
+                    "US " + year + ": Christmas Eve presence must match December 25 dow rule (dow=" + dec25Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "US: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "US: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "US: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "US: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
         }
     }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -208,4 +208,46 @@ public class HolidayCalendar30YearIT {
         }
     }
 
+    // =========================================================================
+    // 6. UK EARLY CLOSES (LSE Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // The shift-to-preceding-Friday rule always yields a date (never suppressed),
+    // so the count is deterministic: 2 holidays/year * 30 years.
+    private static final int EXPECTED_UK_EARLY_CLOSES = 2 * RANGE_SIZE;
+
+    @Test(description = "UK calculateEarlyCloses across 2026-2055 must yield exactly 60 entries, "
+            + "no nulls, and be chronologically ordered")
+    public void testUKEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("UK");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "UK: calculateEarlyCloses(" + year + ") must not be null");
+            assertEquals(earlyCloses.size(), 2,
+                    "UK: expected exactly 2 early closes in " + year + ", got " + earlyCloses.size());
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        assertEquals(allEarlyCloses.size(), EXPECTED_UK_EARLY_CLOSES,
+                "UK: expected exactly " + EXPECTED_UK_EARLY_CLOSES + " early-close entries over "
+                        + RANGE_SIZE + " years, got " + allEarlyCloses.size());
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "UK: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "UK: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "UK: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "UK: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
 }


### PR DESCRIPTION
## Release Summary

This PR finalizes the Holiday Calendar Java **v2.0.0 GA** release, resolving all issues in milestone #7.

### Major Features

**Core API Enhancement — Half-Day Market Closures (#176)**
- New `EarlyCloseHoliday` sealed interface type with timezone-aware close times
- New `HolidayCalendar.calculateEarlyCloses(int year)` API
- New `HolidayCalendar.hasEarlyCloses()` convenience method

**8 Regional Exchanges Updated with Half-Day Modeling**
- US NYSE: Thanksgiving Friday, Christmas Eve, July 3rd (#205)
- CA TSX: Christmas Eve close (#206, #220)
- AU ASX: Christmas Eve & New Year's Eve 14:10 Sydney closes (#211, #221)
- FR Euronext Paris: Christmas Eve & New Year's Eve half-days (#210)
- UK LSE: Christmas Eve & New Year's Eve half-days (#207)
- SG SGX: Christmas Eve & New Year's Eve half-days (#212)
- CH SIX: Christmas Eve & New Year's Eve (no-roll convention) (#208)
- DE Xetra: Christmas Eve & New Year's Eve modeling (#209)

**Turkey Holiday Improvements (#180)**
- Diyanet astronomical ilmi takvim calculator for 2036-2055
- Corrected Arefe/Bayram data
- Validated against 24 published Diyanet dates 2024-2035

### Breaking Changes

⚠️ This is a **MAJOR** version bump (1.4.0 → 2.0.0) due to:
1. `Holiday` sealed interface now includes `EarlyCloseHoliday` permittee
2. `HolidayCalendar.calculate()` now excludes early close days (use `calculateEarlyCloses()` instead)

### Changes in This Release

- Version bumped to 2.0.0 in all 6 pom.xml files
- CHANGELOG.md updated with comprehensive 2.0.0 entry
- README.md regenerated with new version
- All 1,162 tests passing
- Code coverage verified

### Verification

- ✅ All tests pass (1,162 tests, 0 failures)
- ✅ Code coverage acceptable (JaCoCo)
- ✅ Builds cleanly
- ✅ All milestone #7 issues resolved

### Next Steps

1. Review and approve this PR
2. Merge to main
3. Create v2.0.0 tag on main
4. Create GitHub release
5. Back-merge to develop and bump to 2.1.0-SNAPSHOT

**Related:** Resolves milestone #7 "GA Release 2.0.0"