### PR TITLE
#267 Fix CivicHoliday.apply(null) throwing NPE instead of returning null

### DIFF
--- a/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/CivicHoliday.java
+++ b/holiday-calendar-western/src/main/java/org/holiday/calendar/observance/ca/CivicHoliday.java
@@ -18,7 +18,7 @@
 
 package org.holiday.calendar.observance.ca;
 
-import org.holiday.calendar.function.Observance;
+import org.holiday.calendar.observance.AbstractObservance;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
@@ -35,10 +35,10 @@ import java.time.temporal.TemporalAdjusters;
  *
  * @author <a href="mailto:dave@osframework.org">Dave Joyce</a>
  */
-public class CivicHoliday implements Observance {
+public class CivicHoliday extends AbstractObservance {
 
     @Override
-    public LocalDate apply(Integer year) {
+    protected LocalDate computeDate(int year) {
         return Year.of(year)
                    .atMonth(Month.AUGUST)
                    .atDay(1)

--- a/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/ca/CivicHolidayTest.java
+++ b/holiday-calendar-western/src/test/java/org/holiday/calendar/observance/ca/CivicHolidayTest.java
@@ -19,16 +19,24 @@
 package org.holiday.calendar.observance.ca;
 
 import org.holiday.calendar.western.test.AbstractObservanceTest;
+import org.testng.annotations.Test;
 
 import java.time.LocalDate;
 import java.time.Month;
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.testng.Assert.assertNull;
+
 public class CivicHolidayTest extends AbstractObservanceTest {
 
     public CivicHolidayTest() {
         super(new CivicHoliday());
+    }
+
+    @Test
+    public void testApply_NullYear() {
+        assertNull(observance.apply(null));
     }
 
     @Override


### PR DESCRIPTION
### Title of the PR

Fix CivicHoliday.apply(null) throwing NPE instead of returning null

**Description**

`CivicHoliday` implemented `Observance` directly and never guarded `apply(Integer year)` with `test(year)`, so `Year.of(year)` unboxed a `null` year immediately and threw an unguarded `NullPointerException` instead of returning `null` per the `Observance` contract. Converted `CivicHoliday` to extend `AbstractObservance`, whose `apply`/`test` are `final` and null-safe by construction, and added a regression test.

**Related Issue**

- #267

**Type of Change**

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed