### PR TITLE
Split AU national holidays from ASX (XASX) market calendar

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -51,6 +51,7 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
         org.holiday.calendar.impl.HolidayCalendarServiceUS,
         org.holiday.calendar.impl.HolidayCalendarServiceUSD,
+        org.holiday.calendar.impl.HolidayCalendarServiceXASX,
         org.holiday.calendar.impl.HolidayCalendarServiceXLON,
         org.holiday.calendar.impl.HolidayCalendarServiceXNYS,
         org.holiday.calendar.impl.HolidayCalendarServiceXTSE;

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/AuHolidays.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/AuHolidays.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.au.KingsBirthday;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the 9 holidays common to both the
+ * Australia national ({@code AU}) and Australian Securities Exchange
+ * ({@code XASX}) calendars: New Year's Day, Australia Day, Good Friday,
+ * Easter Saturday, Easter Monday, ANZAC Day, King's Birthday, Christmas Day,
+ * and Boxing Day. ASX is closed on all of these, so the full list is shared
+ * verbatim — only {@code XASX} adds the Christmas Eve/New Year's Eve early
+ * closes on top.
+ *
+ * <p>Easter Saturday is not observed in Western Australia or Tasmania, and
+ * King's Birthday uses different dates in Queensland (1st Monday in October)
+ * and Western Australia (a late-September date) than the 2nd-Monday-in-June
+ * convention used elsewhere — both are genuine, state-backed public holidays
+ * somewhere in the country, so both are retained here with these caveats.
+ */
+class AuHolidays {
+
+    private AuHolidays() {}
+
+    static List<Holiday> baseHolidays() {
+        final EasterObservance easter = new WesternEaster();
+        final GoodFriday goodFridayObs = new GoodFriday(easter);
+
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Australia Day")
+                    .description("Australia Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JANUARY, 26)
+                    .build(),
+            Holiday.builder()
+                    .name("Good Friday")
+                    .description("Friday before Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(goodFridayObs)
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Saturday")
+                    .description("Day after Good Friday; not observed in Western Australia or Tasmania")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(year -> goodFridayObs.apply(year).plusDays(1))
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Monday")
+                    .description("Monday after Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EasterMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("ANZAC Day")
+                    .description("ANZAC Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.APRIL, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("King's Birthday")
+                    .description("King's Birthday (2nd Monday in June); Queensland uses the 1st "
+                                 + "Monday in October and Western Australia uses a late-September date")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new KingsBirthday())
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Celebration of traditional Christmas holiday")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Boxing Day")
+                    .description("Day after Christmas")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 26)
+                    .build()
+        );
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceAU.java
@@ -19,32 +19,24 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
-import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.au.ChristmasEveEarlyClose;
-import org.holiday.calendar.observance.au.KingsBirthday;
-import org.holiday.calendar.observance.au.NewYearsEveEarlyClose;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.GoodFriday;
-import org.holiday.calendar.observance.christian.WesternEaster;
-
-import java.time.LocalTime;
-import java.time.Month;
-import java.time.ZoneId;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
 /**
- * Service for provision of Australia (ASX) holiday calendar.
+ * Service for provision of the Australia national public holiday calendar.
+ * Distinct from {@link HolidayCalendarServiceXASX}, the Australian
+ * Securities Exchange (ASX) trading calendar: this calendar contains only
+ * the 9 national public holidays, and never includes early-close (half-day)
+ * trading sessions.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
 
     private static final String CODE = "AU";
-    private static final String NAME = "Australian Securities Exchange (ASX) Holidays";
+    private static final String NAME = "Australia National Holidays";
 
     public HolidayCalendarServiceAU() {
         super(CODE, NAME);
@@ -52,109 +44,12 @@ public class HolidayCalendarServiceAU extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-        final GoodFriday goodFridayObs = new GoodFriday(easter);
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday australiaDay = Holiday.builder()
-                .name("Australia Day")
-                .description("Australia Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 26)
-                .build();
-        final Holiday goodFriday = Holiday.builder()
-                .name("Good Friday")
-                .description("Friday before Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(goodFridayObs)
-                .build();
-        final Holiday easterSaturday = Holiday.builder()
-                .name("Easter Saturday")
-                .description("Day after Good Friday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(year -> goodFridayObs.apply(year).plusDays(1))
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Monday after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday anzacDay = Holiday.builder()
-                .name("ANZAC Day")
-                .description("ANZAC Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.APRIL, 25)
-                .build();
-        final Holiday kingsBirthday = Holiday.builder()
-                .name("King's Birthday")
-                .description("King's Birthday (ASX; 2nd Monday in June)")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new KingsBirthday())
-                .build();
-        final Holiday christmasDay = Holiday.builder()
-                .name("Christmas Day")
-                .description("Celebration of traditional Christmas holiday")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 25)
-                .build();
-        final Holiday boxingDay = Holiday.builder()
-                .name("Boxing Day")
-                .description("Day after Christmas")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 26)
-                .build();
-        final Holiday christmasEveEarlyClose = Holiday.builder()
-                .name("Christmas Eve")
-                .description("ASX half-day close; suppressed entirely (not shifted) " +
-                             "when December 24 falls on a Saturday or Sunday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new ChristmasEveEarlyClose())
-                .closeTime(LocalTime.of(14, 10))
-                .zoneId(ZoneId.of("Australia/Sydney"))
-                .build();
-        final Holiday newYearsEveEarlyClose = Holiday.builder()
-                .name("New Year's Eve")
-                .description("ASX half-day close; suppressed entirely (not shifted) " +
-                             "when December 31 falls on a Saturday or Sunday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new NewYearsEveEarlyClose())
-                .closeTime(LocalTime.of(14, 10))
-                .zoneId(ZoneId.of("Australia/Sydney"))
-                .build();
-
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.previousFridayOrFollowingMonday())
                 .weekendDays(STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(australiaDay)
-                .holiday(goodFriday)
-                .holiday(easterSaturday)
-                .holiday(easterMonday)
-                .holiday(anzacDay)
-                .holiday(kingsBirthday)
-                .holiday(christmasDay)
-                .holiday(boxingDay)
-                .holiday(christmasEveEarlyClose)
-                .holiday(newYearsEveEarlyClose)
+                .holidays(AuHolidays.baseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXASX.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXASX.java
@@ -1,0 +1,90 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.au.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.au.NewYearsEveEarlyClose;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of Australia (ASX) holiday calendar. Distinct from
+ * {@link HolidayCalendarServiceAU}, the Australia national public holiday
+ * calendar: this calendar additionally includes two {@code EARLY_CLOSE}
+ * holidays representing ASX's Christmas Eve and New Year's Eve half-day
+ * closes. ASX is closed on every public holiday observed by {@code AU}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceXASX extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "XASX";
+    private static final String NAME = "Australia (ASX) Holidays";
+    private static final ZoneId ASX_ZONE = ZoneId.of("Australia/Sydney");
+
+    public HolidayCalendarServiceXASX() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("ASX half-day close; suppressed entirely (not shifted) " +
+                             "when December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(14, 10))
+                .zoneId(ASX_ZONE)
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("ASX half-day close; suppressed entirely (not shifted) " +
+                             "when December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(14, 10))
+                .zoneId(ASX_ZONE)
+                .build();
+
+        final List<Holiday> holidays = new ArrayList<>(AuHolidays.baseHolidays());
+        holidays.add(christmasEveEarlyClose);
+        holidays.add(newYearsEveEarlyClose);
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.previousFridayOrFollowingMonday())
+                .weekendDays(STANDARD_WEEKEND)
+                .holidays(holidays)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -11,6 +11,7 @@ org.holiday.calendar.impl.HolidayCalendarServiceGBP
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS
 org.holiday.calendar.impl.HolidayCalendarServiceUSD
+org.holiday.calendar.impl.HolidayCalendarServiceXASX
 org.holiday.calendar.impl.HolidayCalendarServiceXLON
 org.holiday.calendar.impl.HolidayCalendarServiceXNYS
 org.holiday.calendar.impl.HolidayCalendarServiceXTSE

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXASXEarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXASXEarlyCloseTest.java
@@ -40,14 +40,14 @@ import java.util.stream.Collectors;
 import static org.testng.Assert.*;
 
 /**
- * Tests for the {@code AU} calendar's early-close (ASX half-day closure)
+ * Tests for the {@code XASX} calendar's early-close (ASX half-day closure)
  * holidays: Christmas Eve and New Year's Eve. Because December 24 and
  * December 31 are always exactly 7 days apart, they always share the same
  * day-of-week within a given year — both early closes are always present
  * together or absent together, never one without the other, same shape as
  * FR.
  *
- * <p>AU's Christmas Day and New Year's Day are both {@code rollable(true)}
+ * <p>XASX's Christmas Day and New Year's Day are both {@code rollable(true)}
  * under {@code previousFridayOrFollowingMonday} (the same roll rule FR
  * uses), producing the same two genuine date collisions with the early
  * closes that FR's test suite covers, both verified explicitly below:
@@ -63,23 +63,23 @@ import static org.testng.Assert.*;
  *     same-year intersection check alone.</li>
  * </ul>
  */
-public class HolidayCalendarServiceAUEarlyCloseTest {
+public class HolidayCalendarServiceXASXEarlyCloseTest {
 
     private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(14, 10);
     private static final ZoneId EXPECTED_ZONE = ZoneId.of("Australia/Sydney");
 
-    // 9 full-day holidays registered in HolidayCalendarServiceAU; the two Eve
+    // 9 full-day holidays registered in HolidayCalendarServiceXASX; the two Eve
     // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 9.
     private static final int FULL_DAY_HOLIDAY_COUNT = 9;
 
-    private final HolidayCalendarServiceAU service = new HolidayCalendarServiceAU();
+    private final HolidayCalendarServiceXASX service = new HolidayCalendarServiceXASX();
 
     // -------------------------------------------------------------------------
     // Count / presence per year (verified 2020-2029 ASX cycle)
     // -------------------------------------------------------------------------
 
-    @DataProvider(name = "auEarlyCloseFixture")
-    public Iterator<Object[]> auEarlyCloseFixture() {
+    @DataProvider(name = "xasxEarlyCloseFixture")
+    public Iterator<Object[]> xasxEarlyCloseFixture() {
         List<Object[]> data = Arrays.asList(
                 new Object[]{2020, true},
                 new Object[]{2021, true},
@@ -95,23 +95,23 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
         return data.iterator();
     }
 
-    @Test(dataProvider = "auEarlyCloseFixture")
+    @Test(dataProvider = "xasxEarlyCloseFixture")
     public void testEarlyCloseCountForYear(int year, boolean present) {
         List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
         assertNotNull(earlyCloses);
-        assertEquals(earlyCloses.size(), present ? 2 : 0, "AU " + year + ": unexpected early-close count");
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "XASX " + year + ": unexpected early-close count");
     }
 
-    @Test(dataProvider = "auEarlyCloseFixture")
+    @Test(dataProvider = "xasxEarlyCloseFixture")
     public void testChristmasEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
-                "AU " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+                "XASX " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
     }
 
-    @Test(dataProvider = "auEarlyCloseFixture")
+    @Test(dataProvider = "xasxEarlyCloseFixture")
     public void testNewYearsEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
-                "AU " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+                "XASX " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
     }
 
     private Set<String> earlyCloseNames(int year) {
@@ -120,10 +120,10 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
                 .collect(Collectors.toSet());
     }
 
-    @Test(dataProvider = "auEarlyCloseFixture")
+    @Test(dataProvider = "xasxEarlyCloseFixture")
     public void testEarlyCloseCountAlwaysZeroOrTwo(int year, boolean present) {
         int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
-        assertNotEquals(count, 1, "AU " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+        assertNotEquals(count, 1, "XASX " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
     }
 
     // -------------------------------------------------------------------------
@@ -188,7 +188,7 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
         for (int year : List.of(2024, 2027)) {
             List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
             assertNotNull(holidays);
-            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "AU " + year + ": unexpected full-day holiday count");
+            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "XASX " + year + ": unexpected full-day holiday count");
         }
     }
 
@@ -198,7 +198,7 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
     // onto Christmas Eve
     // -------------------------------------------------------------------------
 
-    @Test(dataProvider = "auEarlyCloseFixture")
+    @Test(dataProvider = "xasxEarlyCloseFixture")
     public void testCrossListDateOverlapOnlyOnKnownChristmasDayRollYears(int year, boolean present) {
         HolidayCalendar calendar = service.getHolidayCalendar();
         Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
@@ -215,9 +215,9 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
                 DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
         if (isChristmasDaySaturdayRollYear) {
             assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
-                    "AU " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+                    "XASX " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
         } else {
-            assertTrue(intersection.isEmpty(), "AU " + year + ": unexpected cross-list date collision: " + intersection);
+            assertTrue(intersection.isEmpty(), "XASX " + year + ": unexpected cross-list date collision: " + intersection);
         }
     }
 
@@ -228,7 +228,7 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
 
     @Test
     public void testChristmasDayAndChristmasEveCoexistOn24Dec2027() {
-        // December 25, 2027 is a Saturday and rolls to Friday December 24 under AU's
+        // December 25, 2027 is a Saturday and rolls to Friday December 24 under XASX's
         // previousFridayOrFollowingMonday roll rule -- the same date the non-rolling
         // Christmas Eve EARLY_CLOSE independently occupies (December 24, 2027 is a
         // Friday, a valid early-close weekday). Both facts are true simultaneously and
@@ -255,7 +255,7 @@ public class HolidayCalendarServiceAUEarlyCloseTest {
     @Test
     public void testNewYearsDayAndNewYearsEveCoexistOn31Dec2027() {
         // January 1, 2028 is a Saturday and rolls back to Friday December 31, 2027
-        // under AU's previousFridayOrFollowingMonday roll rule -- the same date the
+        // under XASX's previousFridayOrFollowingMonday roll rule -- the same date the
         // non-rolling New Year's Eve EARLY_CLOSE independently occupies in 2027
         // (December 31, 2027 is a Friday, a valid early-close weekday). This is a
         // genuine same-date coexistence spanning two different year arguments:

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXASXTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXASXTest.java
@@ -18,28 +18,18 @@
 
 package org.holiday.calendar.impl;
 
-import org.holiday.calendar.HolidayCalendar;
-import org.holiday.calendar.HolidayCalendarService;
-import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
+public class HolidayCalendarServiceXASXTest extends AbstractHolidayCalendarServiceTest {
 
-public class HolidayCalendarServiceAUTest extends AbstractHolidayCalendarServiceTest {
+    static final String CODE = "XASX";
 
-    static final String CODE = "AU";
-
-    public HolidayCalendarServiceAUTest() {
+    public HolidayCalendarServiceXASXTest() {
         super(CODE);
     }
 
@@ -48,9 +38,9 @@ public class HolidayCalendarServiceAUTest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] australiaDay = {"Australia Day"};
         final Object[] anzacDay = {"ANZAC Day"};
-        final Object[] easterSaturday = {"Easter Saturday"};
-        final Object[] kingsBirthday = {"King's Birthday"};
-        return Arrays.asList(australiaDay, anzacDay, easterSaturday, kingsBirthday).listIterator();
+        final Object[] christmasEve = {"Christmas Eve"};
+        final Object[] newYearsEve = {"New Year's Eve"};
+        return Arrays.asList(australiaDay, anzacDay, christmasEve, newYearsEve).listIterator();
     }
 
     @DataProvider
@@ -75,39 +65,6 @@ public class HolidayCalendarServiceAUTest extends AbstractHolidayCalendarService
         return Arrays.asList(christmas21, christmas22, christmas23,
                              boxingDay21, boxingDay22, boxingDay23,
                              australiaDay20, australiaDay23).listIterator();
-    }
-
-    @Test
-    public void testEarlyCloseHolidaysAbsentFromCalculate() {
-        HolidayCalendarService service = factory.getService(CODE);
-        for (int year : List.of(2021, 2023, 2024, 2025)) {
-            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
-            Set<String> actualNames = holidays.stream()
-                    .map(hd -> hd.getHoliday().getName())
-                    .collect(Collectors.toSet());
-            assertFalse(actualNames.contains("Christmas Eve"),
-                    "Christmas Eve must not appear in calculate(" + year + ") — moved to XASX");
-            assertFalse(actualNames.contains("New Year's Eve"),
-                    "New Year's Eve must not appear in calculate(" + year + ") — moved to XASX");
-        }
-    }
-
-    @Test
-    public void testAuHasNoEarlyCloses() {
-        HolidayCalendarService service = factory.getService(CODE);
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        assertFalse(calendar.hasEarlyCloses(), "AU: national calendar must have zero early closes");
-    }
-
-    @Test
-    public void testEasterSaturdayAndKingsBirthdayPresentInCalculate() {
-        HolidayCalendarService service = factory.getService(CODE);
-        List<HolidayDate> holidays = service.getHolidayCalendar().calculate(2024);
-        Set<String> actualNames = holidays.stream()
-                .map(hd -> hd.getHoliday().getName())
-                .collect(Collectors.toSet());
-        assertTrue(actualNames.contains("Easter Saturday"), "AU: Easter Saturday must remain in the national calendar");
-        assertTrue(actualNames.contains("King's Birthday"), "AU: King's Birthday must remain in the national calendar");
     }
 
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -90,6 +90,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"UK"},
                 new Object[]{"US"},
                 new Object[]{"USD"},
+                new Object[]{"XASX"},
                 new Object[]{"XLON"},
                 new Object[]{"XNYS"},
                 new Object[]{"XTSE"}
@@ -594,7 +595,7 @@ public class HolidayCalendar30YearIT {
     }
 
     // =========================================================================
-    // 12. AU EARLY CLOSES (ASX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // 12. XASX EARLY CLOSES (ASX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
     // =========================================================================
 
     // Both ASX Eve early closes are suppressed (not shifted) when their date falls on a
@@ -603,27 +604,27 @@ public class HolidayCalendar30YearIT {
     // presence is re-derived from December 24's day-of-week rule for every year rather than
     // hand-fixtured.
     //
-    // AU's Christmas Day and New Year's Day are both rollable under
+    // XASX's Christmas Day and New Year's Day are both rollable under
     // previousFridayOrFollowingMonday, same as FR, so this section additionally verifies the
     // two genuine cross-list date collisions this produces: Christmas Day rolling back onto
     // December 24 in Dec-25-Saturday years, and New Year's Day rolling back onto the prior
     // December 31 in Jan-1-Saturday years (a year-boundary-crossing collision that a same-year
     // intersection check alone would miss).
-    @Test(description = "AU calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+    @Test(description = "XASX calculateEarlyCloses across 2026-2055: count always in {0,2}, "
             + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
             + "and always co-occur, no nulls, chronological order, and known Christmas Day/New Year's "
             + "Day roll collisions are accounted for")
-    public void testAUEarlyClosesOver30Years() {
-        HolidayCalendar calendar = new HolidayCalendarFactory().create("AU");
+    public void testXASXEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XASX");
 
         List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
         for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
             List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
-            assertNotNull(earlyCloses, "AU: calculateEarlyCloses(" + year + ") must not be null");
+            assertNotNull(earlyCloses, "XASX: calculateEarlyCloses(" + year + ") must not be null");
 
             int count = earlyCloses.size();
             assertTrue(count == 0 || count == 2,
-                    "AU " + year + ": expected count in {0,2}, got " + count);
+                    "XASX " + year + ": expected count in {0,2}, got " + count);
 
             DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
             boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
@@ -632,9 +633,9 @@ public class HolidayCalendar30YearIT {
                     .map(hd -> hd.holiday().getName())
                     .collect(Collectors.toSet());
             assertEquals(names.contains("Christmas Eve"), expected,
-                    "AU " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+                    "XASX " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
             assertEquals(names.contains("New Year's Eve"), expected,
-                    "AU " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+                    "XASX " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
 
             // Cross-list date collision: empty in ordinary years, exactly one date
             // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
@@ -649,9 +650,9 @@ public class HolidayCalendar30YearIT {
                     DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
             if (isChristmasDaySaturdayRollYear) {
                 assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
-                        "AU " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+                        "XASX " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
             } else {
-                assertTrue(intersection.isEmpty(), "AU " + year + ": unexpected cross-list date collision: " + intersection);
+                assertTrue(intersection.isEmpty(), "XASX " + year + ": unexpected cross-list date collision: " + intersection);
             }
 
             // Cross-year collision: New Year's Day rolling back onto this year's December 31
@@ -664,9 +665,9 @@ public class HolidayCalendar30YearIT {
                         .anyMatch(hd -> "New Year's Day".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
                 boolean newYearsEvePresent = names.contains("New Year's Eve");
                 assertTrue(newYearsDayPresent,
-                        "AU " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
+                        "XASX " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
                 assertTrue(newYearsEvePresent,
-                        "AU " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
+                        "XASX " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
             }
 
             allEarlyCloses.addAll(earlyCloses);
@@ -674,16 +675,16 @@ public class HolidayCalendar30YearIT {
 
         for (int i = 0; i < allEarlyCloses.size(); i++) {
             HolidayDate hd = allEarlyCloses.get(i);
-            assertNotNull(hd, "AU: early-close entry at index " + i + " must not be null");
-            assertNotNull(hd.holiday(), "AU: early-close holiday at index " + i + " must not be null");
-            assertNotNull(hd.date(), "AU: early-close date at index " + i + " must not be null");
+            assertNotNull(hd, "XASX: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "XASX: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "XASX: early-close date at index " + i + " must not be null");
         }
 
         for (int i = 1; i < allEarlyCloses.size(); i++) {
             LocalDate prev = allEarlyCloses.get(i - 1).date();
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
-                    "AU: early-close dates out of order at index " + i
+                    "XASX: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
         }
     }


### PR DESCRIPTION
### Title of the PR

Split AU national holidays from ASX (XASX) market calendar

**Description**

- Sub-issue of #231 (itself a sub-issue of #229). Introduces `HolidayCalendarServiceXASX` as a verbatim copy of the former `HolidayCalendarServiceAU` behavior (9 shared national holidays plus the Christmas Eve/New Year's Eve ASX early closes), while `HolidayCalendarServiceAU` is stripped down to the 9 national public holidays and no longer includes early closes.
- Easter Saturday and King's Birthday remain in both calendars — both are genuine, state-backed public holidays somewhere in Australia despite non-uniform observance (Easter Saturday not observed in WA/Tasmania; King's Birthday uses different dates in QLD/WA) — with Javadoc caveats documenting the divergence.
- Shared holiday definitions extracted into a new package-private `AuHolidays` factory, consumed by both `HolidayCalendarServiceAU` and `HolidayCalendarServiceXASX`.
- Registered `HolidayCalendarServiceXASX` in `module-info.java` and `META-INF/services/org.holiday.calendar.HolidayCalendarService`.
- Renamed `HolidayCalendarServiceAUEarlyCloseTest` → `HolidayCalendarServiceXASXEarlyCloseTest`, added `HolidayCalendarServiceXASXTest`, added early-close-absence and Easter Saturday/King's Birthday-presence assertions to `HolidayCalendarServiceAUTest`, and updated `HolidayCalendar30YearIT` (added `XASX` to the code list, renamed `testAUEarlyClosesOver30Years` → `testXASXEarlyClosesOver30Years`).
- README calendar table updates are tracked separately in #230 and are intentionally out of scope here, consistent with the prior UK/XLON and CA/XTSE splits.

**Related Issue**

- [#237](https://github.com/holiday-calendar/holiday-calendar-java/issues/237)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed (README table deferred to #230)
- [ ] Screenshots or additional notes added, if needed
