### PR TITLE
Split FR national holidays from Euronext Paris (XPAR) market calendar; add missing Good Friday

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -53,5 +53,6 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceUSD,
         org.holiday.calendar.impl.HolidayCalendarServiceXLON,
         org.holiday.calendar.impl.HolidayCalendarServiceXNYS,
+        org.holiday.calendar.impl.HolidayCalendarServiceXPAR,
         org.holiday.calendar.impl.HolidayCalendarServiceXTSE;
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/FrHolidays.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/FrHolidays.java
@@ -1,0 +1,128 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.christian.AscensionDay;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.christian.WhitMonday;
+
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the 11 holidays common to both the
+ * France national ({@code FR}) and Euronext Paris ({@code XPAR}) calendars:
+ * New Year's Day, Easter Monday, Labour Day, Victory in Europe Day,
+ * Ascension Day, Whit Monday, Bastille Day, Assumption Day, All Saints'
+ * Day, Armistice Day, and Christmas Day. Euronext Paris is closed on all of
+ * these, so the full list is shared verbatim — only {@code XPAR} adds Good
+ * Friday and the Christmas Eve/New Year's Eve early closes on top.
+ */
+class FrHolidays {
+
+    private FrHolidays() {}
+
+    static List<Holiday> baseHolidays() {
+        final EasterObservance easter = new WesternEaster();
+
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Monday")
+                    .description("Monday after Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EasterMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Victory in Europe Day")
+                    .description("Victory in Europe Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.MAY, 8)
+                    .build(),
+            Holiday.builder()
+                    .name("Ascension Day")
+                    .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new AscensionDay(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Whit Monday")
+                    .description("Monday after Whit Sunday (Pentecost)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new WhitMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Bastille Day")
+                    .description("Bastille Day (French National Day)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JULY, 14)
+                    .build(),
+            Holiday.builder()
+                    .name("Assumption Day")
+                    .description("Assumption of the Blessed Virgin Mary")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.AUGUST, 15)
+                    .build(),
+            Holiday.builder()
+                    .name("All Saints' Day")
+                    .description("All Saints' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.NOVEMBER, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Armistice Day")
+                    .description("Armistice Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.NOVEMBER, 11)
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Celebration of traditional Christmas holiday")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build()
+        );
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceFR.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceFR.java
@@ -19,32 +19,25 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
-import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.christian.AscensionDay;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.WesternEaster;
-import org.holiday.calendar.observance.christian.WhitMonday;
-import org.holiday.calendar.observance.fr.ChristmasEveEarlyClose;
-import org.holiday.calendar.observance.fr.NewYearsEveEarlyClose;
-
-import java.time.LocalTime;
-import java.time.Month;
-import java.time.ZoneId;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
 /**
- * Service for provision of France (Euronext Paris) holiday calendar.
+ * Service for provision of the France national public holiday calendar
+ * (jours fériés). Distinct from {@link HolidayCalendarServiceXPAR}, the
+ * Euronext Paris trading calendar: this calendar contains only the 11
+ * national public holidays — Good Friday is correctly absent, as it is not
+ * a French national holiday — and never includes early-close (half-day)
+ * trading sessions.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HolidayCalendarServiceFR extends AbstractHolidayCalendarService {
 
     private static final String CODE = "FR";
-    private static final String NAME = "France (Euronext Paris) Holidays";
+    private static final String NAME = "France National Holidays";
 
     public HolidayCalendarServiceFR() {
         super(CODE, NAME);
@@ -52,124 +45,12 @@ public class HolidayCalendarServiceFR extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Monday after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday labourDay = Holiday.builder()
-                .name("Labour Day")
-                .description("International Workers' Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.MAY, 1)
-                .build();
-        final Holiday victoryInEuropeDay = Holiday.builder()
-                .name("Victory in Europe Day")
-                .description("Victory in Europe Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.MAY, 8)
-                .build();
-        final Holiday ascensionDay = Holiday.builder()
-                .name("Ascension Day")
-                .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new AscensionDay(easter))
-                .build();
-        final Holiday whitMonday = Holiday.builder()
-                .name("Whit Monday")
-                .description("Monday after Whit Sunday (Pentecost)")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new WhitMonday(easter))
-                .build();
-        final Holiday bastilleDay = Holiday.builder()
-                .name("Bastille Day")
-                .description("Bastille Day (French National Day)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JULY, 14)
-                .build();
-        final Holiday assumptionDay = Holiday.builder()
-                .name("Assumption Day")
-                .description("Assumption of the Blessed Virgin Mary")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.AUGUST, 15)
-                .build();
-        final Holiday allSaintsDay = Holiday.builder()
-                .name("All Saints' Day")
-                .description("All Saints' Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.NOVEMBER, 1)
-                .build();
-        final Holiday armisticeDay = Holiday.builder()
-                .name("Armistice Day")
-                .description("Armistice Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.NOVEMBER, 11)
-                .build();
-        final Holiday christmasDay = Holiday.builder()
-                .name("Christmas Day")
-                .description("Celebration of traditional Christmas holiday")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 25)
-                .build();
-        final Holiday christmasEveEarlyClose = Holiday.builder()
-                .name("Christmas Eve")
-                .description("Euronext Paris half-day close; suppressed entirely (not shifted) " +
-                             "when December 24 falls on a Saturday or Sunday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new ChristmasEveEarlyClose())
-                .closeTime(LocalTime.of(14, 5))
-                .zoneId(ZoneId.of("Europe/Paris"))
-                .build();
-        final Holiday newYearsEveEarlyClose = Holiday.builder()
-                .name("New Year's Eve")
-                .description("Euronext Paris half-day close; suppressed entirely (not shifted) " +
-                             "when December 31 falls on a Saturday or Sunday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new NewYearsEveEarlyClose())
-                .closeTime(LocalTime.of(14, 5))
-                .zoneId(ZoneId.of("Europe/Paris"))
-                .build();
-
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.previousFridayOrFollowingMonday())
                 .weekendDays(STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(easterMonday)
-                .holiday(labourDay)
-                .holiday(victoryInEuropeDay)
-                .holiday(ascensionDay)
-                .holiday(whitMonday)
-                .holiday(bastilleDay)
-                .holiday(assumptionDay)
-                .holiday(allSaintsDay)
-                .holiday(armisticeDay)
-                .holiday(christmasDay)
-                .holiday(christmasEveEarlyClose)
-                .holiday(newYearsEveEarlyClose)
+                .holidays(FrHolidays.baseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXPAR.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXPAR.java
@@ -1,0 +1,106 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.fr.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.fr.NewYearsEveEarlyClose;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of France (Euronext Paris) holiday calendar.
+ * Distinct from {@link HolidayCalendarServiceFR}, the France national
+ * public holiday calendar: this calendar additionally includes Good
+ * Friday — a confirmed Euronext Paris market closure that is not a French
+ * national holiday — and two {@code EARLY_CLOSE} holidays representing
+ * Euronext Paris's Christmas Eve and New Year's Eve half-day closes.
+ * Euronext Paris is closed on every public holiday observed by {@code FR}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceXPAR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "XPAR";
+    private static final String NAME = "France (Euronext Paris) Holidays";
+    private static final ZoneId EURONEXT_PARIS_ZONE = ZoneId.of("Europe/Paris");
+
+    public HolidayCalendarServiceXPAR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final EasterObservance easter = new WesternEaster();
+
+        final Holiday goodFriday = Holiday.builder()
+                .name("Good Friday")
+                .description("Friday before Easter Sunday; Euronext Paris market closure, "
+                             + "not a French national holiday")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new GoodFriday(easter))
+                .build();
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("Euronext Paris half-day close; suppressed entirely (not shifted) " +
+                             "when December 24 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(14, 5))
+                .zoneId(EURONEXT_PARIS_ZONE)
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("Euronext Paris half-day close; suppressed entirely (not shifted) " +
+                             "when December 31 falls on a Saturday or Sunday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(14, 5))
+                .zoneId(EURONEXT_PARIS_ZONE)
+                .build();
+
+        final List<Holiday> holidays = new ArrayList<>(FrHolidays.baseHolidays());
+        holidays.add(goodFriday);
+        holidays.add(christmasEveEarlyClose);
+        holidays.add(newYearsEveEarlyClose);
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.previousFridayOrFollowingMonday())
+                .weekendDays(STANDARD_WEEKEND)
+                .holidays(holidays)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -13,4 +13,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceUS
 org.holiday.calendar.impl.HolidayCalendarServiceUSD
 org.holiday.calendar.impl.HolidayCalendarServiceXLON
 org.holiday.calendar.impl.HolidayCalendarServiceXNYS
+org.holiday.calendar.impl.HolidayCalendarServiceXPAR
 org.holiday.calendar.impl.HolidayCalendarServiceXTSE

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXPAREarlyCloseTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXPAREarlyCloseTest.java
@@ -40,7 +40,7 @@ import java.util.stream.Collectors;
 import static org.testng.Assert.*;
 
 /**
- * Tests for the {@code FR} calendar's early-close (Euronext Paris half-day
+ * Tests for the {@code XPAR} calendar's early-close (Euronext Paris half-day
  * closure) holidays: Christmas Eve and New Year's Eve. Because December 24
  * and December 31 are always exactly 7 days apart, they always share the
  * same day-of-week within a given year — both early closes are always
@@ -48,8 +48,8 @@ import static org.testng.Assert.*;
  * shape as SG.
  *
  * <p>Unlike CA (Christmas Day {@code rollable(false)}) and SG (no rollable
- * holiday ever lands on Dec 24/31), FR's Christmas Day and New Year's Day are
- * both {@code rollable(true)} under {@code previousFridayOrFollowingMonday}.
+ * holiday ever lands on Dec 24/31), XPAR's Christmas Day and New Year's Day
+ * are both {@code rollable(true)} under {@code previousFridayOrFollowingMonday}.
  * This produces two genuine, independently-verified date collisions with the
  * early closes, both covered explicitly below rather than relying on a naive
  * "always empty intersection" assertion:
@@ -65,23 +65,24 @@ import static org.testng.Assert.*;
  *     same-year intersection check alone.</li>
  * </ul>
  */
-public class HolidayCalendarServiceFREarlyCloseTest {
+public class HolidayCalendarServiceXPAREarlyCloseTest {
 
     private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(14, 5);
     private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/Paris");
 
-    // 11 full-day holidays registered in HolidayCalendarServiceFR; the two Eve
-    // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 11.
-    private static final int FULL_DAY_HOLIDAY_COUNT = 11;
+    // 12 full-day holidays registered in HolidayCalendarServiceXPAR (11 shared with FR
+    // plus Good Friday); the two Eve holidays are EARLY_CLOSE and excluded by
+    // calculate(), so calculate() sees 12.
+    private static final int FULL_DAY_HOLIDAY_COUNT = 12;
 
-    private final HolidayCalendarServiceFR service = new HolidayCalendarServiceFR();
+    private final HolidayCalendarServiceXPAR service = new HolidayCalendarServiceXPAR();
 
     // -------------------------------------------------------------------------
     // Count / presence per year (verified 2020-2029 Euronext cycle)
     // -------------------------------------------------------------------------
 
-    @DataProvider(name = "frEarlyCloseFixture")
-    public Iterator<Object[]> frEarlyCloseFixture() {
+    @DataProvider(name = "xparEarlyCloseFixture")
+    public Iterator<Object[]> xparEarlyCloseFixture() {
         List<Object[]> data = Arrays.asList(
                 new Object[]{2020, true},
                 new Object[]{2021, true},
@@ -97,23 +98,23 @@ public class HolidayCalendarServiceFREarlyCloseTest {
         return data.iterator();
     }
 
-    @Test(dataProvider = "frEarlyCloseFixture")
+    @Test(dataProvider = "xparEarlyCloseFixture")
     public void testEarlyCloseCountForYear(int year, boolean present) {
         List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
         assertNotNull(earlyCloses);
-        assertEquals(earlyCloses.size(), present ? 2 : 0, "FR " + year + ": unexpected early-close count");
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "XPAR " + year + ": unexpected early-close count");
     }
 
-    @Test(dataProvider = "frEarlyCloseFixture")
+    @Test(dataProvider = "xparEarlyCloseFixture")
     public void testChristmasEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
-                "FR " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+                "XPAR " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
     }
 
-    @Test(dataProvider = "frEarlyCloseFixture")
+    @Test(dataProvider = "xparEarlyCloseFixture")
     public void testNewYearsEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
-                "FR " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+                "XPAR " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
     }
 
     private Set<String> earlyCloseNames(int year) {
@@ -122,10 +123,10 @@ public class HolidayCalendarServiceFREarlyCloseTest {
                 .collect(Collectors.toSet());
     }
 
-    @Test(dataProvider = "frEarlyCloseFixture")
+    @Test(dataProvider = "xparEarlyCloseFixture")
     public void testEarlyCloseCountAlwaysZeroOrTwo(int year, boolean present) {
         int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
-        assertNotEquals(count, 1, "FR " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+        assertNotEquals(count, 1, "XPAR " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
     }
 
     // -------------------------------------------------------------------------
@@ -190,7 +191,7 @@ public class HolidayCalendarServiceFREarlyCloseTest {
         for (int year : List.of(2024, 2027)) {
             List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
             assertNotNull(holidays);
-            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "FR " + year + ": unexpected full-day holiday count");
+            assertEquals(holidays.size(), FULL_DAY_HOLIDAY_COUNT, "XPAR " + year + ": unexpected full-day holiday count");
         }
     }
 
@@ -200,7 +201,7 @@ public class HolidayCalendarServiceFREarlyCloseTest {
     // onto Christmas Eve
     // -------------------------------------------------------------------------
 
-    @Test(dataProvider = "frEarlyCloseFixture")
+    @Test(dataProvider = "xparEarlyCloseFixture")
     public void testCrossListDateOverlapOnlyOnKnownChristmasDayRollYears(int year, boolean present) {
         HolidayCalendar calendar = service.getHolidayCalendar();
         Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
@@ -217,9 +218,9 @@ public class HolidayCalendarServiceFREarlyCloseTest {
                 DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
         if (isChristmasDaySaturdayRollYear) {
             assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
-                    "FR " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+                    "XPAR " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
         } else {
-            assertTrue(intersection.isEmpty(), "FR " + year + ": unexpected cross-list date collision: " + intersection);
+            assertTrue(intersection.isEmpty(), "XPAR " + year + ": unexpected cross-list date collision: " + intersection);
         }
     }
 
@@ -230,7 +231,7 @@ public class HolidayCalendarServiceFREarlyCloseTest {
 
     @Test
     public void testChristmasDayAndChristmasEveCoexistOn24Dec2027() {
-        // December 25, 2027 is a Saturday and rolls to Friday December 24 under FR's
+        // December 25, 2027 is a Saturday and rolls to Friday December 24 under XPAR's
         // previousFridayOrFollowingMonday roll rule -- the same date the non-rolling
         // Christmas Eve EARLY_CLOSE independently occupies (December 24, 2027 is a
         // Friday, a valid early-close weekday). Both facts are true simultaneously and
@@ -257,7 +258,7 @@ public class HolidayCalendarServiceFREarlyCloseTest {
     @Test
     public void testNewYearsDayAndNewYearsEveCoexistOn31Dec2027() {
         // January 1, 2028 is a Saturday and rolls back to Friday December 31, 2027
-        // under FR's previousFridayOrFollowingMonday roll rule -- the same date the
+        // under XPAR's previousFridayOrFollowingMonday roll rule -- the same date the
         // non-rolling New Year's Eve EARLY_CLOSE independently occupies in 2027
         // (December 31, 2027 is a Friday, a valid early-close weekday). This is a
         // genuine same-date coexistence spanning two different year arguments:

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXPARTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXPARTest.java
@@ -18,27 +18,18 @@
 
 package org.holiday.calendar.impl;
 
-import org.holiday.calendar.HolidayCalendar;
-import org.holiday.calendar.HolidayCalendarService;
-import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
-import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertFalse;
+public class HolidayCalendarServiceXPARTest extends AbstractHolidayCalendarServiceTest {
 
-public class HolidayCalendarServiceFRTest extends AbstractHolidayCalendarServiceTest {
+    static final String CODE = "XPAR";
 
-    static final String CODE = "FR";
-
-    public HolidayCalendarServiceFRTest() {
+    public HolidayCalendarServiceXPARTest() {
         super(CODE);
     }
 
@@ -47,7 +38,8 @@ public class HolidayCalendarServiceFRTest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] bastilleDay = {"Bastille Day"};
         final Object[] armisticeDay = {"Armistice Day"};
-        return Arrays.asList(bastilleDay, armisticeDay).listIterator();
+        final Object[] goodFriday = {"Good Friday"};
+        return Arrays.asList(bastilleDay, armisticeDay, goodFriday).listIterator();
     }
 
     @DataProvider
@@ -63,40 +55,13 @@ public class HolidayCalendarServiceFRTest extends AbstractHolidayCalendarService
         final Object[] bastilleDay21 = {2021, "Bastille Day", LocalDate.of(2021, Month.JULY, 14)};
         // Bastille Day 2024: Jul 14 is Sunday -> rolls to Monday Jul 15
         final Object[] bastilleDay24 = {2024, "Bastille Day", LocalDate.of(2024, Month.JULY, 15)};
+        // Good Friday: Friday before Easter Sunday, known Easter dates
+        final Object[] goodFriday21 = {2021, "Good Friday", LocalDate.of(2021, Month.APRIL, 2)};
+        final Object[] goodFriday22 = {2022, "Good Friday", LocalDate.of(2022, Month.APRIL, 15)};
+        final Object[] goodFriday24 = {2024, "Good Friday", LocalDate.of(2024, Month.MARCH, 29)};
         return Arrays.asList(christmas21, christmas22, christmas23,
-                             bastilleDay21, bastilleDay24).listIterator();
-    }
-
-    @Test
-    public void testEarlyCloseHolidaysAbsentFromCalculate() {
-        HolidayCalendarService service = factory.getService(CODE);
-        for (int year : List.of(2021, 2023, 2024, 2025)) {
-            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
-            Set<String> actualNames = holidays.stream()
-                    .map(hd -> hd.getHoliday().getName())
-                    .collect(Collectors.toSet());
-            assertFalse(actualNames.contains("Christmas Eve"),
-                    "Christmas Eve must not appear in calculate(" + year + ") — moved to XPAR");
-            assertFalse(actualNames.contains("New Year's Eve"),
-                    "New Year's Eve must not appear in calculate(" + year + ") — moved to XPAR");
-        }
-    }
-
-    @Test
-    public void testFrHasNoEarlyCloses() {
-        HolidayCalendarService service = factory.getService(CODE);
-        HolidayCalendar calendar = service.getHolidayCalendar();
-        assertFalse(calendar.hasEarlyCloses(), "FR: national calendar must have zero early closes");
-    }
-
-    @Test
-    public void testGoodFridayAbsentFromCalculate() {
-        HolidayCalendarService service = factory.getService(CODE);
-        for (int year : List.of(2021, 2022, 2024)) {
-            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
-            assertFalse(holidays.stream().anyMatch(hd -> "Good Friday".equals(hd.getHoliday().getName())),
-                    "FR: Good Friday must not appear for " + year + " (not a French national holiday)");
-        }
+                             bastilleDay21, bastilleDay24,
+                             goodFriday21, goodFriday22, goodFriday24).listIterator();
     }
 
 }

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -92,6 +92,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"USD"},
                 new Object[]{"XLON"},
                 new Object[]{"XNYS"},
+                new Object[]{"XPAR"},
                 new Object[]{"XTSE"}
         ).iterator();
     }
@@ -499,7 +500,7 @@ public class HolidayCalendar30YearIT {
     }
 
     // =========================================================================
-    // 11. FR EARLY CLOSES (Euronext Paris Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // 11. XPAR EARLY CLOSES (Euronext Paris Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
     // =========================================================================
 
     // Both Euronext Eve early closes are suppressed (not shifted) when their date falls on a
@@ -508,27 +509,27 @@ public class HolidayCalendar30YearIT {
     // presence is re-derived from December 24's day-of-week rule for every year rather than
     // hand-fixtured.
     //
-    // FR's Christmas Day and New Year's Day are both rollable under
+    // XPAR's Christmas Day and New Year's Day are both rollable under
     // previousFridayOrFollowingMonday, unlike SG, so this section additionally verifies the two
     // genuine cross-list date collisions this produces: Christmas Day rolling back onto
     // December 24 in Dec-25-Saturday years, and New Year's Day rolling back onto the prior
     // December 31 in Jan-1-Saturday years (a year-boundary-crossing collision that a same-year
     // intersection check alone would miss).
-    @Test(description = "FR calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+    @Test(description = "XPAR calculateEarlyCloses across 2026-2055: count always in {0,2}, "
             + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
             + "and always co-occur, no nulls, chronological order, and known Christmas Day/New Year's "
             + "Day roll collisions are accounted for")
-    public void testFREarlyClosesOver30Years() {
-        HolidayCalendar calendar = new HolidayCalendarFactory().create("FR");
+    public void testXPAREarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XPAR");
 
         List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
         for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
             List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
-            assertNotNull(earlyCloses, "FR: calculateEarlyCloses(" + year + ") must not be null");
+            assertNotNull(earlyCloses, "XPAR: calculateEarlyCloses(" + year + ") must not be null");
 
             int count = earlyCloses.size();
             assertTrue(count == 0 || count == 2,
-                    "FR " + year + ": expected count in {0,2}, got " + count);
+                    "XPAR " + year + ": expected count in {0,2}, got " + count);
 
             DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
             boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
@@ -537,9 +538,9 @@ public class HolidayCalendar30YearIT {
                     .map(hd -> hd.holiday().getName())
                     .collect(Collectors.toSet());
             assertEquals(names.contains("Christmas Eve"), expected,
-                    "FR " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+                    "XPAR " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
             assertEquals(names.contains("New Year's Eve"), expected,
-                    "FR " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+                    "XPAR " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
 
             // Cross-list date collision: empty in ordinary years, exactly one date
             // (December 24) in Dec-25-Saturday years, when Christmas Day rolls back
@@ -554,9 +555,9 @@ public class HolidayCalendar30YearIT {
                     DayOfWeek.SATURDAY.equals(LocalDate.of(year, Month.DECEMBER, 25).getDayOfWeek());
             if (isChristmasDaySaturdayRollYear) {
                 assertEquals(intersection, Set.of(LocalDate.of(year, Month.DECEMBER, 24)),
-                        "FR " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
+                        "XPAR " + year + ": expected exactly the known Christmas Day/Christmas Eve collision");
             } else {
-                assertTrue(intersection.isEmpty(), "FR " + year + ": unexpected cross-list date collision: " + intersection);
+                assertTrue(intersection.isEmpty(), "XPAR " + year + ": unexpected cross-list date collision: " + intersection);
             }
 
             // Cross-year collision: New Year's Day rolling back onto this year's December 31
@@ -569,9 +570,9 @@ public class HolidayCalendar30YearIT {
                         .anyMatch(hd -> "New Year's Day".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
                 boolean newYearsEvePresent = names.contains("New Year's Eve");
                 assertTrue(newYearsDayPresent,
-                        "FR " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
+                        "XPAR " + year + ": New Year's Day (rolled back from Jan 1, " + (year + 1) + ") must appear on Dec 31, " + year);
                 assertTrue(newYearsEvePresent,
-                        "FR " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
+                        "XPAR " + year + ": New Year's Eve early close must independently appear on Dec 31, " + year);
             }
 
             allEarlyCloses.addAll(earlyCloses);
@@ -579,16 +580,16 @@ public class HolidayCalendar30YearIT {
 
         for (int i = 0; i < allEarlyCloses.size(); i++) {
             HolidayDate hd = allEarlyCloses.get(i);
-            assertNotNull(hd, "FR: early-close entry at index " + i + " must not be null");
-            assertNotNull(hd.holiday(), "FR: early-close holiday at index " + i + " must not be null");
-            assertNotNull(hd.date(), "FR: early-close date at index " + i + " must not be null");
+            assertNotNull(hd, "XPAR: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "XPAR: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "XPAR: early-close date at index " + i + " must not be null");
         }
 
         for (int i = 1; i < allEarlyCloses.size(); i++) {
             LocalDate prev = allEarlyCloses.get(i - 1).date();
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
-                    "FR: early-close dates out of order at index " + i
+                    "XPAR: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
         }
     }


### PR DESCRIPTION
### Title of the PR

Split FR national holidays from Euronext Paris (XPAR) market calendar; add missing Good Friday

**Description**

- Sub-issue of #231 (itself a sub-issue of #229). Introduces `HolidayCalendarServiceXPAR` as a verbatim copy of the former `HolidayCalendarServiceFR` behavior (11 shared national holidays plus the Christmas Eve/New Year's Eve Euronext Paris early closes), while `HolidayCalendarServiceFR` is stripped down to the 11 national jours fériés and no longer includes early closes.
- Bundles a missing-holiday fix discovered during research: Good Friday is a confirmed, current Euronext Paris market closure that had never been coded anywhere in this repo. It is added as net-new `FLOATING` content to `HolidayCalendarServiceXPAR` only (not a relocation, since it didn't exist in `FR` either) using the existing `observance.christian.GoodFriday`/`WesternEaster` pair already used elsewhere in this module. `FR` correctly stays without it, since Good Friday is not a French national holiday.
- Shared holiday definitions extracted into a new package-private `FrHolidays` factory, consumed by both `HolidayCalendarServiceFR` and `HolidayCalendarServiceXPAR`.
- Registered `HolidayCalendarServiceXPAR` in `module-info.java` and `META-INF/services/org.holiday.calendar.HolidayCalendarService`.
- Renamed `HolidayCalendarServiceFREarlyCloseTest` → `HolidayCalendarServiceXPAREarlyCloseTest` (full-day holiday count updated 11 → 12 to account for the added Good Friday), added `HolidayCalendarServiceXPARTest` with Good Friday fixtures verified against known Easter dates, and added early-close-absence and Good-Friday-absence assertions to `HolidayCalendarServiceFRTest`. Updated `HolidayCalendar30YearIT` (added `XPAR` to the code list, renamed `testFREarlyClosesOver30Years` → `testXPAREarlyClosesOver30Years`).
- README calendar table updates are tracked separately in #230 and are intentionally out of scope here, consistent with the prior UK/XLON, CA/XTSE, and AU/XASX splits.

**Related Issue**

- [#238](https://github.com/holiday-calendar/holiday-calendar-java/issues/238)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed (README table deferred to #230)
- [ ] Screenshots or additional notes added, if needed
