### PR TITLE
Create national Switzerland (CH) calendar alongside SIX (XSWX) market calendar

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -53,5 +53,6 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceUSD,
         org.holiday.calendar.impl.HolidayCalendarServiceXLON,
         org.holiday.calendar.impl.HolidayCalendarServiceXNYS,
+        org.holiday.calendar.impl.HolidayCalendarServiceXSWX,
         org.holiday.calendar.impl.HolidayCalendarServiceXTSE;
 }

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/ChHolidays.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/ChHolidays.java
@@ -1,0 +1,121 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.christian.AscensionDay;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.christian.WhitMonday;
+
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the 9 holidays common to both the
+ * Switzerland national ({@code CH}) and SIX Swiss Exchange ({@code XSWX})
+ * calendars: New Year's Day, Good Friday, Easter Monday, Labour Day,
+ * Ascension Day, Whit Monday, Swiss National Day, Christmas Day, and Boxing
+ * Day. SIX is closed on all of these, so the full list is shared verbatim —
+ * only {@code XSWX} adds the Christmas Eve/New Year's Eve holidays on top.
+ *
+ * <p>Switzerland has only one federally-mandated nationwide public holiday:
+ * Swiss National Day (August 1). Every other holiday in this list, including
+ * New Year's Day and Christmas, is decided at the cantonal level and adopted
+ * by most-but-not-all of the 26 cantons (e.g. Good Friday is not observed in
+ * Ticino or Valais). This list represents the majority-cantonal convention,
+ * not uniform federal law.
+ */
+class ChHolidays {
+
+    private ChHolidays() {}
+
+    static List<Holiday> baseHolidays() {
+        final EasterObservance easter = new WesternEaster();
+
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Good Friday")
+                    .description("Friday before Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new GoodFriday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Monday")
+                    .description("Monday after Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EasterMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Ascension Day")
+                    .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new AscensionDay(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Whit Monday")
+                    .description("Monday after Whit Sunday (Pentecost)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new WhitMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Swiss National Day")
+                    .description("Date of the Federal Charter of 1291")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.AUGUST, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Celebration of traditional Christmas holiday")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Boxing Day")
+                    .description("Day after Christmas")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 26)
+                    .build()
+        );
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCH.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceCH.java
@@ -19,29 +19,34 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
-import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.christian.AscensionDay;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.GoodFriday;
-import org.holiday.calendar.observance.christian.WesternEaster;
-import org.holiday.calendar.observance.christian.WhitMonday;
-
-import java.time.Month;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
 /**
- * Service for provision of Switzerland (SIX Stock Exchange) holiday calendar.
+ * Service for provision of the Switzerland national public holiday
+ * calendar. Distinct from {@link HolidayCalendarServiceXSWX}, the SIX Swiss
+ * Exchange trading calendar: this calendar never includes early-close
+ * (half-day) trading sessions.
+ *
+ * <p>Switzerland has only <strong>one</strong> federally-mandated nationwide
+ * public holiday: Swiss National Day (August 1), enshrined in the Federal
+ * Act on the Swiss National Holiday. Every other holiday in this calendar,
+ * including New Year's Day and Christmas, is decided at the cantonal level
+ * and is adopted by most-but-not-all of the 26 cantons — for example, Good
+ * Friday is not observed in Ticino or Valais. There is no single
+ * unambiguous "Swiss national holiday list" defined by federal law: the 8
+ * non-federal holidays here represent the <strong>majority-cantonal
+ * convention</strong> (holidays observed by most/all cantons), not uniform
+ * federal law.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
 
     private static final String CODE = "CH";
-    private static final String NAME = "Switzerland (SIX) Holidays";
+    private static final String NAME = "Switzerland National Holidays";
 
     public HolidayCalendarServiceCH() {
         super(CODE, NAME);
@@ -49,102 +54,12 @@ public class HolidayCalendarServiceCH extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday goodFriday = Holiday.builder()
-                .name("Good Friday")
-                .description("Friday before Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new GoodFriday(easter))
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Monday after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday labourDay = Holiday.builder()
-                .name("Labour Day")
-                .description("International Workers' Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.MAY, 1)
-                .build();
-        final Holiday ascensionDay = Holiday.builder()
-                .name("Ascension Day")
-                .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new AscensionDay(easter))
-                .build();
-        final Holiday whitMonday = Holiday.builder()
-                .name("Whit Monday")
-                .description("Monday after Whit Sunday (Pentecost)")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new WhitMonday(easter))
-                .build();
-        final Holiday swissNationalDay = Holiday.builder()
-                .name("Swiss National Day")
-                .description("Date of the Federal Charter of 1291")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.AUGUST, 1)
-                .build();
-        final Holiday christmasEve = Holiday.builder()
-                .name("Christmas Eve")
-                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 24)
-                .build();
-        final Holiday christmasDay = Holiday.builder()
-                .name("Christmas Day")
-                .description("Celebration of traditional Christmas holiday")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 25)
-                .build();
-        final Holiday boxingDay = Holiday.builder()
-                .name("Boxing Day")
-                .description("Day after Christmas")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 26)
-                .build();
-        final Holiday newYearsEve = Holiday.builder()
-                .name("New Year's Eve")
-                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 31)
-                .build();
-
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.previousFridayOrFollowingMonday())
                 .weekendDays(STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(goodFriday)
-                .holiday(easterMonday)
-                .holiday(labourDay)
-                .holiday(ascensionDay)
-                .holiday(whitMonday)
-                .holiday(swissNationalDay)
-                .holiday(christmasEve)
-                .holiday(christmasDay)
-                .holiday(boxingDay)
-                .holiday(newYearsEve)
+                .holidays(ChHolidays.baseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXSWX.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXSWX.java
@@ -1,0 +1,83 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+
+import java.time.Month;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of Switzerland (SIX Swiss Exchange) holiday
+ * calendar. Distinct from {@link HolidayCalendarServiceCH}, the Switzerland
+ * national public holiday calendar: this calendar additionally includes
+ * Christmas Eve and New Year's Eve, both SIX-only market holidays per the
+ * official SIX Trading Calendar, not cantonal-law public holidays. SIX is
+ * closed on every public holiday observed by {@code CH}. All holidays here
+ * are {@code FIXED}, {@code rollable(true)} — SIX has no {@code EARLY_CLOSE}
+ * (half-day) sessions.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceXSWX extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "XSWX";
+    private static final String NAME = "Switzerland (SIX) Holidays";
+
+    public HolidayCalendarServiceXSWX() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday christmasEve = Holiday.builder()
+                .name("Christmas Eve")
+                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 24)
+                .build();
+        final Holiday newYearsEve = Holiday.builder()
+                .name("New Year's Eve")
+                .description("SIX Swiss Exchange market holiday per official Trading Calendar")
+                .type(Holiday.Type.FIXED)
+                .rollable(true)
+                .monthDay(Month.DECEMBER, 31)
+                .build();
+
+        final List<Holiday> holidays = new ArrayList<>(ChHolidays.baseHolidays());
+        holidays.add(christmasEve);
+        holidays.add(newYearsEve);
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.previousFridayOrFollowingMonday())
+                .weekendDays(STANDARD_WEEKEND)
+                .holidays(holidays)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -13,4 +13,5 @@ org.holiday.calendar.impl.HolidayCalendarServiceUS
 org.holiday.calendar.impl.HolidayCalendarServiceUSD
 org.holiday.calendar.impl.HolidayCalendarServiceXLON
 org.holiday.calendar.impl.HolidayCalendarServiceXNYS
+org.holiday.calendar.impl.HolidayCalendarServiceXSWX
 org.holiday.calendar.impl.HolidayCalendarServiceXTSE

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceCHTest.java
@@ -19,7 +19,7 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.HolidayCalendar;
-import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayCalendarService;
 import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -29,9 +29,10 @@ import java.time.Month;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
-import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertFalse;
 
 public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarServiceTest {
 
@@ -45,10 +46,8 @@ public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarService
     @Override
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
-        final Object[] christmasEve = new Object[]{"Christmas Eve"};
         final Object[] boxingDay = new Object[]{"Boxing Day"};
-        final Object[] newYearsEve = new Object[]{"New Year's Eve"};
-        return Arrays.asList(swissNationalDay, christmasEve, boxingDay, newYearsEve).listIterator();
+        return Arrays.asList(swissNationalDay, boxingDay).listIterator();
     }
 
     @DataProvider
@@ -67,72 +66,32 @@ public class HolidayCalendarServiceCHTest extends AbstractHolidayCalendarService
         final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // Christmas Day 2023: Dec 25 is Monday -> no roll
         final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
-        // Christmas Eve: Dec 24
-        // 2021: Dec 24 is Friday -> no roll
-        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
-        // 2022: Dec 24 is Saturday -> rolls to Friday Dec 23
-        final Object[] christmasEve22 = {2022, "Christmas Eve", LocalDate.of(2022, Month.DECEMBER, 23)};
-        // 2023: Dec 24 is Sunday -> rolls to Monday Dec 25
-        final Object[] christmasEve23 = {2023, "Christmas Eve", LocalDate.of(2023, Month.DECEMBER, 25)};
-        // New Year's Eve: Dec 31
-        // 2021: Dec 31 is Friday -> no roll
-        final Object[] newYearsEve21 = {2021, "New Year's Eve", LocalDate.of(2021, Month.DECEMBER, 31)};
-        // 2022: Dec 31 is Saturday -> rolls to Friday Dec 30
-        final Object[] newYearsEve22 = {2022, "New Year's Eve", LocalDate.of(2022, Month.DECEMBER, 30)};
-        // 2023: Dec 31 is Sunday -> rolls to Monday Jan 1, 2024
-        final Object[] newYearsEve23 = {2023, "New Year's Eve", LocalDate.of(2024, Month.JANUARY, 1)};
         return Arrays.asList(swissNationalDay21, swissNationalDay22, swissNationalDay23,
-                             christmas21, christmas22, christmas23,
-                             christmasEve21, christmasEve22, christmasEve23,
-                             newYearsEve21, newYearsEve22, newYearsEve23).listIterator();
-    }
-
-    // -------------------------------------------------------------------------
-    // Same-resolved-date collisions between independently-rolled fixed holidays
-    // -------------------------------------------------------------------------
-
-    @Test
-    public void testCollision_ChristmasDayRollAndChristmasEveShareDec24_2021() {
-        HolidayCalendarFactory factory = new HolidayCalendarFactory();
-        HolidayCalendar calendar = factory.create(CODE);
-        assertNotNull(calendar);
-
-        List<HolidayDate> holidays2021 = calendar.calculate(2021);
-
-        Optional<HolidayDate> christmasDay = holidays2021.stream()
-                .filter(hd -> "Christmas Day".equals(hd.getHoliday().getName()))
-                .findFirst();
-        Optional<HolidayDate> christmasEve = holidays2021.stream()
-                .filter(hd -> "Christmas Eve".equals(hd.getHoliday().getName()))
-                .findFirst();
-
-        assertTrue(christmasDay.isPresent());
-        assertTrue(christmasEve.isPresent());
-        assertEquals(christmasDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
-        assertEquals(christmasEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+                             christmas21, christmas22, christmas23).listIterator();
     }
 
     @Test
-    public void testCollision_NewYearsDayRollAndNewYearsEveShareDec31_2021() {
-        HolidayCalendarFactory factory = new HolidayCalendarFactory();
-        HolidayCalendar calendar = factory.create(CODE);
-        assertNotNull(calendar);
+    public void testEarlyCloseHolidaysAbsentFromCalculate() {
+        // Trivially true: CH never had any EarlyCloseHoliday entries. Retained as an
+        // explicit regression guard alongside the sibling XSWX/AU/FR/CA national tests.
+        HolidayCalendarService service = factory.getService(CODE);
+        for (int year : List.of(2021, 2023, 2024, 2025)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            Set<String> actualNames = holidays.stream()
+                    .map(hd -> hd.getHoliday().getName())
+                    .collect(Collectors.toSet());
+            assertFalse(actualNames.contains("Christmas Eve"),
+                    "Christmas Eve must not appear in calculate(" + year + ") — moved to XSWX");
+            assertFalse(actualNames.contains("New Year's Eve"),
+                    "New Year's Eve must not appear in calculate(" + year + ") — moved to XSWX");
+        }
+    }
 
-        // 2022: Jan 1 is Saturday -> New Year's Day rolls back to Friday Dec 31, 2021
-        List<HolidayDate> holidays2022 = calendar.calculate(2022);
-        Optional<HolidayDate> newYearsDay = holidays2022.stream()
-                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
-                .findFirst();
-        assertTrue(newYearsDay.isPresent());
-        assertEquals(newYearsDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
-
-        // 2021: Dec 31 is Friday -> New Year's Eve stays on Dec 31, 2021
-        List<HolidayDate> holidays2021 = calendar.calculate(2021);
-        Optional<HolidayDate> newYearsEve = holidays2021.stream()
-                .filter(hd -> "New Year's Eve".equals(hd.getHoliday().getName()))
-                .findFirst();
-        assertTrue(newYearsEve.isPresent());
-        assertEquals(newYearsEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
+    @Test
+    public void testChHasNoEarlyCloses() {
+        HolidayCalendarService service = factory.getService(CODE);
+        HolidayCalendar calendar = service.getHolidayCalendar();
+        assertFalse(calendar.hasEarlyCloses(), "CH: national calendar must have zero early closes");
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXSWXTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXSWXTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarFactory;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Optional;
+
+import static org.testng.Assert.*;
+
+public class HolidayCalendarServiceXSWXTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "XSWX";
+
+    public HolidayCalendarServiceXSWXTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        final Object[] swissNationalDay = new Object[]{"Swiss National Day"};
+        final Object[] christmasEve = new Object[]{"Christmas Eve"};
+        final Object[] boxingDay = new Object[]{"Boxing Day"};
+        final Object[] newYearsEve = new Object[]{"New Year's Eve"};
+        return Arrays.asList(swissNationalDay, christmasEve, boxingDay, newYearsEve).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // Swiss National Day: Aug 1
+        // 2021: Aug 1 is Sunday -> rolls to Monday Aug 2
+        final Object[] swissNationalDay21 = {2021, "Swiss National Day", LocalDate.of(2021, Month.AUGUST, 2)};
+        // 2022: Aug 1 is Monday -> no roll
+        final Object[] swissNationalDay22 = {2022, "Swiss National Day", LocalDate.of(2022, Month.AUGUST, 1)};
+        // 2023: Aug 1 is Tuesday -> no roll
+        final Object[] swissNationalDay23 = {2023, "Swiss National Day", LocalDate.of(2023, Month.AUGUST, 1)};
+        // Christmas Day 2021: Dec 25 is Saturday -> rolls to Friday Dec 24
+        final Object[] christmas21 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 24)};
+        // Christmas Day 2022: Dec 25 is Sunday -> rolls to Monday Dec 26
+        final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // Christmas Day 2023: Dec 25 is Monday -> no roll
+        final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // Christmas Eve: Dec 24
+        // 2021: Dec 24 is Friday -> no roll
+        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
+        // 2022: Dec 24 is Saturday -> rolls to Friday Dec 23
+        final Object[] christmasEve22 = {2022, "Christmas Eve", LocalDate.of(2022, Month.DECEMBER, 23)};
+        // 2023: Dec 24 is Sunday -> rolls to Monday Dec 25
+        final Object[] christmasEve23 = {2023, "Christmas Eve", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // New Year's Eve: Dec 31
+        // 2021: Dec 31 is Friday -> no roll
+        final Object[] newYearsEve21 = {2021, "New Year's Eve", LocalDate.of(2021, Month.DECEMBER, 31)};
+        // 2022: Dec 31 is Saturday -> rolls to Friday Dec 30
+        final Object[] newYearsEve22 = {2022, "New Year's Eve", LocalDate.of(2022, Month.DECEMBER, 30)};
+        // 2023: Dec 31 is Sunday -> rolls to Monday Jan 1, 2024
+        final Object[] newYearsEve23 = {2023, "New Year's Eve", LocalDate.of(2024, Month.JANUARY, 1)};
+        return Arrays.asList(swissNationalDay21, swissNationalDay22, swissNationalDay23,
+                             christmas21, christmas22, christmas23,
+                             christmasEve21, christmasEve22, christmasEve23,
+                             newYearsEve21, newYearsEve22, newYearsEve23).listIterator();
+    }
+
+    // -------------------------------------------------------------------------
+    // Same-resolved-date collisions between independently-rolled fixed holidays
+    // -------------------------------------------------------------------------
+
+    @Test
+    public void testCollision_ChristmasDayRollAndChristmasEveShareDec24_2021() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        List<HolidayDate> holidays2021 = calendar.calculate(2021);
+
+        Optional<HolidayDate> christmasDay = holidays2021.stream()
+                .filter(hd -> "Christmas Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        Optional<HolidayDate> christmasEve = holidays2021.stream()
+                .filter(hd -> "Christmas Eve".equals(hd.getHoliday().getName()))
+                .findFirst();
+
+        assertTrue(christmasDay.isPresent());
+        assertTrue(christmasEve.isPresent());
+        assertEquals(christmasDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+        assertEquals(christmasEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 24));
+    }
+
+    @Test
+    public void testCollision_NewYearsDayRollAndNewYearsEveShareDec31_2021() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertNotNull(calendar);
+
+        // 2022: Jan 1 is Saturday -> New Year's Day rolls back to Friday Dec 31, 2021
+        List<HolidayDate> holidays2022 = calendar.calculate(2022);
+        Optional<HolidayDate> newYearsDay = holidays2022.stream()
+                .filter(hd -> "New Year's Day".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(newYearsDay.isPresent());
+        assertEquals(newYearsDay.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
+
+        // 2021: Dec 31 is Friday -> New Year's Eve stays on Dec 31, 2021
+        List<HolidayDate> holidays2021 = calendar.calculate(2021);
+        Optional<HolidayDate> newYearsEve = holidays2021.stream()
+                .filter(hd -> "New Year's Eve".equals(hd.getHoliday().getName()))
+                .findFirst();
+        assertTrue(newYearsEve.isPresent());
+        assertEquals(newYearsEve.get().getDate(), LocalDate.of(2021, Month.DECEMBER, 31));
+    }
+
+    @Test
+    public void testXswxHasNoEarlyCloses() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertFalse(calendar.hasEarlyCloses(),
+                "XSWX: all holidays are FIXED rollable(true); SIX has no EARLY_CLOSE sessions");
+    }
+
+    @Test
+    public void testXswxHasExactlyElevenHolidays() {
+        HolidayCalendarFactory factory = new HolidayCalendarFactory();
+        HolidayCalendar calendar = factory.create(CODE);
+        assertEquals(calendar.getHolidays().size(), 11,
+                "XSWX: must carry forward the exact same 11 holidays as the former CH class");
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -18,6 +18,8 @@
 
 package org.holiday.calendar;
 
+import org.holiday.calendar.function.DateRoll;
+import org.holiday.calendar.function.DateRolls;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -92,6 +94,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"USD"},
                 new Object[]{"XLON"},
                 new Object[]{"XNYS"},
+                new Object[]{"XSWX"},
                 new Object[]{"XTSE"}
         ).iterator();
     }
@@ -684,6 +687,68 @@ public class HolidayCalendar30YearIT {
             LocalDate curr = allEarlyCloses.get(i).date();
             assertFalse(curr.isBefore(prev),
                     "AU: early-close dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
+    // =========================================================================
+    // 13. XSWX CHRISTMAS EVE / NEW YEAR'S EVE (SIX full non-trading days) OVER 30 YEARS
+    // =========================================================================
+
+    // SIX's Christmas Eve and New Year's Eve are FIXED, rollable(true) full holidays
+    // under previousFridayOrFollowingMonday — unlike DE (omitted on Sat/Sun), they are
+    // never suppressed, only shifted, so calculate() always contains exactly 11 entries.
+    // Expected dates are re-derived directly from the production DateRoll rather than
+    // hand-fixtured, since CH has no existing 30-year test today (it never had early
+    // closes).
+    @Test(description = "XSWX calculate() across 2026-2055: exactly 11 holidays every year, "
+            + "Christmas Eve/New Year's Eve dates match previousFridayOrFollowingMonday roll of "
+            + "December 24/31, no nulls, chronological order")
+    public void testXSWXOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XSWX");
+        DateRoll roll = DateRolls.previousFridayOrFollowingMonday();
+
+        List<HolidayDate> allHolidays = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            final int currentYear = year;
+            List<HolidayDate> holidays = calendar.calculate(year);
+            assertNotNull(holidays, "XSWX: calculate(" + year + ") must not be null");
+            assertEquals(holidays.size(), 11,
+                    "XSWX " + year + ": expected exactly 11 holidays, got " + holidays.size());
+
+            LocalDate expectedChristmasEve = roll.rollToObservedDate(LocalDate.of(year, Month.DECEMBER, 24));
+            LocalDate actualChristmasEve = holidays.stream()
+                    .filter(hd -> "Christmas Eve".equals(hd.holiday().getName()))
+                    .map(HolidayDate::date)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("XSWX " + currentYear + ": Christmas Eve missing"));
+            assertEquals(actualChristmasEve, expectedChristmasEve,
+                    "XSWX " + year + ": Christmas Eve must match previousFridayOrFollowingMonday roll of December 24");
+
+            LocalDate expectedNewYearsEve = roll.rollToObservedDate(LocalDate.of(year, Month.DECEMBER, 31));
+            LocalDate actualNewYearsEve = holidays.stream()
+                    .filter(hd -> "New Year's Eve".equals(hd.holiday().getName()))
+                    .map(HolidayDate::date)
+                    .findFirst()
+                    .orElseThrow(() -> new AssertionError("XSWX " + currentYear + ": New Year's Eve missing"));
+            assertEquals(actualNewYearsEve, expectedNewYearsEve,
+                    "XSWX " + year + ": New Year's Eve must match previousFridayOrFollowingMonday roll of December 31");
+
+            allHolidays.addAll(holidays);
+        }
+
+        for (int i = 0; i < allHolidays.size(); i++) {
+            HolidayDate hd = allHolidays.get(i);
+            assertNotNull(hd, "XSWX: entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "XSWX: holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "XSWX: date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allHolidays.size(); i++) {
+            LocalDate prev = allHolidays.get(i - 1).date();
+            LocalDate curr = allHolidays.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "XSWX: dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
         }
     }


### PR DESCRIPTION
### Title of the PR

Create national Switzerland (CH) calendar alongside SIX (XSWX) market calendar

**Description**

- Sub-issue of #231 (itself a sub-issue of #229). Repurposes `HolidayCalendarServiceCH` as a pure national calendar and introduces `HolidayCalendarServiceXSWX` (ISO 10383 MIC code for SIX) to carry forward the existing market-calendar content as a verbatim, lossless copy (all 11 entries, all `FIXED rollable(true)`, no early closes).
- Switzerland has only **one** federally-mandated nationwide public holiday — Swiss National Day (August 1). Every other holiday, including New Year's Day and Christmas, is decided at the cantonal level and adopted by most-but-not-all of the 26 cantons (e.g. Good Friday is not observed in Ticino or Valais). The new national `CH` calendar (9 holidays: drops the SIX-only Christmas Eve/New Year's Eve) uses the **majority-cantonal convention**, documented explicitly in class-level Javadoc rather than presented as uniform federal law.
- Shared holiday definitions extracted into a new package-private `ChHolidays` factory, consumed by both `HolidayCalendarServiceCH` and `HolidayCalendarServiceXSWX`.
- Registered `HolidayCalendarServiceXSWX` in `module-info.java` and `META-INF/services/org.holiday.calendar.HolidayCalendarService`.
- Moved `CH`'s existing Christmas Eve/New Year's Eve collision tests to the new `HolidayCalendarServiceXSWXTest`, trimmed `CH`'s DataProviders to drop the now-deleted fixtures, and added `testEarlyCloseHolidaysAbsentFromCalculate()` to `CH` (trivially true — `CH` never had `EarlyCloseHoliday` entries).
- `HolidayCalendar30YearIT`: added `XSWX` to the calendar-code list, plus a new hand-written 30-year test (`testXSWXOver30Years`) verifying Christmas Eve/New Year's Eve roll directly against the production `DateRoll`, since `CH` never had `calculateEarlyCloses()` coverage of this shape to build on.
- README calendar table updates are tracked separately in #230 and are intentionally out of scope here, consistent with the prior UK/XLON, CA/XTSE, AU/XASX, and FR/XPAR splits.

**Related Issue**

- [#239](https://github.com/holiday-calendar/holiday-calendar-java/issues/239)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed (README table deferred to #230)
- [ ] Screenshots or additional notes added, if needed
