### PR TITLE
[APAC] Split SGX from SG national calendar; redocument JP as national-only

### DIFF
--- a/holiday-calendar-apac/src/main/java/module-info.java
+++ b/holiday-calendar-apac/src/main/java/module-info.java
@@ -21,8 +21,9 @@
  *
  * <p>Provides holiday calendar implementations and observances for Asia-Pacific
  * countries, including lunar, Islamic, and Hindu calendar-based holidays.
- * Supports Singapore SGX (SG), Singapore MAS MEPS+ (SGD), Tokyo Stock Exchange (JP),
- * Bank of Japan (JPY), People's Bank of China (CNY), and China national (CN).
+ * Supports Singapore national (SG), Singapore Exchange (XSES), Singapore MAS
+ * MEPS+ (SGD), Japan national (JP), Bank of Japan (JPY), People's Bank of
+ * China (CNY), and China national (CN).
  */
 module org.holiday.calendar.apac {
     requires org.holiday.calendar.core;
@@ -39,6 +40,7 @@ module org.holiday.calendar.apac {
     provides org.holiday.calendar.HolidayCalendarService with
         org.holiday.calendar.impl.HolidayCalendarServiceCNY,
         org.holiday.calendar.impl.HolidayCalendarServiceSG,
+        org.holiday.calendar.impl.HolidayCalendarServiceXSES,
         org.holiday.calendar.impl.HolidayCalendarServiceSGD,
         org.holiday.calendar.impl.HolidayCalendarServiceJP,
         org.holiday.calendar.impl.HolidayCalendarServiceJPY,

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJP.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJP.java
@@ -23,18 +23,21 @@ import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
 
 /**
- * Service for provision of the Japan (Tokyo Stock Exchange / TSE) holiday calendar.
+ * Service for provision of the Japan national public holiday calendar.
  *
- * <p>Calendar code: {@code JP}. The TSE calendar is based on Japanese national
- * public holidays with the substitute-holiday rule (振替休日): when a holiday falls
- * on Sunday, the following Monday is observed instead. The sandwiched-day rule
- * (国民の休日) is also applied: a non-holiday weekday between two consecutive
- * national holidays becomes a holiday.
+ * <p>Calendar code: {@code JP}. Based on Japan's national Holiday Act, with the
+ * substitute-holiday rule (振替休日): when a holiday falls on Sunday, the
+ * following Monday is observed instead. The sandwiched-day rule (国民の休日) is
+ * also applied: a non-holiday weekday between two consecutive national
+ * holidays becomes a holiday. This is a pure national calendar with no
+ * exchange- or bank-specific content; see {@link HolidayCalendarServiceJPY}
+ * for the Bank of Japan's settlement calendar, which adds genuine
+ * BOJ-specific closures (Jan 2, Jan 3, Dec 31) on top of this list.
  */
 public class HolidayCalendarServiceJP extends AbstractHolidayCalendarService {
 
     private static final String CODE = "JP";
-    private static final String NAME = "Japan (TSE) Holidays";
+    private static final String NAME = "Japan National Holidays";
 
     public HolidayCalendarServiceJP() {
         super(CODE, NAME);

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJPY.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceJPY.java
@@ -29,7 +29,7 @@ import java.time.Month;
  * Service for provision of the Japan (Bank of Japan / BOJ) holiday calendar.
  *
  * <p>Calendar code: {@code JPY}. The BOJ calendar shares all Japanese national
- * public holidays with the TSE calendar ({@code JP}) and additionally closes on
+ * public holidays with the national calendar ({@code JP}) and additionally closes on
  * January 2, January 3, and December 31 as BOJ operational closures. The
  * substitute-holiday rule (振替休日) and sandwiched-day rule (国民の休日) both apply.
  */

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceSG.java
@@ -19,31 +19,25 @@
 package org.holiday.calendar.impl;
 
 import org.holiday.calendar.AbstractHolidayCalendarService;
-import org.holiday.calendar.Holiday;
 import org.holiday.calendar.HolidayCalendar;
 import org.holiday.calendar.function.DateRolls;
-import org.holiday.calendar.observance.sg.ChristmasEveEarlyClose;
-import org.holiday.calendar.observance.sg.NewYearsEveEarlyClose;
 
-import java.time.LocalTime;
-import java.time.ZoneId;
 import java.util.OptionalInt;
 
 /**
- * Service for provision of Singapore Exchange (SGX) holiday calendar.
+ * Service for provision of the Singapore national public holiday calendar.
  *
- * <p>Includes two {@code EARLY_CLOSE} holidays representing SGX's Christmas
- * Eve and New Year's Eve half-day trading closes. The MAS/MEPS+ settlement
- * calendar ({@link HolidayCalendarServiceSGD}) does not include these — MEPS+
- * RTGS settlement and SGX equities trading are distinct systems.
+ * <p>Distinct from {@link HolidayCalendarServiceXSES}, the Singapore Exchange
+ * (SGX) trading calendar: that calendar additionally includes two
+ * {@code EARLY_CLOSE} holidays representing SGX's Christmas Eve and New
+ * Year's Eve half-day trading closes, which this national calendar does not.
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
 public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
 
     private static final String CODE = "SG";
-    private static final String NAME = "Singapore (SGX) Holidays";
-    private static final ZoneId SGX_ZONE = ZoneId.of("Asia/Singapore");
+    private static final String NAME = "Singapore National Holidays";
 
     public HolidayCalendarServiceSG() {
         super(CODE, NAME);
@@ -56,35 +50,12 @@ public class HolidayCalendarServiceSG extends AbstractHolidayCalendarService {
 
     @Override
     public HolidayCalendar getHolidayCalendar() {
-        final Holiday christmasEveEarlyClose = Holiday.builder()
-                .name("Christmas Eve")
-                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
-                             + "December 24 falls Monday through Friday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new ChristmasEveEarlyClose())
-                .closeTime(LocalTime.of(12, 0))
-                .zoneId(SGX_ZONE)
-                .build();
-        final Holiday newYearsEveEarlyClose = Holiday.builder()
-                .name("New Year's Eve")
-                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
-                             + "December 31 falls Monday through Friday")
-                .type(Holiday.Type.EARLY_CLOSE)
-                .rollable(false)
-                .observance(new NewYearsEveEarlyClose())
-                .closeTime(LocalTime.of(12, 0))
-                .zoneId(SGX_ZONE)
-                .build();
-
         return HolidayCalendar.builder()
                 .code(CODE)
                 .name(NAME)
                 .dateRoll(DateRolls.followingMonday())
                 .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
                 .holidays(SingaporeHolidays.baseHolidays(true))
-                .holiday(christmasEveEarlyClose)
-                .holiday(newYearsEveEarlyClose)
                 .build();
     }
 

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXSES.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/HolidayCalendarServiceXSES.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Holiday Calendar - A library for definition and calculation of holiday calendars
+ * Copyright (C) 2021-2026 The Holiday Calendar Project Contributors
+ *
+ * This library is free software; you can redistribute it and/or modify it under
+ * the terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option) any
+ * later version.
+ *
+ * This library is distributed in the hope that it will be useful, but WITHOUT ANY
+ * WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+ * PARTICULAR PURPOSE. See the GNU Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License along
+ * with this library; if not, write to the Free Software Foundation, Inc., 59
+ * Temple Place, Suite 330, Boston, MA 02111-1307 USA
+ ******************************************************************************/
+
+package org.holiday.calendar.impl;
+
+import org.holiday.calendar.AbstractHolidayCalendarService;
+import org.holiday.calendar.Holiday;
+import org.holiday.calendar.HolidayCalendar;
+import org.holiday.calendar.function.DateRolls;
+import org.holiday.calendar.observance.sg.ChristmasEveEarlyClose;
+import org.holiday.calendar.observance.sg.NewYearsEveEarlyClose;
+
+import java.time.LocalTime;
+import java.time.ZoneId;
+import java.util.OptionalInt;
+
+/**
+ * Service for provision of Singapore Exchange (SGX) holiday calendar. Distinct
+ * from {@link HolidayCalendarServiceSG}, the Singapore national public holiday
+ * calendar: this calendar additionally includes two {@code EARLY_CLOSE}
+ * holidays representing SGX's Christmas Eve and New Year's Eve half-day
+ * trading closes. The MAS/MEPS+ settlement calendar
+ * ({@link HolidayCalendarServiceSGD}) does not include these — MEPS+ RTGS
+ * settlement and SGX equities trading are distinct systems.
+ *
+ * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
+ */
+public class HolidayCalendarServiceXSES extends AbstractHolidayCalendarService {
+
+    private static final String CODE = "XSES";
+    private static final String NAME = "Singapore Exchange (SGX) Holidays";
+    private static final ZoneId SGX_ZONE = ZoneId.of("Asia/Singapore");
+
+    public HolidayCalendarServiceXSES() {
+        super(CODE, NAME);
+    }
+
+    @Override
+    public OptionalInt dataValidThrough() {
+        return OptionalInt.of(SingaporeHolidays.DATA_VALID_THROUGH);
+    }
+
+    @Override
+    public HolidayCalendar getHolidayCalendar() {
+        final Holiday christmasEveEarlyClose = Holiday.builder()
+                .name("Christmas Eve")
+                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
+                             + "December 24 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new ChristmasEveEarlyClose())
+                .closeTime(LocalTime.of(12, 0))
+                .zoneId(SGX_ZONE)
+                .build();
+        final Holiday newYearsEveEarlyClose = Holiday.builder()
+                .name("New Year's Eve")
+                .description("SGX half-day trading close (09:00-12:00 SGT); occurs whenever "
+                             + "December 31 falls Monday through Friday")
+                .type(Holiday.Type.EARLY_CLOSE)
+                .rollable(false)
+                .observance(new NewYearsEveEarlyClose())
+                .closeTime(LocalTime.of(12, 0))
+                .zoneId(SGX_ZONE)
+                .build();
+
+        return HolidayCalendar.builder()
+                .code(CODE)
+                .name(NAME)
+                .dateRoll(DateRolls.followingMonday())
+                .weekendDays(HolidayCalendar.STANDARD_WEEKEND)
+                .holidays(SingaporeHolidays.baseHolidays(true))
+                .holiday(christmasEveEarlyClose)
+                .holiday(newYearsEveEarlyClose)
+                .build();
+    }
+
+}

--- a/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidays.java
+++ b/holiday-calendar-apac/src/main/java/org/holiday/calendar/impl/JapaneseHolidays.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 /**
  * Package-private factory that builds the shared base set of Japanese national
- * holidays used by both the TSE ({@code JP}) and BOJ ({@code JPY}) calendars.
+ * holidays used by both the national ({@code JP}) and BOJ ({@code JPY}) calendars.
  */
 class JapaneseHolidays {
 

--- a/holiday-calendar-apac/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
+++ b/holiday-calendar-apac/src/main/resources/META-INF/services/org.holiday.calendar.HolidayCalendarService
@@ -1,5 +1,6 @@
 org.holiday.calendar.impl.HolidayCalendarServiceCNY
 org.holiday.calendar.impl.HolidayCalendarServiceSG
+org.holiday.calendar.impl.HolidayCalendarServiceXSES
 org.holiday.calendar.impl.HolidayCalendarServiceSGD
 org.holiday.calendar.impl.HolidayCalendarServiceJP
 org.holiday.calendar.impl.HolidayCalendarServiceJPY

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceJPTest.java
@@ -55,7 +55,7 @@ public class HolidayCalendarServiceJPTest {
 
     @Test
     public void testGetRegion() {
-        assertEquals(service.getRegion(), "Japan (TSE) Holidays");
+        assertEquals(service.getRegion(), "Japan National Holidays");
     }
 
     @Test

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXSESEarlyCloseTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXSESEarlyCloseTest.java
@@ -38,7 +38,7 @@ import java.util.stream.Collectors;
 import static org.testng.Assert.*;
 
 /**
- * Tests for the {@code SG} calendar's early-close (SGX half-day closure)
+ * Tests for the {@code XSES} calendar's early-close (SGX half-day closure)
  * holidays: Christmas Eve and New Year's Eve. Because December 24 and
  * December 31 are always exactly 7 days apart, they always share the same
  * day-of-week within a given year — both early closes are always present
@@ -46,23 +46,23 @@ import static org.testng.Assert.*;
  * difference from CA (single early close) and worth its own dedicated
  * assertions below, beyond the standard count/presence/closeTime/zone checks.
  */
-public class HolidayCalendarServiceSGEarlyCloseTest {
+public class HolidayCalendarServiceXSESEarlyCloseTest {
 
     private static final LocalTime EXPECTED_CLOSE_TIME = LocalTime.of(12, 0);
     private static final ZoneId EXPECTED_ZONE = ZoneId.of("Asia/Singapore");
 
-    // 11 full-day holidays registered in HolidayCalendarServiceSG; the two Eve
+    // 11 full-day holidays registered in HolidayCalendarServiceXSES; the two Eve
     // holidays are EARLY_CLOSE and excluded by calculate(), so calculate() sees 11.
     private static final int FULL_DAY_HOLIDAY_COUNT = 11;
 
-    private final HolidayCalendarServiceSG service = new HolidayCalendarServiceSG();
+    private final HolidayCalendarServiceXSES service = new HolidayCalendarServiceXSES();
 
     // -------------------------------------------------------------------------
     // Count / presence per year (verified 2018-2026 SGX cycle)
     // -------------------------------------------------------------------------
 
-    @DataProvider(name = "sgEarlyCloseFixture")
-    public Iterator<Object[]> sgEarlyCloseFixture() {
+    @DataProvider(name = "xsesEarlyCloseFixture")
+    public Iterator<Object[]> xsesEarlyCloseFixture() {
         List<Object[]> data = Arrays.asList(
                 new Object[]{2018, true},
                 new Object[]{2019, true},
@@ -77,23 +77,23 @@ public class HolidayCalendarServiceSGEarlyCloseTest {
         return data.iterator();
     }
 
-    @Test(dataProvider = "sgEarlyCloseFixture")
+    @Test(dataProvider = "xsesEarlyCloseFixture")
     public void testEarlyCloseCountForYear(int year, boolean present) {
         List<HolidayDate> earlyCloses = service.getHolidayCalendar().calculateEarlyCloses(year);
         assertNotNull(earlyCloses);
-        assertEquals(earlyCloses.size(), present ? 2 : 0, "SG " + year + ": unexpected early-close count");
+        assertEquals(earlyCloses.size(), present ? 2 : 0, "XSES " + year + ": unexpected early-close count");
     }
 
-    @Test(dataProvider = "sgEarlyCloseFixture")
+    @Test(dataProvider = "xsesEarlyCloseFixture")
     public void testChristmasEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("Christmas Eve"), present,
-                "SG " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
+                "XSES " + year + ": Christmas Eve presence must match December 24 day-of-week rule");
     }
 
-    @Test(dataProvider = "sgEarlyCloseFixture")
+    @Test(dataProvider = "xsesEarlyCloseFixture")
     public void testNewYearsEvePresenceForYear(int year, boolean present) {
         assertEquals(earlyCloseNames(year).contains("New Year's Eve"), present,
-                "SG " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
+                "XSES " + year + ": New Year's Eve presence must match December 31 day-of-week rule");
     }
 
     private Set<String> earlyCloseNames(int year) {
@@ -103,7 +103,7 @@ public class HolidayCalendarServiceSGEarlyCloseTest {
     }
 
     // -------------------------------------------------------------------------
-    // Dual-suppression / dual-presence boundary (the SG-specific difference)
+    // Dual-suppression / dual-presence boundary (the XSES-specific difference)
     // -------------------------------------------------------------------------
 
     @Test
@@ -128,10 +128,10 @@ public class HolidayCalendarServiceSGEarlyCloseTest {
         assertEquals(names, Set.of("Christmas Eve", "New Year's Eve"));
     }
 
-    @Test(dataProvider = "sgEarlyCloseFixture")
+    @Test(dataProvider = "xsesEarlyCloseFixture")
     public void testCountIsNeverExactlyOne(int year, boolean present) {
         int count = service.getHolidayCalendar().calculateEarlyCloses(year).size();
-        assertNotEquals(count, 1, "SG " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
+        assertNotEquals(count, 1, "XSES " + year + ": Christmas Eve and New Year's Eve must always co-occur, never appear alone");
     }
 
     // -------------------------------------------------------------------------
@@ -185,7 +185,7 @@ public class HolidayCalendarServiceSGEarlyCloseTest {
     // No date appears in both calculate() and calculateEarlyCloses() for the same year
     // -------------------------------------------------------------------------
 
-    @Test(dataProvider = "sgEarlyCloseFixture")
+    @Test(dataProvider = "xsesEarlyCloseFixture")
     public void testNoDateCollisionBetweenFullDayAndEarlyClose(int year, boolean present) {
         HolidayCalendar calendar = service.getHolidayCalendar();
         Set<LocalDate> fullDayDates = calendar.calculate(year).stream()
@@ -198,7 +198,7 @@ public class HolidayCalendarServiceSGEarlyCloseTest {
                 .filter(earlyCloseDates::contains)
                 .collect(Collectors.toSet());
         assertTrue(intersection.isEmpty(),
-                "SG " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
+                "XSES " + year + ": dates must not appear in both calculate() and calculateEarlyCloses(): " + intersection);
     }
 
     // -------------------------------------------------------------------------

--- a/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXSESTest.java
+++ b/holiday-calendar-apac/src/test/java/org/holiday/calendar/impl/HolidayCalendarServiceXSESTest.java
@@ -35,9 +35,9 @@ import java.util.OptionalInt;
 
 import static org.testng.Assert.*;
 
-public class HolidayCalendarServiceSGTest {
+public class HolidayCalendarServiceXSESTest {
 
-    private final HolidayCalendarServiceSG service = new HolidayCalendarServiceSG();
+    private final HolidayCalendarServiceXSES service = new HolidayCalendarServiceXSES();
     private HolidayCalendarFactory factory;
 
     @BeforeClass
@@ -47,25 +47,25 @@ public class HolidayCalendarServiceSGTest {
 
     @Test
     public void testIsProvided() {
-        assertTrue(service.isProvided("SG"));
+        assertTrue(service.isProvided("XSES"));
         assertFalse(service.isProvided("US"));
     }
 
     @Test
     public void testGetCode() {
-        assertEquals(service.getCode(), "SG");
+        assertEquals(service.getCode(), "XSES");
     }
 
     @Test
     public void testGetRegion() {
-        assertEquals(service.getRegion(), "Singapore National Holidays");
+        assertEquals(service.getRegion(), "Singapore Exchange (SGX) Holidays");
     }
 
     @Test
     public void testHolidayCalendarFactoryCreate() {
-        HolidayCalendar calendar = factory.create("SG");
+        HolidayCalendar calendar = factory.create("XSES");
         assertNotNull(calendar);
-        assertEquals(calendar.getCode(), "SG");
+        assertEquals(calendar.getCode(), "XSES");
     }
 
     @Test
@@ -86,18 +86,14 @@ public class HolidayCalendarServiceSGTest {
                     .anyMatch(hd -> "Christmas Eve".equals(hd.getHoliday().getName())
                             || "New Year's Eve".equals(hd.getHoliday().getName()));
             assertFalse(anyEarlyClose,
-                    "SG " + year + ": Christmas Eve/New Year's Eve must not appear — moved to XSES");
+                    "XSES " + year + ": EARLY_CLOSE holidays must not appear in calculate(), only calculateEarlyCloses()");
         }
     }
 
     @Test
-    public void testSgHasNoEarlyCloses() {
+    public void testXsesHasEarlyCloses() {
         HolidayCalendar calendar = service.getHolidayCalendar();
-        assertFalse(calendar.hasEarlyCloses(), "SG: national calendar must have zero early closes");
-        for (int year : List.of(2021, 2023, 2024, 2025)) {
-            assertTrue(calendar.calculateEarlyCloses(year).isEmpty(),
-                    "SG " + year + ": calculateEarlyCloses() must be empty on the national calendar");
-        }
+        assertTrue(calendar.hasEarlyCloses(), "XSES: exchange calendar must have early closes");
     }
 
     @Test
@@ -181,7 +177,7 @@ public class HolidayCalendarServiceSGTest {
     public void testDataValidThroughReturnsPresent() {
         OptionalInt result = service.dataValidThrough();
         assertTrue(result.isPresent(),
-            "SG calendar has lookup-table holidays; must return a bounded year from dataValidThrough()");
+            "XSES calendar has lookup-table holidays; must return a bounded year from dataValidThrough()");
     }
 
     @Test
@@ -194,10 +190,10 @@ public class HolidayCalendarServiceSGTest {
 
     @Test
     public void testDataValidThroughViaFactory() {
-        OptionalInt result = factory.dataValidThrough("SG");
+        OptionalInt result = factory.dataValidThrough("XSES");
         assertTrue(result.isPresent());
         assertEquals(result.getAsInt(), service.dataValidThrough().orElseThrow(() -> new RuntimeException("Expected present boundary year")),
-            "factory.dataValidThrough(\"SG\") must delegate to the service and return the same year");
+            "factory.dataValidThrough(\"XSES\") must delegate to the service and return the same year");
     }
 
     @Test
@@ -208,7 +204,7 @@ public class HolidayCalendarServiceSGTest {
         assertFalse(holidays.isEmpty(),
             "calculate(" + boundaryYear + ") must return holidays — it is within the covered range");
         assertEquals(holidays.size(), 11,
-            "Expected all 11 SG holidays for boundary year " + boundaryYear);
+            "Expected all 11 XSES holidays for boundary year " + boundaryYear);
     }
 
     @Test

--- a/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
+++ b/tests/src/test/java/org/holiday/calendar/HolidayCalendar30YearIT.java
@@ -86,6 +86,7 @@ public class HolidayCalendar30YearIT {
                 new Object[]{"SA"},
                 new Object[]{"SAR"},
                 new Object[]{"SG"},
+                new Object[]{"XSES"},
                 new Object[]{"SGD"},
                 new Object[]{"TR"},
                 new Object[]{"TRY"},
@@ -451,56 +452,22 @@ public class HolidayCalendar30YearIT {
     }
 
     // =========================================================================
-    // 10. SG EARLY CLOSES (SGX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // 10. SG HAS NO EARLY CLOSES OVER 30 YEARS (moved to XSES, see #232)
     // =========================================================================
 
-    // Both SGX Eve early closes are suppressed (not shifted) when their date falls on a
-    // weekend; since December 24 and December 31 are always exactly 7 days apart, they
-    // always share the same day-of-week within a year, so count is always 0 or 2, never 1.
-    // Expected presence is re-derived from December 24's day-of-week rule for every year
-    // rather than hand-fixtured.
-    @Test(description = "SG calculateEarlyCloses across 2026-2055: count always in {0,2}, "
-            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
-            + "and always co-occur, no nulls, chronological order")
-    public void testSGEarlyClosesOver30Years() {
+    // SG's two SGX Eve early closes were extracted into the new XSES calendar (#232);
+    // SG is now a pure national calendar and must never report an early close. See
+    // section 14 below for the XSES early-close suite that replaces this one.
+    @Test(description = "SG calculateEarlyCloses across 2026-2055: always empty — "
+            + "early closes moved to XSES")
+    public void testSGHasNoEarlyClosesOver30Years() {
         HolidayCalendar calendar = new HolidayCalendarFactory().create("SG");
+        assertFalse(calendar.hasEarlyCloses(), "SG: national calendar must have zero early closes");
 
-        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
         for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
             List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
             assertNotNull(earlyCloses, "SG: calculateEarlyCloses(" + year + ") must not be null");
-
-            int count = earlyCloses.size();
-            assertTrue(count == 0 || count == 2,
-                    "SG " + year + ": expected count in {0,2}, got " + count);
-
-            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
-            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
-                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
-            Set<String> names = earlyCloses.stream()
-                    .map(hd -> hd.holiday().getName())
-                    .collect(Collectors.toSet());
-            assertEquals(names.contains("Christmas Eve"), expected,
-                    "SG " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
-            assertEquals(names.contains("New Year's Eve"), expected,
-                    "SG " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
-
-            allEarlyCloses.addAll(earlyCloses);
-        }
-
-        for (int i = 0; i < allEarlyCloses.size(); i++) {
-            HolidayDate hd = allEarlyCloses.get(i);
-            assertNotNull(hd, "SG: early-close entry at index " + i + " must not be null");
-            assertNotNull(hd.holiday(), "SG: early-close holiday at index " + i + " must not be null");
-            assertNotNull(hd.date(), "SG: early-close date at index " + i + " must not be null");
-        }
-
-        for (int i = 1; i < allEarlyCloses.size(); i++) {
-            LocalDate prev = allEarlyCloses.get(i - 1).date();
-            LocalDate curr = allEarlyCloses.get(i).date();
-            assertFalse(curr.isBefore(prev),
-                    "SG: early-close dates out of order at index " + i
-                            + " — " + prev + " followed by " + curr);
+            assertTrue(earlyCloses.isEmpty(), "SG " + year + ": expected no early closes, found " + earlyCloses);
         }
     }
 
@@ -752,6 +719,61 @@ public class HolidayCalendar30YearIT {
             LocalDate curr = allHolidays.get(i).date();
             assertFalse(curr.isBefore(prev),
                     "XSWX: dates out of order at index " + i
+                            + " — " + prev + " followed by " + curr);
+        }
+    }
+
+    // =========================================================================
+    // 14. XSES EARLY CLOSES (SGX Christmas Eve / New Year's Eve half-day closures) OVER 30 YEARS
+    // =========================================================================
+
+    // Same shape as SG's early-close suite (issue #232 split SGX out of SG into XSES).
+    // Both SGX Eve early closes are suppressed (not shifted) when their date falls on a
+    // weekend; since December 24 and December 31 are always exactly 7 days apart, they
+    // always share the same day-of-week within a year, so count is always 0 or 2, never 1.
+    // Expected presence is re-derived from December 24's day-of-week rule for every year
+    // rather than hand-fixtured.
+    @Test(description = "XSES calculateEarlyCloses across 2026-2055: count always in {0,2}, "
+            + "Christmas Eve/New Year's Eve presence matches December 24 dow rule (excludes Sat/Sun) "
+            + "and always co-occur, no nulls, chronological order")
+    public void testXSESEarlyClosesOver30Years() {
+        HolidayCalendar calendar = new HolidayCalendarFactory().create("XSES");
+
+        List<HolidayDate> allEarlyCloses = new java.util.ArrayList<>();
+        for (int year = FROM_YEAR; year <= TO_YEAR; year++) {
+            List<HolidayDate> earlyCloses = calendar.calculateEarlyCloses(year);
+            assertNotNull(earlyCloses, "XSES: calculateEarlyCloses(" + year + ") must not be null");
+
+            int count = earlyCloses.size();
+            assertTrue(count == 0 || count == 2,
+                    "XSES " + year + ": expected count in {0,2}, got " + count);
+
+            DayOfWeek dec24Dow = LocalDate.of(year, Month.DECEMBER, 24).getDayOfWeek();
+            boolean expected = !DayOfWeek.SATURDAY.equals(dec24Dow)
+                    && !DayOfWeek.SUNDAY.equals(dec24Dow);
+            Set<String> names = earlyCloses.stream()
+                    .map(hd -> hd.holiday().getName())
+                    .collect(Collectors.toSet());
+            assertEquals(names.contains("Christmas Eve"), expected,
+                    "XSES " + year + ": Christmas Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+            assertEquals(names.contains("New Year's Eve"), expected,
+                    "XSES " + year + ": New Year's Eve presence must match December 24 dow rule (dow=" + dec24Dow + ")");
+
+            allEarlyCloses.addAll(earlyCloses);
+        }
+
+        for (int i = 0; i < allEarlyCloses.size(); i++) {
+            HolidayDate hd = allEarlyCloses.get(i);
+            assertNotNull(hd, "XSES: early-close entry at index " + i + " must not be null");
+            assertNotNull(hd.holiday(), "XSES: early-close holiday at index " + i + " must not be null");
+            assertNotNull(hd.date(), "XSES: early-close date at index " + i + " must not be null");
+        }
+
+        for (int i = 1; i < allEarlyCloses.size(); i++) {
+            LocalDate prev = allEarlyCloses.get(i - 1).date();
+            LocalDate curr = allEarlyCloses.get(i).date();
+            assertFalse(curr.isBefore(prev),
+                    "XSES: early-close dates out of order at index " + i
                             + " — " + prev + " followed by " + curr);
         }
     }


### PR DESCRIPTION
### [APAC] Split SGX from SG national calendar; redocument JP as national-only

**Description**

- Extracts Singapore Exchange (SGX)'s two `EARLY_CLOSE` holidays (Christmas Eve, New Year's Eve) out of `HolidayCalendarServiceSG` into a new `HolidayCalendarServiceXSES` (ISO 10383 MIC code), leaving `SG` as a pure Singapore national public holiday calendar.
- Redocuments `HolidayCalendarServiceJP` to remove "Tokyo Stock Exchange / TSE" branding — its content is 100% Japan's national Holiday Act with no TSE-specific rules. No behavior change; `JPY` (Bank of Japan) is untouched.
- Registers `XSES` in `module-info.java` and `META-INF/services`.
- Adds/updates tests: `SG` now asserts `hasEarlyCloses() == false`; new `XSES`/`XSESEarlyCloseTest` cover the moved early closes; `HolidayCalendar30YearIT` extended to cover `XSES` across 2026–2055 and updated so the old SG early-close section reflects the move.

**Related Issue**

- [#232](https://github.com/holiday-calendar/holiday-calendar-java/issues/232)
- Parent: [#229](https://github.com/holiday-calendar/holiday-calendar-java/issues/229)

**Type of Change**

- [ ] Bug fix
- [x] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed

Note: README calendar table update is out of scope here — deferred to #230 per the issue's own scope notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)