### PR TITLE
Create national Germany (DE) calendar alongside Xetra (XETR) market calendar

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -51,6 +51,7 @@ module org.holiday.calendar.western {
         org.holiday.calendar.impl.HolidayCalendarServiceUK,
         org.holiday.calendar.impl.HolidayCalendarServiceUS,
         org.holiday.calendar.impl.HolidayCalendarServiceUSD,
+        org.holiday.calendar.impl.HolidayCalendarServiceXETR,
         org.holiday.calendar.impl.HolidayCalendarServiceXLON,
         org.holiday.calendar.impl.HolidayCalendarServiceXNYS,
         org.holiday.calendar.impl.HolidayCalendarServiceXTSE;

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/DeHolidays.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/DeHolidays.java
@@ -1,0 +1,116 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.observance.christian.AscensionDay;
+import org.holiday.calendar.observance.christian.EasterMonday;
+import org.holiday.calendar.observance.christian.EasterObservance;
+import org.holiday.calendar.observance.christian.GoodFriday;
+import org.holiday.calendar.observance.christian.WesternEaster;
+import org.holiday.calendar.observance.christian.WhitMonday;
+
+import java.time.Month;
+import java.util.List;
+
+/**
+ * Package-private factory building the 9 holidays common to both the
+ * Germany national ({@code DE}) and Xetra ({@code XETR}) calendars: New
+ * Year's Day, Good Friday, Easter Monday, Labour Day, Ascension Day, Whit
+ * Monday, German Unity Day, Christmas Day, and Boxing Day. These are
+ * exactly Germany's 9 official nationwide (bundesweite) public holidays,
+ * and Xetra/Frankfurt is closed on all of them, so the full list is shared
+ * verbatim — only {@code XETR} adds the Christmas Eve/New Year's Eve
+ * market-only closures on top.
+ */
+class DeHolidays {
+
+    private DeHolidays() {}
+
+    static List<Holiday> baseHolidays() {
+        final EasterObservance easter = new WesternEaster();
+
+        return List.of(
+            Holiday.builder()
+                    .name("New Year's Day")
+                    .description("First day of new year in the Common Era (CE)")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.JANUARY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Good Friday")
+                    .description("Friday before Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new GoodFriday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Easter Monday")
+                    .description("Monday after Easter Sunday")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new EasterMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Labour Day")
+                    .description("International Workers' Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.MAY, 1)
+                    .build(),
+            Holiday.builder()
+                    .name("Ascension Day")
+                    .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new AscensionDay(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("Whit Monday")
+                    .description("Monday after Whit Sunday (Pentecost)")
+                    .type(Holiday.Type.FLOATING)
+                    .rollable(false)
+                    .observance(new WhitMonday(easter))
+                    .build(),
+            Holiday.builder()
+                    .name("German Unity Day")
+                    .description("German Unity Day")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.OCTOBER, 3)
+                    .build(),
+            Holiday.builder()
+                    .name("Christmas Day")
+                    .description("Celebration of traditional Christmas holiday")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 25)
+                    .build(),
+            Holiday.builder()
+                    .name("Boxing Day")
+                    .description("Day after Christmas")
+                    .type(Holiday.Type.FIXED)
+                    .rollable(true)
+                    .monthDay(Month.DECEMBER, 26)
+                    .build()
+        );
+    }
+
+}

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceDE.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceDE.java
@@ -19,31 +19,25 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
-import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.christian.AscensionDay;
-import org.holiday.calendar.observance.christian.EasterMonday;
-import org.holiday.calendar.observance.christian.EasterObservance;
-import org.holiday.calendar.observance.christian.GoodFriday;
-import org.holiday.calendar.observance.christian.WesternEaster;
-import org.holiday.calendar.observance.christian.WhitMonday;
-import org.holiday.calendar.observance.de.ChristmasEve;
-import org.holiday.calendar.observance.de.NewYearsEve;
-
-import java.time.Month;
 
 import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
 
 /**
- * Service for provision of Germany (Xetra/FSE) holiday calendar.
+ * Service for provision of the Germany national public holiday calendar.
+ * Distinct from {@link HolidayCalendarServiceXETR}, the Xetra/Frankfurt
+ * Stock Exchange trading calendar: this calendar contains only Germany's 9
+ * official nationwide (bundesweite) public holidays — Christmas Eve and New
+ * Year's Eve are correctly absent, as they are Xetra/Frankfurt-specific
+ * market closures, not German public holidays.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
 
     private static final String CODE = "DE";
-    private static final String NAME = "Germany (Xetra) Holidays";
+    private static final String NAME = "Germany National Holidays";
 
     public HolidayCalendarServiceDE() {
         super(CODE, NAME);
@@ -51,104 +45,12 @@ public class HolidayCalendarServiceDE extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final EasterObservance easter = new WesternEaster();
-
-        final Holiday newYearsDay = Holiday.builder()
-                .name("New Year's Day")
-                .description("First day of new year in the Common Era (CE)")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.JANUARY, 1)
-                .build();
-        final Holiday goodFriday = Holiday.builder()
-                .name("Good Friday")
-                .description("Friday before Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new GoodFriday(easter))
-                .build();
-        final Holiday easterMonday = Holiday.builder()
-                .name("Easter Monday")
-                .description("Monday after Easter Sunday")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new EasterMonday(easter))
-                .build();
-        final Holiday labourDay = Holiday.builder()
-                .name("Labour Day")
-                .description("International Workers' Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.MAY, 1)
-                .build();
-        final Holiday ascensionDay = Holiday.builder()
-                .name("Ascension Day")
-                .description("The 40th day of Easter; Jesus Christ's ascension into heaven")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new AscensionDay(easter))
-                .build();
-        final Holiday whitMonday = Holiday.builder()
-                .name("Whit Monday")
-                .description("Monday after Whit Sunday (Pentecost)")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new WhitMonday(easter))
-                .build();
-        final Holiday germanUnityDay = Holiday.builder()
-                .name("German Unity Day")
-                .description("German Unity Day")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.OCTOBER, 3)
-                .build();
-        final Holiday christmasEve = Holiday.builder()
-                .name("Christmas Eve")
-                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
-                        + "Exchange; omitted (not shifted) when it falls on a weekend")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new ChristmasEve())
-                .build();
-        final Holiday christmasDay = Holiday.builder()
-                .name("Christmas Day")
-                .description("Celebration of traditional Christmas holiday")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 25)
-                .build();
-        final Holiday boxingDay = Holiday.builder()
-                .name("Boxing Day")
-                .description("Day after Christmas")
-                .type(Holiday.Type.FIXED)
-                .rollable(true)
-                .monthDay(Month.DECEMBER, 26)
-                .build();
-        final Holiday newYearsEve = Holiday.builder()
-                .name("New Year's Eve")
-                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
-                        + "Exchange; omitted (not shifted) when it falls on a weekend")
-                .type(Holiday.Type.FLOATING)
-                .rollable(false)
-                .observance(new NewYearsEve())
-                .build();
-
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.previousFridayOrFollowingMonday())
                 .weekendDays(STANDARD_WEEKEND)
-                .holiday(newYearsDay)
-                .holiday(goodFriday)
-                .holiday(easterMonday)
-                .holiday(labourDay)
-                .holiday(ascensionDay)
-                .holiday(whitMonday)
-                .holiday(germanUnityDay)
-                .holiday(christmasEve)
-                .holiday(christmasDay)
-                .holiday(boxingDay)
-                .holiday(newYearsEve)
+                .holidays(DeHolidays.baseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXETR.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXETR.java
@@ -1,0 +1,85 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.de.ChristmasEve;
+import org.holiday.calendar.observance.de.NewYearsEve;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.holiday.calendar.HolidayCalendar.STANDARD_WEEKEND;
+
+/**
+ * Service for provision of Germany (Xetra) holiday calendar. Distinct from
+ * {@link HolidayCalendarServiceDE}, the Germany national public holiday
+ * calendar: this calendar additionally includes Christmas Eve and New
+ * Year's Eve as full non-trading days (Erfüllungstage) at Xetra/Frankfurt
+ * Stock Exchange — both are confirmed genuinely NOT German public holidays,
+ * and are omitted (not shifted) when they fall on a weekend. Xetra/FWB is
+ * closed on every public holiday observed by {@code DE}.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceXETR extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "XETR";
+    private static final String NAME = "Germany (Xetra) Holidays";
+
+    public HolidayCalendarServiceXETR() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday christmasEve = Holiday.builder()
+                .name("Christmas Eve")
+                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
+                        + "Exchange; omitted (not shifted) when it falls on a weekend")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new ChristmasEve())
+                .build();
+        final Holiday newYearsEve = Holiday.builder()
+                .name("New Year's Eve")
+                .description("Full non-trading day (Erfüllungstag) at Xetra/Frankfurt Stock "
+                        + "Exchange; omitted (not shifted) when it falls on a weekend")
+                .type(Holiday.Type.FLOATING)
+                .rollable(false)
+                .observance(new NewYearsEve())
+                .build();
+
+        final List<Holiday> holidays = new ArrayList<>(DeHolidays.baseHolidays());
+        holidays.add(christmasEve);
+        holidays.add(newYearsEve);
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.previousFridayOrFollowingMonday())
+                .weekendDays(STANDARD_WEEKEND)
+                .holidays(holidays)
+                .build();
+    }
+
+}

--- a/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-western/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -11,6 +11,7 @@ org.holiday.calendar.impl.HolidayCalendarServiceGBP
 org.holiday.calendar.impl.HolidayCalendarServiceUK
 org.holiday.calendar.impl.HolidayCalendarServiceUS
 org.holiday.calendar.impl.HolidayCalendarServiceUSD
+org.holiday.calendar.impl.HolidayCalendarServiceXETR
 org.holiday.calendar.impl.HolidayCalendarServiceXLON
 org.holiday.calendar.impl.HolidayCalendarServiceXNYS
 org.holiday.calendar.impl.HolidayCalendarServiceXTSE

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceDETest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceDETest.java
@@ -18,7 +18,7 @@
 
 package org.holiday.calendar.impl;
 
-import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayCalendarService;
 import org.holiday.calendar.HolidayDate;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
@@ -31,9 +31,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertTrue;
 
 public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarServiceTest {
 
@@ -48,9 +46,7 @@ public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarService
     Iterator<Object[]> expectedHolidayNames() {
         final Object[] germanUnityDay = {"German Unity Day"};
         final Object[] labourDay = {"Labour Day"};
-        final Object[] christmasEve = {"Christmas Eve"};
-        final Object[] newYearsEve = {"New Year's Eve"};
-        return Arrays.asList(germanUnityDay, labourDay, christmasEve, newYearsEve).listIterator();
+        return Arrays.asList(germanUnityDay, labourDay).listIterator();
     }
 
     @DataProvider
@@ -68,45 +64,23 @@ public class HolidayCalendarServiceDETest extends AbstractHolidayCalendarService
         final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
         // Boxing Day 2023: Dec 26 is Tuesday -> no roll
         final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
-        // Christmas Eve 2024: Dec 24 is Tuesday -> present, unrolled (primary-sourced)
-        final Object[] christmasEve24 = {2024, "Christmas Eve", LocalDate.of(2024, Month.DECEMBER, 24)};
-        // New Year's Eve 2025: Dec 31 is Wednesday -> present, unrolled (primary-sourced)
-        final Object[] newYearsEve25 = {2025, "New Year's Eve", LocalDate.of(2025, Month.DECEMBER, 31)};
-        // Christmas Eve 2021: Dec 24 is Friday -> present, unrolled (collision year, see
-        // testChristmasEveAndChristmasDayCoexistOn24Dec2021 below)
-        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
         return Arrays.asList(christmas21, christmas22, christmas23,
-                             boxingDay21, boxingDay22, boxingDay23,
-                             christmasEve24, newYearsEve25, christmasEve21).listIterator();
+                             boxingDay21, boxingDay22, boxingDay23).listIterator();
     }
 
     @Test
-    public void testChristmasEveAndNewYearsEveOmittedOnWeekend() {
-        // 2023: Dec 24 and Dec 31 both fall on a Sunday, so Xetra/FWB simply doesn't
-        // list an exception day at all -- no shift, no entry.
-        final HolidayCalendar calendar = factory.create(CODE);
-        final Set<String> names = calendar.calculate(2023).stream()
-                .map(hd -> hd.getHoliday().getName())
-                .collect(Collectors.toSet());
-        assertFalse(names.contains("Christmas Eve"), "Christmas Eve must be omitted in 2023 (Sunday)");
-        assertFalse(names.contains("New Year's Eve"), "New Year's Eve must be omitted in 2023 (Sunday)");
-    }
-
-    @Test
-    public void testChristmasEveAndChristmasDayCoexistOn24Dec2021() {
-        // Dec 25, 2021 is a Saturday and rolls to Friday Dec 24 under DE's
-        // previousFridayOrFollowingMonday roll rule, landing on the same calendar date
-        // as the new non-rolling Christmas Eve holiday. Both facts are independently
-        // true and must both appear -- no accidental de-duplication.
-        final HolidayCalendar calendar = factory.create(CODE);
-        final List<HolidayDate> dec24 = calendar.calculate(2021).stream()
-                .filter(hd -> LocalDate.of(2021, Month.DECEMBER, 24).equals(hd.getDate()))
-                .toList();
-
-        assertEquals(dec24.size(), 2, "Expected both Christmas Day (rolled) and Christmas Eve on 2021-12-24");
-        final Set<String> names = dec24.stream().map(hd -> hd.getHoliday().getName()).collect(Collectors.toSet());
-        assertTrue(names.contains("Christmas Day"));
-        assertTrue(names.contains("Christmas Eve"));
+    public void testChristmasEveAndNewYearsEveAbsentFromCalculate() {
+        HolidayCalendarService service = factory.getService(CODE);
+        for (int year : List.of(2021, 2023, 2024, 2025)) {
+            List<HolidayDate> holidays = service.getHolidayCalendar().calculate(year);
+            Set<String> actualNames = holidays.stream()
+                    .map(hd -> hd.getHoliday().getName())
+                    .collect(Collectors.toSet());
+            assertFalse(actualNames.contains("Christmas Eve"),
+                    "Christmas Eve must not appear in calculate(" + year + ") — moved to XETR");
+            assertFalse(actualNames.contains("New Year's Eve"),
+                    "New Year's Eve must not appear in calculate(" + year + ") — moved to XETR");
+        }
     }
 
 }

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXETRTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXETRTest.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.HolidayDate;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.time.LocalDate;
+import java.time.Month;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+
+public class HolidayCalendarServiceXETRTest extends AbstractHolidayCalendarServiceTest {
+
+    static final String CODE = "XETR";
+
+    public HolidayCalendarServiceXETRTest() {
+        super(CODE);
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayNames() {
+        final Object[] germanUnityDay = {"German Unity Day"};
+        final Object[] labourDay = {"Labour Day"};
+        final Object[] christmasEve = {"Christmas Eve"};
+        final Object[] newYearsEve = {"New Year's Eve"};
+        return Arrays.asList(germanUnityDay, labourDay, christmasEve, newYearsEve).listIterator();
+    }
+
+    @DataProvider
+    @Override
+    Iterator<Object[]> expectedHolidayOccurrences() {
+        // Christmas Day 2021: Dec 25 is Saturday -> rolls to Friday Dec 24
+        final Object[] christmas21 = {2021, "Christmas Day", LocalDate.of(2021, Month.DECEMBER, 24)};
+        // Christmas Day 2022: Dec 25 is Sunday -> rolls to Monday Dec 26
+        final Object[] christmas22 = {2022, "Christmas Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // Christmas Day 2023: Dec 25 is Monday -> no roll
+        final Object[] christmas23 = {2023, "Christmas Day", LocalDate.of(2023, Month.DECEMBER, 25)};
+        // Boxing Day 2021: Dec 26 is Sunday -> rolls to Monday Dec 27
+        final Object[] boxingDay21 = {2021, "Boxing Day", LocalDate.of(2021, Month.DECEMBER, 27)};
+        // Boxing Day 2022: Dec 26 is Monday -> no roll
+        final Object[] boxingDay22 = {2022, "Boxing Day", LocalDate.of(2022, Month.DECEMBER, 26)};
+        // Boxing Day 2023: Dec 26 is Tuesday -> no roll
+        final Object[] boxingDay23 = {2023, "Boxing Day", LocalDate.of(2023, Month.DECEMBER, 26)};
+        // Christmas Eve 2024: Dec 24 is Tuesday -> present, unrolled (primary-sourced)
+        final Object[] christmasEve24 = {2024, "Christmas Eve", LocalDate.of(2024, Month.DECEMBER, 24)};
+        // New Year's Eve 2025: Dec 31 is Wednesday -> present, unrolled (primary-sourced)
+        final Object[] newYearsEve25 = {2025, "New Year's Eve", LocalDate.of(2025, Month.DECEMBER, 31)};
+        // Christmas Eve 2021: Dec 24 is Friday -> present, unrolled (collision year, see
+        // testChristmasEveAndChristmasDayCoexistOn24Dec2021 below)
+        final Object[] christmasEve21 = {2021, "Christmas Eve", LocalDate.of(2021, Month.DECEMBER, 24)};
+        return Arrays.asList(christmas21, christmas22, christmas23,
+                             boxingDay21, boxingDay22, boxingDay23,
+                             christmasEve24, newYearsEve25, christmasEve21).listIterator();
+    }
+
+    @Test
+    public void testChristmasEveAndNewYearsEveOmittedOnWeekend() {
+        // 2023: Dec 24 and Dec 31 both fall on a Sunday, so Xetra/FWB simply doesn't
+        // list an exception day at all -- no shift, no entry.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final Set<String> names = calendar.calculate(2023).stream()
+                .map(hd -> hd.getHoliday().getName())
+                .collect(Collectors.toSet());
+        assertFalse(names.contains("Christmas Eve"), "Christmas Eve must be omitted in 2023 (Sunday)");
+        assertFalse(names.contains("New Year's Eve"), "New Year's Eve must be omitted in 2023 (Sunday)");
+    }
+
+    @Test
+    public void testChristmasEveAndChristmasDayCoexistOn24Dec2021() {
+        // Dec 25, 2021 is a Saturday and rolls to Friday Dec 24 under XETR's
+        // previousFridayOrFollowingMonday roll rule, landing on the same calendar date
+        // as the non-rolling Christmas Eve holiday. Both facts are independently
+        // true and must both appear -- no accidental de-duplication.
+        final HolidayCalendar calendar = factory.create(CODE);
+        final List<HolidayDate> dec24 = calendar.calculate(2021).stream()
+                .filter(hd -> LocalDate.of(2021, Month.DECEMBER, 24).equals(hd.getDate()))
+                .toList();
+
+        assertEquals(dec24.size(), 2, "Expected both Christmas Day (rolled) and Christmas Eve on 2021-12-24");
+        final Set<String> names = dec24.stream().map(hd -> hd.getHoliday().getName()).collect(Collectors.toSet());
+        assertTrue(names.contains("Christmas Day"));
+        assertTrue(names.contains("Christmas Eve"));
+    }
+
+}

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -90,6 +90,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"UK"},
                 new Object[]{"US"},
                 new Object[]{"USD"},
+                new Object[]{"XETR"},
                 new Object[]{"XLON"},
                 new Object[]{"XNYS"},
                 new Object[]{"XTSE"}
@@ -407,7 +408,7 @@ public class HolidayCalendar30YearIT {
     }
 
     // =========================================================================
-    // 9. DE CHRISTMAS EVE / NEW YEAR'S EVE (Xetra/FWB full non-trading days) OVER 30 YEARS
+    // 9. XETR CHRISTMAS EVE / NEW YEAR'S EVE (Xetra/FWB full non-trading days) OVER 30 YEARS
     // =========================================================================
 
     // Xetra/FWB's Christmas Eve and New Year's Eve are full non-trading days, not
@@ -415,14 +416,14 @@ public class HolidayCalendar30YearIT {
     // calculateEarlyCloses(). Each is omitted (not shifted) when its date falls on a
     // weekend; expected presence is re-derived from each date's day-of-week rule for
     // every year rather than hand-fixtured.
-    @Test(description = "DE calculate() across 2026-2055: Christmas Eve/New Year's Eve present "
+    @Test(description = "XETR calculate() across 2026-2055: Christmas Eve/New Year's Eve present "
             + "unrolled whenever not Sat/Sun, absent (not shifted) when Sat/Sun, no nulls")
-    public void testDEChristmasEveAndNewYearsEveOver30Years() {
-        HolidayCalendar calendar = new HolidayCalendarFactory().create("DE");
+    public void testXETRChristmasEveAndNewYearsEveOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XETR");
 
         for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
             List<HolidayDate> all = calendar.calculate(year);
-            assertNotNull(all, "DE: calculate(" + year + ") must not be null");
+            assertNotNull(all, "XETR: calculate(" + year + ") must not be null");
 
             LocalDate dec24 = LocalDate.of(year, Month.DECEMBER, 24);
             DayOfWeek dec24Dow = dec24.getDayOfWeek();
@@ -431,7 +432,7 @@ public class HolidayCalendar30YearIT {
             boolean dec24Present = all.stream().anyMatch(hd ->
                     "Christmas Eve".equals(hd.holiday().getName()) && dec24.equals(hd.date()));
             assertEquals(dec24Present, dec24Expected,
-                    "DE " + year + ": Christmas Eve presence/date must match December 24 dow rule (dow=" + dec24Dow + ")");
+                    "XETR " + year + ": Christmas Eve presence/date must match December 24 dow rule (dow=" + dec24Dow + ")");
 
             LocalDate dec31 = LocalDate.of(year, Month.DECEMBER, 31);
             DayOfWeek dec31Dow = dec31.getDayOfWeek();
@@ -440,7 +441,7 @@ public class HolidayCalendar30YearIT {
             boolean dec31Present = all.stream().anyMatch(hd ->
                     "New Year's Eve".equals(hd.holiday().getName()) && dec31.equals(hd.date()));
             assertEquals(dec31Present, dec31Expected,
-                    "DE " + year + ": New Year's Eve presence/date must match December 31 dow rule (dow=" + dec31Dow + ")");
+                    "XETR " + year + ": New Year's Eve presence/date must match December 31 dow rule (dow=" + dec31Dow + ")");
         }
     }
 


### PR DESCRIPTION
### Title of the PR

Create national Germany (DE) calendar alongside Xetra (XETR) market calendar

**Description**

- Sub-issue of #231 (itself a sub-issue of #229). Repurposes `HolidayCalendarServiceDE` as a pure national calendar and introduces `HolidayCalendarServiceXETR` (ISO 10383 MIC code for Xetra) to carry forward the existing market-calendar content as a verbatim, lossless copy (all 11 entries, including Christmas Eve/New Year's Eve as `FLOATING` full closures with weekend suppression via `isValidYear`).
- Research confirmed the 9 non-Eve holidays are **exactly** Germany's 9 official nationwide (bundesweite) public holidays — no accuracy issues, the lowest-risk sub-issue of the seven (unlike CH's cantonal ambiguity). Christmas Eve and New Year's Eve are confirmed genuinely NOT German public holidays; they are Xetra/Frankfurt-specific market closures and correctly move to the market-only class.
- Shared holiday definitions extracted into a new package-private `DeHolidays` factory, consumed by both `HolidayCalendarServiceDE` and `HolidayCalendarServiceXETR`.
- Registered `HolidayCalendarServiceXETR` in `module-info.java` and `META-INF/services/org.holiday.calendar.HolidayCalendarService`.
- Added `HolidayCalendarServiceXETRTest` and moved `DE`'s existing Christmas Eve/New Year's Eve collision tests there; trimmed `DE`'s DataProviders to drop the now-deleted fixtures and added `testChristmasEveAndNewYearsEveAbsentFromCalculate()`.
- `HolidayCalendar30YearIT`: added `XETR` to the calendar-code list; renamed `testDEChristmasEveAndNewYearsEveOver30Years` → `testXETRChristmasEveAndNewYearsEveOver30Years`.
- README calendar table updates are tracked separately in #230 and are intentionally out of scope here, consistent with the prior UK/XLON, CA/XTSE, AU/XASX, FR/XPAR, and CH/XSWX splits.

**Related Issue**

- [#240](https://github.com/holiday-calendar/holiday-calendar-java/issues/240)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed (README table deferred to #230)
- [ ] Screenshots or additional notes added, if needed
