### PR TITLE
Split UK national holidays from LSE (XLON) market calendar

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -48,5 +48,6 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceGBP,
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
         org.holiday.calendar.impl.HolidayCalendarServiceUS,
-        org.holiday.calendar.impl.HolidayCalendarServiceUSD;
+        org.holiday.calendar.impl.HolidayCalendarServiceUSD,
+        org.holiday.calendar.impl.HolidayCalendarServiceXLON;
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUK.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceUK.java
@@ -21,31 +21,16 @@ package org.holiday.calendar.impl;
 import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.GoodFriday;
-import org.holiday.calendar.observance.christian.WesternEaster;
-import org.holiday.calendar.observance.uk.ChristmasEveEarlyClose;
-import org.holiday.calendar.observance.uk.EarlyMayBankHoliday;
-import org.holiday.calendar.observance.uk.NewYearsEveEarlyClose;
-import org.holiday.calendar.observance.uk.SpringBankHoliday;
-import org.holiday.calendar.observance.uk.SummerBankHoliday;
 import org.holiday.calendar.observance.uk.UKDateRolls;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
-import java.time.Month;
-import java.time.ZoneId;
+import java.util.List;
 
 /**
- * Service for provision of UK national holiday calendar.
- *
- * <p>Includes two {@code EARLY_CLOSE} holidays representing the London Stock
- * Exchange's Christmas Eve and New Year's Eve half-day closes. The CHAPS
- * settlement calendar ({@link HolidayCalendarServiceGBP}) does not currently
- * include these — CHAPS payment settlement and LSE equities trading are
- * distinct systems, and adding early closes there would need its own
- * Bank of England-sourced verification.
+ * Service for provision of the United Kingdom national/government bank
+ * holiday calendar. Distinct from {@link HolidayCalendarServiceXLON}, the
+ * London Stock Exchange (LSE) trading calendar: this calendar contains only
+ * England-and-Wales bank holidays, and never includes early-close (half-day)
+ * trading sessions.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -60,131 +45,17 @@ public class HolidayCalendarServiceUK extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday goodFriday = Holiday.builder()
-                .name("Good Friday")
-                .description("Commemoration of the crucifixion of Jesus Christ")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new GoodFriday(easter))
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Day after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday earlyMayBankHoliday = Holiday.builder()
-                .name("Early May Bank Holiday")
-                .description("Early May bank holiday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EarlyMayBankHoliday())
-                .build();
-        final Holiday springBankHoliday = Holiday.builder()
-                .name("Spring Bank Holiday")
-                .description("Late May bank holiday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new SpringBankHoliday())
-                .build();
-        final Holiday silverJubileeBankHoliday = Holiday.builder()
-                .name("Silver Jubilee Bank Holiday")
-                .description("Silver Jubilee of Queen Elizabeth II")
-                .type(Holiday.Type.SPECIAL_ANNIVERSARY)
-                .rollable(false)
-                .anniversaryDate(LocalDate.of(1977, Month.JUNE, 7))
-                .build();
-        final Holiday goldenJubileeBankHoliday = Holiday.builder()
-                .name("Golden Jubilee Bank Holiday")
-                .description("Golden Jubilee of Queen Elizabeth II")
-                .type(Holiday.Type.SPECIAL_ANNIVERSARY)
-                .rollable(false)
-                .anniversaryDate(LocalDate.of(2002, Month.JUNE, 3))
-                .build();
-        final Holiday diamondJubileeBankHoliday = Holiday.builder()
-                .name("Diamond Jubilee Bank Holiday")
-                .description("Diamond Jubilee of Queen Elizabeth II")
-                .type(Holiday.Type.SPECIAL_ANNIVERSARY)
-                .rollable(false)
-                .anniversaryDate(LocalDate.of(2012, Month.JUNE, 5))
-                .build();
-        final Holiday platinumJubileeBankHoliday = Holiday.builder()
-                .name("Platinum Jubilee Bank Holiday")
-                .description("Platinum Jubilee of Queen Elizabeth II")
-                .type(Holiday.Type.SPECIAL_ANNIVERSARY)
-                .rollable(false)
-                .anniversaryDate(LocalDate.of(2022, Month.JUNE, 3))
-                .build();
-        final Holiday summerBankHoliday = Holiday.builder()
-                .name("Summer Bank Holiday")
-                .description("Summer bank holiday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new SummerBankHoliday())
-                .build();
-        final Holiday christmasDay = Holiday.builder()
-                .name("Christmas Day")
-                .description("Commemoration of the birth of Jesus Christ")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 25)
-                .build();
-        final Holiday boxingDay = Holiday.builder()
-                .name("Boxing Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 26)
-                .build();
-        final Holiday christmasEveEarlyClose = Holiday.builder()
-                .name("Christmas Eve")
-                .description("LSE half-day close; shifts to the preceding Friday when " +
-                             "December 24 falls on a Saturday or Sunday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new ChristmasEveEarlyClose())
-                .closeTime(LocalTime.of(12, 30))
-                .zoneId(ZoneId.of("Europe/London"))
-                .build();
-        final Holiday newYearsEveEarlyClose = Holiday.builder()
-                .name("New Year's Eve")
-                .description("LSE half-day close; shifts to the preceding Friday when " +
-                             "December 31 falls on a Saturday or Sunday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new NewYearsEveEarlyClose())
-                .closeTime(LocalTime.of(12, 30))
-                .zoneId(ZoneId.of("Europe/London"))
-                .build();
+        final Holiday newYearsDay = UkHolidays.newYearsDay();
+        final Holiday christmasDay = UkHolidays.christmasDay();
+        final Holiday boxingDay = UkHolidays.boxingDay();
+        final List<Holiday> holidays = UkHolidays.baseHolidays();
 
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(UKDateRolls.fixedHolidayRoll(newYearsDay, christmasDay, boxingDay))
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(goodFriday)
-                .holiday(easterMonday)
-                .holiday(earlyMayBankHoliday)
-                .holiday(springBankHoliday)
-                .holiday(silverJubileeBankHoliday)
-                .holiday(goldenJubileeBankHoliday)
-                .holiday(diamondJubileeBankHoliday)
-                .holiday(platinumJubileeBankHoliday)
-                .holiday(summerBankHoliday)
-                .holiday(christmasDay)
-                .holiday(boxingDay)
-                .holiday(christmasEveEarlyClose)
-                .holiday(newYearsEveEarlyClose)
+                .holidays(holidays)
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXLON.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXLON.java
@@ -1,0 +1,93 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.observance.uk.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.uk.NewYearsEveEarlyClose;
+import org.holiday.calendar.observance.uk.UKDateRolls;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Service for provision of the London Stock Exchange (LSE) trading holiday
+ * calendar. Distinct from {@link HolidayCalendarServiceUK}, the United
+ * Kingdom national holiday calendar: this calendar additionally includes two
+ * {@code EARLY_CLOSE} holidays representing LSE's Christmas Eve and New
+ * Year's Eve half-day closes. LSE is closed on every bank holiday observed
+ * by {@code UK}, including the one-off Jubilee bank holidays.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceXLON extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "XLON";
+    private static final String NAME = "United Kingdom (London Stock Exchange) Holidays";
+    private static final ZoneId LSE_ZONE = ZoneId.of("Europe/London");
+
+    public HolidayCalendarServiceXLON() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday newYearsDay = UkHolidays.newYearsDay();
+        final Holiday christmasDay = UkHolidays.christmasDay();
+        final Holiday boxingDay = UkHolidays.boxingDay();
+
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("LSE half-day close; shifts to the preceding Friday when " +
+                             "December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(12, 30))
+                .zoneId(LSE_ZONE)
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("LSE half-day close; shifts to the preceding Friday when " +
+                             "December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(12, 30))
+                .zoneId(LSE_ZONE)
+                .build();
+
+        final List<Holiday> holidays = new ArrayList<>(UkHolidays.baseHolidays());
+        holidays.add(christmasEveEarlyClose);
+        holidays.add(newYearsEveEarlyClose);
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(UKDateRolls.fixedHolidayRoll(newYearsDay, christmasDay, boxingDay))
+                .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
+                .holidays(holidays)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/UkHolidays.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/UkHolidays.java
@@ -1,0 +1,155 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.uk.EarlyMayBankHoliday;
+import org.holiday.calendar.observance.uk.SpringBankHoliday;
+import org.holiday.calendar.observance.uk.SummerBankHoliday;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the 12 holidays common to both the United
+ * Kingdom national ({@code UK}) and London Stock Exchange ({@code XLON})
+ * calendars: New Year's Day, Good Friday, Easter Monday, Early May Bank
+ * Holiday, Spring Bank Holiday, the 4 Jubilee anniversaries, Summer Bank
+ * Holiday, Christmas Day, and Boxing Day. LSE is closed on all of these,
+ * including the one-off Jubilee bank holidays, so the full list is shared
+ * verbatim — only {@code XLON} adds the Christmas Eve/New Year's Eve early
+ * closes on top.
+ *
+ * <p>{@link #newYearsDay()}, {@link #christmasDay()}, and {@link #boxingDay()}
+ * are exposed individually because {@code UKDateRolls.fixedHolidayRoll}
+ * requires direct references to these three holidays to compute its
+ * substitution logic.
+ */
+class UkHolidays {
+
+    private UkHolidays() {}
+
+    static Holiday newYearsDay() {
+        return Holiday.builder()
+                .name("New Year's Day")
+                .description("First day of new year in the Common Era (CE)")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.JANUARY, 1)
+                .build();
+    }
+
+    static Holiday christmasDay() {
+        return Holiday.builder()
+                .name("Christmas Day")
+                .description("Commemoration of the birth of Jesus Christ")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 25)
+                .build();
+    }
+
+    static Holiday boxingDay() {
+        return Holiday.builder()
+                .name("Boxing Day")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 26)
+                .build();
+    }
+
+    static List<Holiday> baseHolidays() {
+        final EasterObservance easter = new WesternEaster();
+
+        return List.of(
+            newYearsDay(),
+            Holiday.builder()
+                    .name("Good Friday")
+                    .description("Commemoration of the crucifixion of Jesus Christ")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new GoodFriday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Monday")
+                    .description("Day after Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EasterMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Early May Bank Holiday")
+                    .description("Early May bank holiday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EarlyMayBankHoliday())
+                    .build(),
+            Holiday.builder()
+                    .name("Spring Bank Holiday")
+                    .description("Late May bank holiday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new SpringBankHoliday())
+                    .build(),
+            Holiday.builder()
+                    .name("Silver Jubilee Bank Holiday")
+                    .description("Silver Jubilee of Queen Elizabeth II")
+                    .type(Holiday.Type.SPECIAL_ANNIVERSARY)
+                    .rollable(false)
+                    .anniversaryDate(LocalDate.of(1977, Month.JUNE, 7))
+                    .build(),
+            Holiday.builder()
+                    .name("Golden Jubilee Bank Holiday")
+                    .description("Golden Jubilee of Queen Elizabeth II")
+                    .type(Holiday.Type.SPECIAL_ANNIVERSARY)
+                    .rollable(false)
+                    .anniversaryDate(LocalDate.of(2002, Month.JUNE, 3))
+                    .build(),
+            Holiday.builder()
+                    .name("Diamond Jubilee Bank Holiday")
+                    .description("Diamond Jubilee of Queen Elizabeth II")
+                    .type(Holiday.Type.SPECIAL_ANNIVERSARY)
+                    .rollable(false)
+                    .anniversaryDate(LocalDate.of(2012, Month.JUNE, 5))
+                    .build(),
+            Holiday.builder()
+                    .name("Platinum Jubilee Bank Holiday")
+                    .description("Platinum Jubilee of Queen Elizabeth II")
+                    .type(Holiday.Type.SPECIAL_ANNIVERSARY)
+                    .rollable(false)
+                    .anniversaryDate(LocalDate.of(2022, Month.JUNE, 3))
+                    .build(),
+            Holiday.builder()
+                    .name("Summer Bank Holiday")
+                    .description("Summer bank holiday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new SummerBankHoliday())
+                    .build(),
+            christmasDay(),
+            boxingDay()
+        );
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -11,3 +11,4 @@ org.holiday.calendar.impl.HolidayCalendarServiceGBP
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS
 org.holiday.calendar.impl.HolidayCalendarServiceUSD
+org.holiday.calendar.impl.HolidayCalendarServiceXLON

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXLONEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXLONEarlyCloseTest.java
@@ -38,10 +38,10 @@ import java.util.stream.Collectors;
 import static org.testng.Assert.*;
 
 /**
- * Tests for the {@code UK} calendar's early-close (LSE half-day closure)
+ * Tests for the {@code XLON} calendar's early-close (LSE half-day closure)
  * holidays: Christmas Eve and New Year's Eve.
  */
-public class HolidayCalendarServiceUKEarlyCloseTest {
+public class HolidayCalendarServiceXLONEarlyCloseTest {
 
     private static final int EARLY_CLOSE_COUNT = 2;
     // 8 full-day holidays apply in 2025: the 4 Jubilee SPECIAL_ANNIVERSARY
@@ -50,7 +50,7 @@ public class HolidayCalendarServiceUKEarlyCloseTest {
     private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 30);
     private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/London");
 
-    private final HolidayCalendarServiceUK service = new HolidayCalendarServiceUK();
+    private final HolidayCalendarServiceXLON service = new HolidayCalendarServiceXLON();
 
     // -------------------------------------------------------------------------
     // Count

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXLONTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXLONTest.java
@@ -1,0 +1,54 @@
+package org.holiday.calendar.impl;
+
+import org.testng.annotations.DataProvider;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+
+/**
+ * Fixtures mirror {@link HolidayCalendarServiceUKTest} — {@code XLON} shares
+ * the exact same holiday set and {@code UKDateRolls.fixedHolidayRoll}
+ * behavior as {@code UK}, differing only by the addition of the Christmas
+ * Eve/New Year's Eve early closes (see {@link HolidayCalendarServiceXLONEarlyCloseTest}).
+ */
+public class HolidayCalendarServiceXLONTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "XLON";
+
+    public HolidayCalendarServiceXLONTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        final Object[] summerBankHoliday = {"Summer Bank Holiday"};
+        final Object[] boxingDay = {"Boxing Day"};
+        return Arrays.asList(summerBankHoliday, boxingDay).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        final Object[] newYearsDay22 = {2022, "New Year's Day", LocalDate.of(2022, Month.JANUARY, 3)};
+        final Object[] newYearsDay23 = {2023, "New Year's Day", LocalDate.of(2023, Month.JANUARY, 2)};
+        final Object[] christmas18 = {2018, "Christmas Day", LocalDate.of(2018, Month.DECEMBER, 25)};
+        final Object[] christmas19 = {2019, "Christmas Day", LocalDate.of(2019, Month.DECEMBER, 25)};
+        final Object[] christmas20 = {2020, "Christmas Day", LocalDate.of(2020, Month.DECEMBER, 25)};
+        final Object[] christmas21 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 27)};
+        final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 27)};
+        final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        final Object[] boxingDay18 = {2018, "Boxing Day", LocalDate.of(2018, Month.DECEMBER, 26)};
+        final Object[] boxingDay19 = {2019, "Boxing Day", LocalDate.of(2019, Month.DECEMBER, 26)};
+        final Object[] boxingDay20 = {2020, "Boxing Day", LocalDate.of(2020, Month.DECEMBER, 28)};
+        final Object[] boxingDay21 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 28)};
+        final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        return Arrays.asList(newYearsDay22, newYearsDay23,
+                             christmas18, christmas19, christmas20, christmas21, christmas22, christmas23,
+                             boxingDay18, boxingDay19, boxingDay20, boxingDay21, boxingDay22, boxingDay23).listIterator();
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -89,7 +89,8 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"TRY"},
                 new Object[]{"UK"},
                 new Object[]{"US"},
-                new Object[]{"USD"}
+                new Object[]{"USD"},
+                new Object[]{"XLON"}
         ).iterator();
     }
 
@@ -213,44 +214,56 @@ public class HolidayCalendar30YearIT {
     }
 
     // =========================================================================
-    // 6. UK EARLY CLOSES (LSE Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // 6. XLON EARLY CLOSES (LSE Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
     // =========================================================================
 
     // The shift-to-preceding-Friday rule always yields a date (never suppressed),
     // so the count is deterministic: 2 holidays/year * 30 years.
-    private static final int EXPECTED_UK_EARLY_CLOSES = 2 * RANGE_SIZE;
+    private static final int EXPECTED_XLON_EARLY_CLOSES = 2 * RANGE_SIZE;
 
-    @Test(description = "UK calculateEarlyCloses across 2026-2055 must yield exactly 60 entries, "
+    @Test(description = "XLON calculateEarlyCloses across 2026-2055 must yield exactly 60 entries, "
             + "no nulls, and be chronologically ordered")
-    public void testUKEarlyClosesOver30Years() {
-        HolidayCalendar calendar = new HolidayCalendarFactory().create("UK");
+    public void testXLONEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XLON");
 
         List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
         for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
             List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
-            assertNotNull(earlyCloses, "UK: calculateEarlyCloses(" + year + ") must not be null");
+            assertNotNull(earlyCloses, "XLON: calculateEarlyCloses(" + year + ") must not be null");
             assertEquals(earlyCloses.size(), 2,
-                    "UK: expected exactly 2 early closes in " + year + ", got " + earlyCloses.size());
+                    "XLON: expected exactly 2 early closes in " + year + ", got " + earlyCloses.size());
             allEarlyCloses.addAll(earlyCloses);
         }
 
-        assertEquals(allEarlyCloses.size(), EXPECTED_UK_EARLY_CLOSES,
-                "UK: expected exactly " + EXPECTED_UK_EARLY_CLOSES + " early-close entries over "
+        assertEquals(allEarlyCloses.size(), EXPECTED_XLON_EARLY_CLOSES,
+                "XLON: expected exactly " + EXPECTED_XLON_EARLY_CLOSES + " early-close entries over "
                         + RANGE_SIZE + " years, got " + allEarlyCloses.size());
 
         for (int i = 0; i < allEarlyCloses.size(); i++) {
             HolidayDate hd = allEarlyCloses.get(i);
-            assertNotNull(hd, "UK: early-close entry at index " + i + " must not be null");
-            assertNotNull(hd.holiday(), "UK: early-close holiday at index " + i + " must not be null");
-            assertNotNull(hd.date(), "UK: early-close date at index " + i + " must not be null");
+            assertNotNull(hd, "XLON: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "XLON: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "XLON: early-close date at index " + i + " must not be null");
         }
 
         for (int i = 1; i < allEarlyCloses.size(); i++) {
             LocalDate prev = allEarlyCloses.get(i - 1).date();
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
-                    "UK: early-close dates out of order at index " + i
+                    "XLON: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
+        }
+    }
+
+    @Test(description = "UK (national) calculateEarlyCloses must be empty across 2026-2055 "
+            + "— early closes are LSE-only market convention, moved to XLON")
+    public void testUKHasNoEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("UK");
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "UK: calculateEarlyCloses(" + year + ") must not be null");
+            assertTrue(earlyCloses.isEmpty(),
+                    "UK " + year + ": national calendar must have zero early closes, got " + earlyCloses.size());
         }
     }
 


### PR DESCRIPTION
### Title of the PR

Split UK national holidays from LSE (XLON) market calendar

**Description**

- `HolidayCalendarServiceUK` was documented as "United Kingdom National Holidays" but included 2 LSE-specific `EarlyCloseHoliday` entries (Christmas Eve, New Year's Eve — both 12:30 `Europe/London`, shifting to the preceding Friday on a weekend).
- Extracts a new `HolidayCalendarServiceXLON` (ISO 10383 Market Identifier Code for LSE) as the market calendar, carrying forward both early closes and all 4 one-off Jubilee `SpecialAnniversary` bank holidays (LSE is closed on those too, so the duplication is intentional).
- Slims `HolidayCalendarServiceUK` down to 12 pure national holidays (removes both early closes); `UK.hasEarlyCloses()` now correctly returns `false`.
- **Proactive duplication-gate fix**: extracts a shared package-private `UkHolidays` factory (mirroring the existing `CanadaHolidays`/`UaeHolidays` pattern) for the 12 holidays common to both `UK` and `XLON`, since nearly the entire holiday set is shared between the two. This was applied from the start based on the lesson from #235's `XTSE` split, which tripped SonarCloud's new-code duplication gate (11.2% vs 3% threshold) before being fixed in a follow-up commit.
- Registers `XLON` in `module-info.java` and `META-INF/services`.
- Renames `HolidayCalendarServiceUKEarlyCloseTest` → `HolidayCalendarServiceXLONEarlyCloseTest` (behavior moved wholesale, not duplicated); adds `HolidayCalendarServiceXLONTest` (mirrors UK's existing fixtures, since the DateRoll and holiday content are identical).
- Updates `HolidayCalendar30YearIT`: adds `XLON` to the calendar-code list, renames `testUKEarlyClosesOver30Years` → `testXLONEarlyClosesOver30Years`, and adds `testUKHasNoEarlyClosesOver30Years`.

**Related Issue**

- [#236](https://github.com/holiday-calendar/holiday-calendar-java/issues/236) (sub-issue of [#231](https://github.com/holiday-calendar/holiday-calendar-java/issues/231), itself a sub-issue of [#229](https://github.com/holiday-calendar/holiday-calendar-java/issues/229))

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [x] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed