### PR TITLE
Repo-wide national-vs-market invariant test and module-info.java doc update

### DIFF
--- a/holiday-calendar-western/src/main/java/module-info.java
+++ b/holiday-calendar-western/src/main/java/module-info.java
@@ -21,9 +21,11 @@
  *
  * <p>Provides holiday calendar implementations and observances for Western
  * countries: Australia, Canada, France, Germany, Switzerland, the United
- * Kingdom, and the United States. Also provides equities-market/exchange
- * trading calendars (e.g. the New York Stock Exchange) distinct from their
- * national-holiday counterparts.
+ * Kingdom, and the United States. Also provides the corresponding
+ * equities-market/exchange trading calendars — ASX (XASX), Xetra (XETR),
+ * London Stock Exchange (XLON), NYSE (XNYS), Euronext Paris (XPAR), Toronto
+ * Stock Exchange (XTSE), and SIX Swiss Exchange (XSWX) — each distinct from
+ * its national-holiday counterpart.
  */
 module org.holiday.calendar.western {
     requires org.holiday.calendar.core;

--- a/tests/src/test/java/org/holiday/calendar/NationalCalendarNoEarlyClosesIT.java
+++ b/tests/src/test/java/org/holiday/calendar/NationalCalendarNoEarlyClosesIT.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.util.Iterator;
+import java.util.List;
+import java.util.Set;
+
+import static org.testng.Assert.assertFalse;
+
+/**
+ * Repo-wide invariant test (issue #241): every national holiday calendar —
+ * identified by a 2-character ISO 3166-1 alpha-2 code — must never carry
+ * early-close (half-day) entries. Early closes are a market/exchange concept
+ * only, exposed through market/currency/MIC codes of 3 or more characters.
+ *
+ * <p>The set of codes under test is derived from
+ * {@link HolidayCalendarFactory#listAvailableCodes()} rather than a
+ * hardcoded list, so it stays correct as new national calendars are added.
+ *
+ * <p>{@code SG} and {@code TR} are excluded pending the still-open sibling
+ * fixes for those two codes: {@code SG} under APAC issue #232, {@code TR}
+ * under MENA issue #233 (part of the same #229 national-vs-market audit that
+ * produced this test). Remove them from {@link #KNOWN_CONFLATED_CODES} once
+ * those issues land.
+ */
+public class NationalCalendarNoEarlyClosesIT {
+
+    private static final Set<String> KNOWN_CONFLATED_CODES = Set.of("SG", "TR");
+
+    private final HolidayCalendarFactory factory = new HolidayCalendarFactory();
+
+    @DataProvider(name = "nationalCalendarCodes")
+    public Iterator<Object[]> nationalCalendarCodes() {
+        List<String> codes = factory.listAvailableCodes().stream()
+                .filter(code -> code.length() == 2)
+                .filter(code -> !KNOWN_CONFLATED_CODES.contains(code))
+                .toList();
+        return codes.stream().map(code -> new Object[]{code}).iterator();
+    }
+
+    @Test(dataProvider = "nationalCalendarCodes",
+          description = "National calendars (2-character codes) must never report early closes")
+    public void testNationalCalendarHasNoEarlyCloses(String code) {
+        HolidayCalendar calendar = factory.create(code);
+        assertFalse(calendar.hasEarlyCloses(),
+                code + ": national calendar must not carry early-close (half-day) entries");
+    }
+
+}


### PR DESCRIPTION
### Title of the PR

Repo-wide national-vs-market invariant test and module-info.java doc update

**Description**

- Cross-cutting sub-issue of #231 (itself a sub-issue of #229), landed after all 7 country splits (#234–#240).
- Adds `NationalCalendarNoEarlyClosesIT` in the `tests` aggregation module: a single parametrized TestNG test asserting `hasEarlyCloses() == false` for every national calendar code (`code.length() == 2`), derived from `HolidayCalendarFactory.listAvailableCodes()` rather than a hardcoded list, so it stays correct as new national calendars are added.
- `SG` and `TR` are excluded via a documented `KNOWN_CONFLATED_CODES` set, pending their still-open sibling fixes tracked under #232 (APAC) and #233 (MENA) — both part of the same #229 audit but out of scope for this PR.
- Updates the top-of-file Javadoc in `holiday-calendar-western/src/main/java/module-info.java`, which was stale after the 7 new MIC market classes (XNYS, XTSE, XLON, XASX, XPAR, XSWX, XETR) were added across #234–#240; now names all 7 exchange calendars alongside their national counterparts.
- Ran a full `mvn clean verify` (SonarCloud/JaCoCo profile) at the repo root: no new-code duplication-gate regressions from the cumulative set of 7 split PRs, and the invariant test passes for all national codes outside the two known, separately-tracked exceptions.

**Related Issue**

- [#241](https://github.com/holiday-calendar/holiday-calendar-java/issues/241)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed
