### PR TITLE
Split CA national holidays from TSX (XTSE) market calendar

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -48,5 +48,6 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceGBP,
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
         org.holiday.calendar.impl.HolidayCalendarServiceUS,
-        org.holiday.calendar.impl.HolidayCalendarServiceUSD;
+        org.holiday.calendar.impl.HolidayCalendarServiceUSD,
+        org.holiday.calendar.impl.HolidayCalendarServiceXTSE;
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/CanadaHolidays.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/CanadaHolidays.java
@@ -1,0 +1,126 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.ca.CivicHoliday;
+import org.holiday.calendar.observance.ca.FamilyDay;
+import org.holiday.calendar.observance.ca.LabourDay;
+import org.holiday.calendar.observance.ca.Thanksgiving;
+import org.holiday.calendar.observance.ca.VictoriaDay;
+
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the 10 holidays common to both the
+ * Canada national ({@code CA}) and Toronto Stock Exchange ({@code XTSE})
+ * calendars: New Year's Day, Family Day, Good Friday, Easter Monday,
+ * Victoria Day, Canada Day, Civic Holiday, Labour Day, Thanksgiving Day, and
+ * Remembrance Day. Each calling calendar adds its own remaining holidays
+ * (National Day For Truth and Reconciliation, Christmas Day, Boxing Day,
+ * and — for {@code XTSE} only — the Christmas Eve early close), since those
+ * differ between the two calendars.
+ */
+class CanadaHolidays {
+
+    private CanadaHolidays() {}
+
+    static List<Holiday> baseHolidays() {
+        final EasterObservance easter = new WesternEaster();
+
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Family Day")
+                    .description("Day to spend time with the family")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new FamilyDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Good Friday")
+                    .description("Friday before Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new GoodFriday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Monday")
+                    .description("Monday after Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EasterMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Victoria Day")
+                    .description("Official celebration of birthday of Canada's Sovereign")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new VictoriaDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Canada Day")
+                    .description("Anniversary of Canadian Confederation")
+                    .type(Holiday.Type.FIXED)
+                    .monthDay(Month.JULY, 1)
+                    .rollable(true)
+                    .build(),
+            Holiday.builder()
+                    .name("Civic Holiday")
+                    .description("Civic Holiday (observed; varies by province)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new CivicHoliday())
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("Celebration of workers in Canada")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new LabourDay())
+                    .build(),
+            Holiday.builder()
+                    .name("Thanksgiving Day")
+                    .description("National day for giving thanks")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new Thanksgiving())
+                    .build(),
+            Holiday.builder()
+                    .name("Remembrance Day")
+                    .description("Commemoration of armed forces members who have died in the line of duty")
+                    .type(Holiday.Type.FIXED)
+                    .monthDay(Month.NOVEMBER, 11)
+                    .rollable(true)
+                    .build()
+        );
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCA.java
@@ -22,18 +22,11 @@ import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.GoodFriday;
-import org.holiday.calendar.observance.christian.WesternEaster;
-import org.holiday.calendar.observance.ca.CivicHoliday;
-import org.holiday.calendar.observance.ca.FamilyDay;
-import org.holiday.calendar.observance.ca.LabourDay;
 import org.holiday.calendar.observance.ca.NationalDayForTruthAndReconciliation;
-import org.holiday.calendar.observance.ca.Thanksgiving;
-import org.holiday.calendar.observance.ca.VictoriaDay;
 
 import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
@@ -57,64 +50,6 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday familyDay = Holiday.builder()
-                .name("Family Day")
-                .description("Day to spend time with the family")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new FamilyDay())
-                .build();
-        final Holiday goodFriday = Holiday.builder()
-                .name("Good Friday")
-                .description("Friday before Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new GoodFriday(easter))
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Monday after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday victoriaDay = Holiday.builder()
-                .name("Victoria Day")
-                .description("Official celebration of birthday of Canada's Sovereign")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new VictoriaDay())
-                .build();
-        final Holiday canadaDay = Holiday.builder()
-                .name("Canada Day")
-                .description("Anniversary of Canadian Confederation")
-                .type(Holiday.Type.FIXED)
-                .monthDay(Month.JULY, 1)
-                .rollable(true)
-                .build();
-        final Holiday civicHoliday = Holiday.builder()
-                .name("Civic Holiday")
-                .description("Civic Holiday (observed; varies by province)")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new CivicHoliday())
-                .build();
-        final Holiday labourDay = Holiday.builder()
-                .name("Labour Day")
-                .description("Celebration of workers in Canada")
-                .type(Holiday.Type.FLOATING)
-                .observance(new LabourDay())
-                .rollable(false)
-                .build();
         final Holiday nationalDayForTruthAndReconciliation = Holiday.builder()
                 .name("National Day For Truth and Reconciliation")
                 .description("Recognition of the legacy of the Canadian Indian residential school system; "
@@ -122,20 +57,6 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .type(Holiday.Type.FLOATING)
                 .rollable(true)
                 .observance(new NationalDayForTruthAndReconciliation())
-                .build();
-        final Holiday thanksgiving = Holiday.builder()
-                .name("Thanksgiving Day")
-                .description("National day for giving thanks")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new Thanksgiving())
-                .build();
-        final Holiday remembranceDay = Holiday.builder()
-                .name("Remembrance Day")
-                .description("Commemoration of armed forces members who have died in the line of duty")
-                .type(Holiday.Type.FIXED)
-                .monthDay(Month.NOVEMBER, 11)
-                .rollable(true)
                 .build();
         final Holiday christmas = Holiday.builder()
                 .name("Christmas Day")
@@ -152,24 +73,17 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .rollable(false)
                 .build();
 
+        final List<Holiday> holidays = new ArrayList<>(CanadaHolidays.baseHolidays());
+        holidays.add(nationalDayForTruthAndReconciliation);
+        holidays.add(christmas);
+        holidays.add(boxingDay);
+
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(familyDay)
-                .holiday(goodFriday)
-                .holiday(easterMonday)
-                .holiday(victoriaDay)
-                .holiday(canadaDay)
-                .holiday(civicHoliday)
-                .holiday(labourDay)
-                .holiday(nationalDayForTruthAndReconciliation)
-                .holiday(thanksgiving)
-                .holiday(remembranceDay)
-                .holiday(christmas)
-                .holiday(boxingDay)
+                .holidays(holidays)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSE.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSE.java
@@ -26,32 +26,47 @@ import org.holiday.calendar.observance.christian.EasterObservance;
 import org.holiday.calendar.observance.christian.EasterMonday;
 import org.holiday.calendar.observance.christian.GoodFriday;
 import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.ca.BoxingDayCAD;
+import org.holiday.calendar.observance.ca.ChristmasEveEarlyClose;
 import org.holiday.calendar.observance.ca.CivicHoliday;
 import org.holiday.calendar.observance.ca.FamilyDay;
 import org.holiday.calendar.observance.ca.LabourDay;
-import org.holiday.calendar.observance.ca.NationalDayForTruthAndReconciliation;
 import org.holiday.calendar.observance.ca.Thanksgiving;
 import org.holiday.calendar.observance.ca.VictoriaDay;
 
+import java.time.LocalTime;
 import java.time.Month;
+import java.time.ZoneId;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
 /**
- * Service for provision of the Canada national/federal holiday calendar.
- * Distinct from {@link HolidayCalendarServiceXTSE}, the Toronto Stock
- * Exchange (TSX) trading calendar: this calendar contains only holidays
- * observed by the Government of Canada, and never includes early-close
- * (half-day) trading sessions.
+ * Service for provision of the Toronto Stock Exchange (TSX) trading holiday
+ * calendar. Distinct from {@link HolidayCalendarServiceCA}, the Canada
+ * national holiday calendar: this calendar additionally includes a TSX
+ * Christmas Eve early close.
+ *
+ * <p>TSX's weekend substitution rule, per TMX Group's official Holiday
+ * Operating Schedule (verified against the 2021 and 2016 published
+ * schedules, and cross-checked against the 2017 Canada Day schedule): a
+ * statutory holiday falling on Saturday or Sunday rolls <strong>forward</strong>
+ * to the next available business day — never backward. This is identical
+ * to the Bank of Canada (Lynx) settlement convention used by {@code CAD}.
+ * Boxing Day requires collision-aware handling — see {@link BoxingDayCAD},
+ * reused here — since its own roll can collide with Christmas Day's rolled
+ * observance, and vice versa (e.g. in 2021, Christmas Day and Boxing Day
+ * both rolled forward to Monday Dec 27 and Tuesday Dec 28 respectively,
+ * while the ordinary Dec 24 early close proceeded unaffected).</p>
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
+public class HolidayCalendarServiceXTSE extends AbstractHolidayCalendarService {
 
-    private static final String CODE = "CA";
-    private static final String NAME = "Canada National Holidays";
+    private static final String CODE = "XTSE";
+    private static final String NAME = "Canada (Toronto Stock Exchange) Holidays";
+    private static final ZoneId TSX_ZONE = ZoneId.of("America/Toronto");
 
-    public HolidayCalendarServiceCA() {
+    public HolidayCalendarServiceXTSE() {
         super(CODE, NAME);
     }
 
@@ -117,11 +132,10 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .build();
         final Holiday nationalDayForTruthAndReconciliation = Holiday.builder()
                 .name("National Day For Truth and Reconciliation")
-                .description("Recognition of the legacy of the Canadian Indian residential school system; "
-                             + "federal statutory holiday first observed 30 September 2021")
-                .type(Holiday.Type.FLOATING)
-                .rollable(true)
-                .observance(new NationalDayForTruthAndReconciliation())
+                .description("Recognition of the legacy of the Canadian Indian residential school system")
+                .type(Holiday.Type.FIXED)
+                .monthDay(Month.SEPTEMBER, 30)
+                .rollable(false)
                 .build();
         final Holiday thanksgiving = Holiday.builder()
                 .name("Thanksgiving Day")
@@ -137,19 +151,29 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .monthDay(Month.NOVEMBER, 11)
                 .rollable(true)
                 .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("TSX 1:00pm local early close; occurs whenever "
+                             + "December 24 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(13, 0))
+                .zoneId(TSX_ZONE)
+                .build();
         final Holiday christmas = Holiday.builder()
                 .name("Christmas Day")
                 .description("Christmas Day")
                 .type(Holiday.Type.FIXED)
                 .monthDay(Month.DECEMBER, 25)
-                .rollable(false)
+                .rollable(true)
                 .build();
         final Holiday boxingDay = Holiday.builder()
                 .name("Boxing Day")
-                .description("Day after Christmas")
-                .type(Holiday.Type.FIXED)
-                .monthDay(Month.DECEMBER, 26)
+                .description("Day after Christmas (observed; collision-aware with Christmas Day)")
+                .type(Holiday.Type.FLOATING)
                 .rollable(false)
+                .observance(new BoxingDayCAD())
                 .build();
 
         return HolidayCalendar.builder()
@@ -168,6 +192,7 @@ public class HolidayCalendarServiceCA extends AbstractHolidayCalendarService {
                 .holiday(nationalDayForTruthAndReconciliation)
                 .holiday(thanksgiving)
                 .holiday(remembranceDay)
+                .holiday(christmasEveEarlyClose)
                 .holiday(christmas)
                 .holiday(boxingDay)
                 .build();

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSE.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSE.java
@@ -22,21 +22,14 @@ import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.GoodFriday;
-import org.holiday.calendar.observance.christian.WesternEaster;
 import org.holiday.calendar.observance.ca.BoxingDayCAD;
 import org.holiday.calendar.observance.ca.ChristmasEveEarlyClose;
-import org.holiday.calendar.observance.ca.CivicHoliday;
-import org.holiday.calendar.observance.ca.FamilyDay;
-import org.holiday.calendar.observance.ca.LabourDay;
-import org.holiday.calendar.observance.ca.Thanksgiving;
-import org.holiday.calendar.observance.ca.VictoriaDay;
 
 import java.time.LocalTime;
 import java.time.Month;
 import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
@@ -72,84 +65,12 @@ public class HolidayCalendarServiceXTSE extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday familyDay = Holiday.builder()
-                .name("Family Day")
-                .description("Day to spend time with the family")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new FamilyDay())
-                .build();
-        final Holiday goodFriday = Holiday.builder()
-                .name("Good Friday")
-                .description("Friday before Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new GoodFriday(easter))
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Monday after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday victoriaDay = Holiday.builder()
-                .name("Victoria Day")
-                .description("Official celebration of birthday of Canada's Sovereign")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new VictoriaDay())
-                .build();
-        final Holiday canadaDay = Holiday.builder()
-                .name("Canada Day")
-                .description("Anniversary of Canadian Confederation")
-                .type(Holiday.Type.FIXED)
-                .monthDay(Month.JULY, 1)
-                .rollable(true)
-                .build();
-        final Holiday civicHoliday = Holiday.builder()
-                .name("Civic Holiday")
-                .description("Civic Holiday (observed; varies by province)")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new CivicHoliday())
-                .build();
-        final Holiday labourDay = Holiday.builder()
-                .name("Labour Day")
-                .description("Celebration of workers in Canada")
-                .type(Holiday.Type.FLOATING)
-                .observance(new LabourDay())
-                .rollable(false)
-                .build();
         final Holiday nationalDayForTruthAndReconciliation = Holiday.builder()
                 .name("National Day For Truth and Reconciliation")
                 .description("Recognition of the legacy of the Canadian Indian residential school system")
                 .type(Holiday.Type.FIXED)
                 .monthDay(Month.SEPTEMBER, 30)
                 .rollable(false)
-                .build();
-        final Holiday thanksgiving = Holiday.builder()
-                .name("Thanksgiving Day")
-                .description("National day for giving thanks")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new Thanksgiving())
-                .build();
-        final Holiday remembranceDay = Holiday.builder()
-                .name("Remembrance Day")
-                .description("Commemoration of armed forces members who have died in the line of duty")
-                .type(Holiday.Type.FIXED)
-                .monthDay(Month.NOVEMBER, 11)
-                .rollable(true)
                 .build();
         final Holiday christmasEveEarlyClose = Holiday.builder()
                 .name("Christmas Eve")
@@ -176,25 +97,18 @@ public class HolidayCalendarServiceXTSE extends AbstractHolidayCalendarService {
                 .observance(new BoxingDayCAD())
                 .build();
 
+        final List<Holiday> holidays = new ArrayList<>(CanadaHolidays.baseHolidays());
+        holidays.add(nationalDayForTruthAndReconciliation);
+        holidays.add(christmasEveEarlyClose);
+        holidays.add(christmas);
+        holidays.add(boxingDay);
+
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(familyDay)
-                .holiday(goodFriday)
-                .holiday(easterMonday)
-                .holiday(victoriaDay)
-                .holiday(canadaDay)
-                .holiday(civicHoliday)
-                .holiday(labourDay)
-                .holiday(nationalDayForTruthAndReconciliation)
-                .holiday(thanksgiving)
-                .holiday(remembranceDay)
-                .holiday(christmasEveEarlyClose)
-                .holiday(christmas)
-                .holiday(boxingDay)
+                .holidays(holidays)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -11,3 +11,4 @@ org.holiday.calendar.impl.HolidayCalendarServiceGBP
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS
 org.holiday.calendar.impl.HolidayCalendarServiceUSD
+org.holiday.calendar.impl.HolidayCalendarServiceXTSE

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCATest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCATest.java
@@ -1,11 +1,20 @@
 package org.holiday.calendar.impl;
 
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarService;
+import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertFalse;
 
 public class HolidayCalendarServiceCATest extends AbstractHolidayCalendarServiceTest {
 
@@ -20,8 +29,7 @@ public class HolidayCalendarServiceCATest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] familyDay = {"Family Day"};
         final Object[] victoriaDay = {"Victoria Day"};
-        final Object[] christmasEve = {"Christmas Eve"};
-        return Arrays.asList(familyDay, victoriaDay, christmasEve).listIterator();
+        return Arrays.asList(familyDay, victoriaDay).listIterator();
     }
 
     @DataProvider
@@ -32,15 +40,48 @@ public class HolidayCalendarServiceCATest extends AbstractHolidayCalendarService
         final Object[] canadaDay20 = {2020, "Canada Day", LocalDate.of(2020, Month.JULY, 1)};
         final Object[] canadaDay21 = {2021, "Canada Day", LocalDate.of(2021, Month.JULY, 1)};
         final Object[] canadaDay22 = {2022, "Canada Day", LocalDate.of(2022, Month.JULY, 1)};
-        final Object[] canadaDay23 = {2023, "Canada Day", LocalDate.of(2023, Month.JULY, 1)};
+        final Object[] canadaDay23 = {2023, "Canada Day", LocalDate.of(2023, Month.JULY, 3)}; // Sat -> following Monday
         final Object[] remembranceDay18 = {2018, "Remembrance Day", LocalDate.of(2018, Month.NOVEMBER, 12)};
         final Object[] remembranceDay19 = {2019, "Remembrance Day", LocalDate.of(2019, Month.NOVEMBER, 11)};
         final Object[] remembranceDay20 = {2020, "Remembrance Day", LocalDate.of(2020, Month.NOVEMBER, 11)};
         final Object[] remembranceDay21 = {2021, "Remembrance Day", LocalDate.of(2021, Month.NOVEMBER, 11)};
         final Object[] remembranceDay22 = {2022, "Remembrance Day", LocalDate.of(2022, Month.NOVEMBER, 11)};
-        final Object[] remembranceDay23 = {2023, "Remembrance Day", LocalDate.of(2023, Month.NOVEMBER, 11)};
+        final Object[] remembranceDay23 = {2023, "Remembrance Day", LocalDate.of(2023, Month.NOVEMBER, 13)}; // Sat -> following Monday
+        final Object[] ndtr21 = {2021, "National Day For Truth and Reconciliation", LocalDate.of(2021, Month.SEPTEMBER, 30)}; // Thu, no roll, first observed year
+        final Object[] ndtr23 = {2023, "National Day For Truth and Reconciliation", LocalDate.of(2023, Month.OCTOBER, 2)}; // Sat -> following Monday
         return Arrays.asList(canadaDay18, canadaDay19, canadaDay20, canadaDay21, canadaDay22, canadaDay23,
-                             remembranceDay18, remembranceDay19, remembranceDay20, remembranceDay21, remembranceDay22, remembranceDay23).listIterator();
+                             remembranceDay18, remembranceDay19, remembranceDay20, remembranceDay21, remembranceDay22, remembranceDay23,
+                             ndtr21, ndtr23).listIterator();
+    }
+
+    @Test
+    public void testNdtrAbsentBefore2021() {
+        HolidayCalendarService service = factory.getService(CODE);
+        for (int year : List.of(2019, 2020)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            assertFalse(holidays.stream().anyMatch(hd -> "National Day For Truth and Reconciliation".equals(hd.getHoliday().getName())),
+                    "CA: NDTR must not appear for " + year + " (first observed 2021)");
+        }
+    }
+
+    @Test
+    public void testEarlyCloseHolidaysAbsentFromCalculate() {
+        HolidayCalendarService service = factory.getService(CODE);
+        for (int year : List.of(2021, 2023, 2024, 2025)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            Set<String> actualNames = holidays.stream()
+                    .map(hd -> hd.getHoliday().getName())
+                    .collect(Collectors.toSet());
+            assertFalse(actualNames.contains("Christmas Eve"),
+                    "Christmas Eve must not appear in calculate(" + year + ") — moved to XTSE");
+        }
+    }
+
+    @Test
+    public void testCaHasNoEarlyCloses() {
+        HolidayCalendarService service = factory.getService(CODE);
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertFalse(calendar.hasEarlyCloses(), "CA: national calendar must have zero early closes");
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSEEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSEEarlyCloseTest.java
@@ -37,21 +37,21 @@ import java.util.stream.Collectors;
 import static org.testng.Assert.*;
 
 /**
- * Tests for the {@code CA} calendar's early-close (TSX half-day closure)
- * holiday: Christmas Eve. Unlike US's Christmas Eve early close (keyed off
- * December 25's day of week), CA registers exactly one EARLY_CLOSE holiday,
+ * Tests for the {@code XTSE} calendar's early-close (TSX half-day closure)
+ * holiday: Christmas Eve. Unlike NYSE's Christmas Eve early close (keyed off
+ * December 25's day of week), XTSE registers exactly one EARLY_CLOSE holiday,
  * so the count per year is either 0 or 1 — never more than one.
  */
-public class HolidayCalendarServiceCAEarlyCloseTest {
+public class HolidayCalendarServiceXTSEEarlyCloseTest {
 
     private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
     private static final ZoneId EXPECTED_ZONE = ZoneId.of("America/Toronto");
 
-    // 13 full-day holidays registered in HolidayCalendarServiceCA; Christmas Eve is the
+    // 13 full-day holidays registered in HolidayCalendarServiceXTSE; Christmas Eve is the
     // only EARLY_CLOSE holiday and is excluded by calculate(), so calculate() sees 13.
     private static final int FULL_DAY_HOLIDAY_COUNT = 13;
 
-    private final HolidayCalendarServiceCA service = new HolidayCalendarServiceCA();
+    private final HolidayCalendarServiceXTSE service = new HolidayCalendarServiceXTSE();
 
     // -------------------------------------------------------------------------
     // Count / presence per year (verified 2017-2026 TSX cycle)
@@ -77,13 +77,13 @@ public class HolidayCalendarServiceCAEarlyCloseTest {
     public void testEarlyCloseCountForYear(int year, boolean present) {
         List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
         assertNotNull(earlyCloses);
-        assertEquals(earlyCloses.size(), present ? 1 : 0, "CA " + year + ": unexpected early-close count");
+        assertEquals(earlyCloses.size(), present ? 1 : 0, "XTSE " + year +": unexpected early-close count");
     }
 
     @Test(dataProvider = "caEarlyCloseFixture")
     public void testChristmasEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
-                "CA " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+                "XTSE " + year +": Christmas Eve presence must match December 24 day-of-week rule");
     }
 
     private Set<String> earlyCloseNames(int year) {
@@ -183,7 +183,7 @@ public class HolidayCalendarServiceCAEarlyCloseTest {
                 .filter(earlyCloseDates::contains)
                 .collect(Collectors.toSet());
         assertTrue(intersection.isEmpty(),
-                "CA " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+                "XTSE " + year +": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
     }
 
     // -------------------------------------------------------------------------
@@ -195,7 +195,7 @@ public class HolidayCalendarServiceCAEarlyCloseTest {
         HolidayCalendar calendar = service.getHolidayCalendar();
         List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
         if (!present) {
-            assertTrue(earlyCloses.isEmpty(), "CA " + year + ": expected no early closes");
+            assertTrue(earlyCloses.isEmpty(), "XTSE " + year +": expected no early closes");
             return;
         }
         LocalDate expected = new ChristmasEveEarlyClose().apply(year);

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSETest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXTSETest.java
@@ -1,0 +1,67 @@
+package org.holiday.calendar.impl;
+
+import org.testng.annotations.DataProvider;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Fixtures verify TSX's actual weekend substitution rule, per TMX Group's
+ * official Holiday Operating Schedule: both Saturday and Sunday roll
+ * <strong>forward</strong> to the next available business day, never
+ * backward. This is identical to the Bank of Canada (Lynx) / {@code CAD}
+ * convention, and to the corrected {@code CA} national calendar's rule.
+ */
+public class HolidayCalendarServiceXTSETest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "XTSE";
+
+    public HolidayCalendarServiceXTSETest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        final Object[] familyDay = {"Family Day"};
+        final Object[] victoriaDay = {"Victoria Day"};
+        final Object[] christmasEve = {"Christmas Eve"};
+        return Arrays.asList(familyDay, victoriaDay, christmasEve).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        final Object[] canadaDay18 = {2018, "Canada Day", LocalDate.of(2018, Month.JULY, 2)}; // Sun -> following Monday
+        final Object[] canadaDay19 = {2019, "Canada Day", LocalDate.of(2019, Month.JULY, 1)};
+        final Object[] canadaDay20 = {2020, "Canada Day", LocalDate.of(2020, Month.JULY, 1)};
+        final Object[] canadaDay21 = {2021, "Canada Day", LocalDate.of(2021, Month.JULY, 1)};
+        final Object[] canadaDay22 = {2022, "Canada Day", LocalDate.of(2022, Month.JULY, 1)};
+        final Object[] canadaDay23 = {2023, "Canada Day", LocalDate.of(2023, Month.JULY, 3)}; // Sat -> following Monday
+        final Object[] remembranceDay18 = {2018, "Remembrance Day", LocalDate.of(2018, Month.NOVEMBER, 12)}; // Sun -> following Monday
+        final Object[] remembranceDay19 = {2019, "Remembrance Day", LocalDate.of(2019, Month.NOVEMBER, 11)};
+        final Object[] remembranceDay20 = {2020, "Remembrance Day", LocalDate.of(2020, Month.NOVEMBER, 11)};
+        final Object[] remembranceDay21 = {2021, "Remembrance Day", LocalDate.of(2021, Month.NOVEMBER, 11)};
+        final Object[] remembranceDay22 = {2022, "Remembrance Day", LocalDate.of(2022, Month.NOVEMBER, 11)};
+        final Object[] remembranceDay23 = {2023, "Remembrance Day", LocalDate.of(2023, Month.NOVEMBER, 13)}; // Sat -> following Monday
+        final Object[] newYearsDay22 = {2022, "New Year's Day", LocalDate.of(2022, Month.JANUARY, 3)}; // Sat -> following Monday
+        final Object[] christmas21 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 27)}; // Sat -> following Monday (TMX 2021 schedule confirmed)
+        final Object[] boxingDay21 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 28)}; // Christmas=Saturday cascade, displaced to Tuesday (TMX 2021 schedule confirmed)
+        final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)}; // Sun -> following Monday, consumes Boxing Day's natural date
+        final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 27)}; // displaced to Tuesday by Christmas collision
+        final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)}; // Mon, no roll
+        final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)}; // Tue, no roll
+        final Object[] christmas26 = {2026, "Christmas Day", LocalDate.of(2026, Month.DECEMBER, 25)}; // Fri, no roll
+        final Object[] boxingDay26 = {2026, "Boxing Day", LocalDate.of(2026, Month.DECEMBER, 28)}; // Sat -> following Monday, no collision with Friday Christmas
+        return Arrays.asList(canadaDay18, canadaDay19, canadaDay20, canadaDay21, canadaDay22, canadaDay23,
+                             remembranceDay18, remembranceDay19, remembranceDay20, remembranceDay21, remembranceDay22, remembranceDay23,
+                             newYearsDay22,
+                             christmas21, boxingDay21,
+                             christmas22, boxingDay22,
+                             christmas23, boxingDay23,
+                             christmas26, boxingDay26).listIterator();
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -89,7 +89,8 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"TRY"},
                 new Object[]{"UK"},
                 new Object[]{"US"},
-                new Object[]{"USD"}
+                new Object[]{"USD"},
+                new Object[]{"XTSE"}
         ).iterator();
     }
 
@@ -317,27 +318,27 @@ public class HolidayCalendar30YearIT {
     }
 
     // =========================================================================
-    // 8. CA EARLY CLOSES (TSX Christmas Eve half-day closure) OVER 30 YEARS
+    // 8. XTSE EARLY CLOSES (TSX Christmas Eve half-day closure) OVER 30 YEARS
     // =========================================================================
 
     // TSX's Christmas Eve early close is suppressed (not shifted) when December 24
     // falls on a weekend, so count is either 0 or 1 per year; expected presence is
     // re-derived from December 24's day-of-week rule for every year rather than
     // hand-fixtured.
-    @Test(description = "CA calculateEarlyCloses across 2026-2055: count always in [0,1], "
+    @Test(description = "XTSE calculateEarlyCloses across 2026-2055: count always in [0,1], "
             + "Christmas Eve presence matches December 24 dow rule (excludes Sat/Sun), "
             + "no nulls, chronological order")
-    public void testCAEarlyClosesOver30Years() {
-        HolidayCalendar calendar = new HolidayCalendarFactory().create("CA");
+    public void testXTSEEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XTSE");
 
         List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
         for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
             List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
-            assertNotNull(earlyCloses, "CA: calculateEarlyCloses(" + year + ") must not be null");
+            assertNotNull(earlyCloses, "XTSE: calculateEarlyCloses(" + year + ") must not be null");
 
             int count = earlyCloses.size();
             assertTrue(count == 0 || count == 1,
-                    "CA " + year + ": expected count in [0,1], got " + count);
+                    "XTSE " + year + ": expected count in [0,1], got " + count);
 
             DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
             boolean dec24Expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
@@ -346,24 +347,36 @@ public class HolidayCalendar30YearIT {
                     .map(hd -> hd.holiday().getName())
                     .collect(Collectors.toSet());
             assertEquals(names.contains("Christmas Eve"), dec24Expected,
-                    "CA " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+                    "XTSE " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
 
             allEarlyCloses.addAll(earlyCloses);
         }
 
         for (int i = 0; i < allEarlyCloses.size(); i++) {
             HolidayDate hd = allEarlyCloses.get(i);
-            assertNotNull(hd, "CA: early-close entry at index " + i + " must not be null");
-            assertNotNull(hd.holiday(), "CA: early-close holiday at index " + i + " must not be null");
-            assertNotNull(hd.date(), "CA: early-close date at index " + i + " must not be null");
+            assertNotNull(hd, "XTSE: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "XTSE: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "XTSE: early-close date at index " + i + " must not be null");
         }
 
         for (int i = 1; i < allEarlyCloses.size(); i++) {
             LocalDate prev = allEarlyCloses.get(i - 1).date();
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
-                    "CA: early-close dates out of order at index " + i
+                    "XTSE: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
+        }
+    }
+
+    @Test(description = "CA (national) calculateEarlyCloses must be empty across 2026-2055 "
+            + "— early closes are TSX-only market convention, moved to XTSE")
+    public void testCAHasNoEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("CA");
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "CA: calculateEarlyCloses(" + year + ") must not be null");
+            assertTrue(earlyCloses.isEmpty(),
+                    "CA " + year + ": national calendar must have zero early closes, got " + earlyCloses.size());
         }
     }
 


### PR DESCRIPTION
### Title of the PR

Split CA national holidays from TSX (XTSE) market calendar

**Description**

- `HolidayCalendarServiceCA` was documented as "Canada National Holidays" but included a TSX Christmas Eve early close and an unverified Sunday-only date-roll rule (only New Year's Day, Canada Day, and Remembrance Day rolled, and only on Sunday).
- Extracts a new `HolidayCalendarServiceXTSE` (ISO 10383 Market Identifier Code for TSX) as the market calendar, carrying forward the Christmas Eve early close.
- Corrects `XTSE`'s date-roll to the verified TMX Group convention (both Saturday and Sunday roll **forward** to the next business day — confirmed via TMX's official Holiday Operating Schedule press releases for 2021 and 2017, not the "preceding Friday" rule initially assumed). Reuses the existing `BoxingDayCAD` collision-cascade observance directly, since its logic already matches this convention exactly.
- Slims `HolidayCalendarServiceCA` down to 13 pure national holidays (removes the Christmas Eve early close); `CA.hasEarlyCloses()` now correctly returns `false`. Fixes `CA`'s date-roll to `DateRolls.followingMonday()`, matching the verified Canadian federal statutory convention (and the existing `CAD` calendar's behavior).
- **Bundled bug fix**: "National Day For Truth and Reconciliation" now uses the already-existing, already-correct year-gated (`>= 2021`) `NationalDayForTruthAndReconciliation` observance instead of an inline ungated `FIXED` holiday, which previously (incorrectly) showed the holiday for years before its 2021 creation.
- Registers `XTSE` in `module-info.java` and `META-INF/services`.
- Renames `HolidayCalendarServiceCAEarlyCloseTest` → `HolidayCalendarServiceXTSEEarlyCloseTest` (behavior moved wholesale, not duplicated); adds `HolidayCalendarServiceXTSETest`; updates the `CA` test with corrected 2023 fixtures, NDTR gating tests, and an early-close-absence check.
- Updates `HolidayCalendar30YearIT`: adds `XTSE` to the calendar-code list, renames `testCAEarlyClosesOver30Years` → `testXTSEEarlyClosesOver30Years`, and adds `testCAHasNoEarlyClosesOver30Years`.

**Related Issue**

- Closes [#235](https://github.com/holiday-calendar/holiday-calendar-java/issues/235) (sub-issue of [#231](https://github.com/holiday-calendar/holiday-calendar-java/issues/231), itself a sub-issue of [#229](https://github.com/holiday-calendar/holiday-calendar-java/issues/229))

**Type of Change**

- [x] Bug fix
- [x] New feature
- [x] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed