### PR TITLE
#233 Carry Republic Day Eve early close on both TR and TRY, fix close time to 13:00

### DIFF
--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTR.java
@@ -22,15 +22,14 @@ import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
 
-import java.util.List;
 import java.util.OptionalInt;
 
 /**
  * Service for provision of Turkey national public holiday calendar.
  *
- * <p>Calendar code: {@code TR}. Covers public holidays observed in the Republic
- * of Turkey as declared by Borsa Istanbul (BIST) and the Central Bank of the
- * Republic of Turkey (TCMB).
+ * <p>Calendar code: {@code TR}. Covers public holidays observed nationwide in the
+ * Republic of Turkey under Law No. 2429 (Ulusal Bayram ve Genel Tatiller Hakkında
+ * Kanun).
  *
  * <p>Weekend: Saturday + Sunday (standard Western weekend). Fixed holidays that
  * fall on Saturday or Sunday are observed on the following Monday per
@@ -48,12 +47,16 @@ import java.util.OptionalInt;
  * against official announcements as each year is
  * published. Corrections require a new JAR release.
  *
- * <p>Borsa Istanbul (BIST) observes a half-day closure on 28 October (Republic
- * Day Eve), closing at 12:30 {@code Europe/Istanbul}. This is modelled as an
- * {@code EARLY_CLOSE} holiday, non-rollable, and reported separately via
- * {@link HolidayCalendar#calculateEarlyCloses(int)} rather than {@link
- * HolidayCalendar#calculate(int)}. It does not shift when 28 October falls on
- * a Saturday or Sunday.
+ * <p>Law No. 2429 itself declares Republic Day Eve (28 October) a nationwide
+ * half-day holiday, in effect from 13:00 {@code Europe/Istanbul} through the end
+ * of Republic Day on 29 October — it applies to all public institutions, not just
+ * Borsa Istanbul (BIST) or the Central Bank of the Republic of Turkey (TCMB). This
+ * is modelled as an {@code EARLY_CLOSE} holiday, non-rollable, and reported
+ * separately via {@link HolidayCalendar#calculateEarlyCloses(int)} rather than
+ * {@link HolidayCalendar#calculate(int)}. It does not shift when 28 October falls
+ * on a Saturday or Sunday. The same closure is also carried by {@link
+ * HolidayCalendarServiceTRY}, since it is a statutory holiday rather than a
+ * market-only convention.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -78,7 +81,7 @@ public class HolidayCalendarServiceTR extends AbstractHolidayCalendarService {
                 .name(NAME)
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(TurkeyHolidays.STANDARD_WEEKEND)
-                .holidays(TurkeyHolidays.baseHolidays(true, List.of()))
+                .holidays(TurkeyHolidays.baseHolidays(true))
                 .holidays(TurkeyHolidays.earlyCloseHolidays())
                 .build();
     }

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTRY.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceTRY.java
@@ -22,7 +22,6 @@ import org.holiday.calendar.AbstractHolidayCalendarService;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
 
-import java.util.List;
 import java.util.OptionalInt;
 
 /**
@@ -30,7 +29,8 @@ import java.util.OptionalInt;
  *
  * <p>Calendar code: {@code TRY}. Covers settlement closure days for Borsa Istanbul
  * (BIST) and the Central Bank of the Republic of Turkey (TCMB). The settlement
- * holiday schedule mirrors the Turkey national calendar ({@code TR}).
+ * holiday schedule mirrors the Turkey national calendar ({@code TR}), differing
+ * only in roll strategy.
  *
  * <p>Roll strategy: {@link DateRolls#noRoll()} — settlement requires both
  * counterparties to be available on the same calendar date; there is no
@@ -38,12 +38,13 @@ import java.util.OptionalInt;
  *
  * <p>Weekend: Saturday + Sunday (standard Western weekend).
  *
- * <p><strong>Half-day closure not modelled:</strong>
- * Borsa Istanbul (BIST) and TCMB observe a partial closure on 28 October
- * (Republic Day Eve): BIST closes at 12:30 local time and TCMB suspends TRY
- * settlement from midday. This calendar does not include 28 October as a holiday.
- * Callers relying on afternoon liquidity or same-day settlement on this date must
- * apply their own adjustment.
+ * <p>Law No. 2429 (Ulusal Bayram ve Genel Tatiller Hakkında Kanun) declares
+ * Republic Day Eve (28 October) a nationwide half-day holiday, in effect from
+ * 13:00 {@code Europe/Istanbul}. This is modelled as an {@code EARLY_CLOSE}
+ * holiday, non-rollable, and reported separately via {@link
+ * HolidayCalendar#calculateEarlyCloses(int)} rather than {@link
+ * HolidayCalendar#calculate(int)}. It does not shift when 28 October falls on
+ * a Saturday or Sunday.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
@@ -68,7 +69,8 @@ public class HolidayCalendarServiceTRY extends AbstractHolidayCalendarService {
                 .name(NAME)
                 .dateRoll(DateRolls.noRoll())
                 .weekendDays(TurkeyHolidays.STANDARD_WEEKEND)
-                .holidays(TurkeyHolidays.baseHolidays(false, List.of()))
+                .holidays(TurkeyHolidays.baseHolidays(false))
+                .holidays(TurkeyHolidays.earlyCloseHolidays())
                 .build();
     }
 

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/impl/TurkeyHolidays.java
@@ -58,12 +58,14 @@ import java.util.List;
  * <p>Turkey observes three days of Eid al-Fitr (Ramazan Bayramı) and four days
  * of Eid al-Adha (Kurban Bayramı), consistent with BIST market closure announcements.
  *
- * <p>Borsa Istanbul (BIST) observes a half-day closure on 28 October (Republic
- * Day Eve), closing at 12:30 {@code Europe/Istanbul}. This is modelled as an
- * {@link Holiday.Type#EARLY_CLOSE} holiday via {@link #earlyCloseHolidays()},
- * consumed by {@link HolidayCalendarServiceTR}. It does not shift when
- * 28 October falls on a Saturday or Sunday — see {@link RepublicDayEveEarlyClose}.
- * {@link HolidayCalendarServiceTRY} does not yet include this half-day closure.
+ * <p>Law No. 2429 (Ulusal Bayram ve Genel Tatiller Hakkında Kanun) declares
+ * Republic Day Eve (28 October) a nationwide half-day holiday, in effect from
+ * 13:00 {@code Europe/Istanbul}. It applies to all public institutions, not just
+ * Borsa Istanbul (BIST) or the Central Bank of the Republic of Turkey (TCMB), so
+ * it is modelled as an {@link Holiday.Type#EARLY_CLOSE} holiday via {@link
+ * #earlyCloseHolidays()} and consumed by both {@link HolidayCalendarServiceTR}
+ * and {@link HolidayCalendarServiceTRY}. It does not shift when 28 October falls
+ * on a Saturday or Sunday — see {@link RepublicDayEveEarlyClose}.
  *
  * <p>Note: the 2033 Gregorian year contains two Eid al-Fitr occurrences; only the
  * January occurrence is recorded in the CSV. See {@link EidAlFitr} for details.
@@ -78,15 +80,14 @@ class TurkeyHolidays {
     private TurkeyHolidays() {}
 
     /**
-     * Returns the 15 Turkey public holidays.
+     * Returns the 14 Turkey full-day public holidays. Does not include the
+     * Republic Day Eve early close; see {@link #earlyCloseHolidays()}.
      *
      * @param rollableFixed whether fixed-date holidays are rollable; all Islamic
      *                      holidays are always {@code rollable(false)}
-     * @param additional    additional holidays to append (e.g. future BIST-specific
-     *                      closures); pass {@link List#of()} when not needed
      */
-    static List<Holiday> baseHolidays(boolean rollableFixed, List<Holiday> additional) {
-        List<Holiday> holidays = new ArrayList<>(15 + additional.size());
+    static List<Holiday> baseHolidays(boolean rollableFixed) {
+        List<Holiday> holidays = new ArrayList<>(14);
         holidays.add(Holiday.builder()
                 .name("New Year's Day")
                 .description("First day of the new year in the Common Era (CE)")
@@ -189,26 +190,25 @@ class TurkeyHolidays {
                 .rollable(rollableFixed)
                 .monthDay(Month.OCTOBER, 29)
                 .build());
-        holidays.addAll(additional);
         return List.copyOf(holidays);
     }
 
     /**
-     * Returns the single {@code EARLY_CLOSE} holiday representing BIST's
-     * Republic Day Eve half-day close (28 October, closing at 12:30
-     * {@code Europe/Istanbul}). Does not shift when 28 October falls on a
-     * Saturday or Sunday; see {@link RepublicDayEveEarlyClose}.
+     * Returns the single {@code EARLY_CLOSE} holiday representing the
+     * nationwide Republic Day Eve half-day (28 October, in effect from 13:00
+     * {@code Europe/Istanbul} per Law No. 2429). Does not shift when 28 October
+     * falls on a Saturday or Sunday; see {@link RepublicDayEveEarlyClose}.
      */
     static List<Holiday> earlyCloseHolidays() {
         return List.of(
             Holiday.builder()
                     .name("Republic Day Eve")
-                    .description("BIST half-day close ahead of Republic Day; no adjustment when "
-                            + "28 October falls on a Saturday or Sunday")
+                    .description("Nationwide half-day ahead of Republic Day per Law No. 2429; no "
+                            + "adjustment when 28 October falls on a Saturday or Sunday")
                     .type(Holiday.Type.EARLY_CLOSE)
                     .rollable(false)
                     .observance(new RepublicDayEveEarlyClose())
-                    .closeTime(LocalTime.of(12, 30))
+                    .closeTime(LocalTime.of(13, 0))
                     .zoneId(ZoneId.of("Europe/Istanbul"))
                     .build()
         );

--- a/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
+++ b/holiday-calendar-mena/src/main/java/org/holiday/calendar/observance/tr/RepublicDayEveEarlyClose.java
@@ -25,13 +25,15 @@ import java.time.LocalDate;
 import java.time.Month;
 
 /**
- * Observance of Borsa İstanbul's (BIST) Republic Day Eve half-day close
- * (October 28). Unlike the LSE's Christmas Eve convention, BIST does not
- * shift this session to the preceding Friday when October 28 falls on a
- * Saturday or Sunday — the market is simply closed for the weekend as usual,
- * with no early-close adjustment that year (confirmed against BIST's 2023
- * holiday schedule, where 28-29 October fell on Saturday-Sunday with no
- * preceding half-day session).
+ * Observance of Turkey's Republic Day Eve nationwide half-day (October 28),
+ * declared by Law No. 2429 (Ulusal Bayram ve Genel Tatiller Hakkında Kanun)
+ * and observed alike by public institutions, Borsa İstanbul (BIST), and the
+ * Central Bank of the Republic of Turkey (TCMB). Unlike the LSE's Christmas
+ * Eve convention, it does not shift to the preceding Friday when October 28
+ * falls on a Saturday or Sunday — institutions are simply closed for the
+ * weekend as usual, with no early-close adjustment that year (confirmed
+ * against BIST's 2023 holiday schedule, where 28-29 October fell on
+ * Saturday-Sunday with no preceding half-day session).
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRTest.java
@@ -38,7 +38,8 @@ import static org.testng.Assert.*;
 
 public class HolidayCalendarServiceTRTest {
 
-    // 7 fixed + 3 Eid al-Fitr + 4 Eid al-Adha = 14 (Republic Day Eve omitted; half-day not modelled)
+    // 7 fixed + 3 Eid al-Fitr + 4 Eid al-Adha = 14 (Republic Day Eve is an EARLY_CLOSE
+    // holiday, reported separately via calculateEarlyCloses() — not counted here)
     private static final int TR_HOLIDAY_COUNT = 14;
 
     private final HolidayCalendarServiceTR service = new HolidayCalendarServiceTR();

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRYEarlyCloseTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRYEarlyCloseTest.java
@@ -32,17 +32,17 @@ import java.util.List;
 import static org.testng.Assert.*;
 
 /**
- * Tests for the {@code TR} calendar's early-close (nationwide Republic Day Eve
+ * Tests for the {@code TRY} calendar's early-close (nationwide Republic Day Eve
  * half-day per Law No. 2429) holiday, provided by {@link TurkeyHolidays#earlyCloseHolidays()}.
  */
-public class HolidayCalendarServiceTREarlyCloseTest {
+public class HolidayCalendarServiceTRYEarlyCloseTest {
 
     private static final int EARLY_CLOSE_COUNT = 1;
     private static final int FULL_DAY_HOLIDAY_COUNT = 14;
     private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(13, 0);
     private static final ZoneId EXPECTED_ZONE = ZoneId.of("Europe/Istanbul");
 
-    private final HolidayCalendarServiceTR service = new HolidayCalendarServiceTR();
+    private final HolidayCalendarServiceTRY service = new HolidayCalendarServiceTRY();
 
     @Test
     public void testEarlyCloseHolidayCount2025() {

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRYTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceTRYTest.java
@@ -38,7 +38,8 @@ import static org.testng.Assert.*;
 
 public class HolidayCalendarServiceTRYTest {
 
-    // 7 fixed + 3 Eid al-Fitr + 4 Eid al-Adha = 14 (Republic Day Eve omitted; half-day not modelled)
+    // 7 fixed + 3 Eid al-Fitr + 4 Eid al-Adha = 14 (Republic Day Eve is an EARLY_CLOSE
+    // holiday, reported separately via calculateEarlyCloses() — not counted here)
     private static final int TRY_HOLIDAY_COUNT = 14;
 
     private final HolidayCalendarServiceTRY service = new HolidayCalendarServiceTRY();
@@ -264,15 +265,16 @@ public class HolidayCalendarServiceTRYTest {
     }
 
     // =========================================================================
-    // Republic Day Eve (Oct 28) — confirmed absent
+    // Republic Day Eve (Oct 28) — early close, not a full-day holiday
     // =========================================================================
 
     @Test
-    public void testRepublicDayEveAbsent2025() {
+    public void testRepublicDayEveAbsentFromCalculate2025() {
         boolean oct28Present = service.getHolidayCalendar().calculate(2025).stream()
                 .anyMatch(hd -> hd.date().equals(LocalDate.of(2025, Month.OCTOBER, 28)));
         assertFalse(oct28Present,
-                "Oct 28 (Republic Day Eve) must not be present — half-day closures are not modelled");
+                "Oct 28 (Republic Day Eve) is an EARLY_CLOSE holiday and must not appear in calculate(), "
+                        + "only in calculateEarlyCloses() — see HolidayCalendarServiceTRYEarlyCloseTest");
     }
 
     // =========================================================================


### PR DESCRIPTION
### Carry Republic Day Eve early close on both TR and TRY, fix close time to 13:00

**Description**

- Republic Day Eve (28 October) is a statutory nationwide half-day under Law No. 2429, not a BIST-only convention as originally assumed — research found no evidence BIST and TCMB closures have ever diverged on this date, so there's no basis for a market-only calendar carrying it exclusively.
- Instead of moving the `EarlyCloseHoliday` from `TR` to `TRY` (the original scope), it now lives on both, sourced from the shared `TurkeyHolidays.earlyCloseHolidays()`. `TurkeyHolidays.baseHolidays()` dropped its now-unused `additional` parameter, so `TR` and `TRY` construction differs only in `rollableFixed`/`DateRoll` strategy and name/description.
- Fixed the hardcoded close time from 12:30 to 13:00 Europe/Istanbul — every source found (Law No. 2429 itself, BIST's official holiday schedule, TCMB payment-systems docs) says 13:00; 12:30 traced back to one bank's internal EFT product cutoff, not the market/system close.
- Updated Javadoc on `HolidayCalendarServiceTR`, `HolidayCalendarServiceTRY`, `TurkeyHolidays`, and `RepublicDayEveEarlyClose` to cite Law No. 2429 and drop the disproven "BIST-only" framing.

**Related Issue**

- [#233](https://github.com/holiday-calendar/holiday-calendar-java/issues/233) — see issue comments for the research trail behind the scope change from the original issue description

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [x] Other (please describe): corrects existing holiday data (calendar placement + close time) discovered to be inaccurate during implementation

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed
