### PR TITLE
#322 Fix UAE/SA Eid al-Adha 2026 dates recording Arafat Day instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- Corrected UAE (`AE`) and Saudi Arabia (`SA`) Eid al-Adha 2026 dates — the CSV rows had recorded Arafat Day's date (26 May 2026) instead of Eid al-Adha's first day (27 May 2026); also corrected the now-inaccurate "known divergence" comment in `eid-al-adha-tr.csv`, since UAE, Saudi Arabia, and Diyanet all agree on 27 May 2026 (#322)
+
 ## [2.1.0] - 2026-08-03
 
 > **Breaking changes** — see [MIGRATION.md](MIGRATION.md) for the full upgrade guide from v1.4.0.

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-ae.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-ae.csv
@@ -15,7 +15,7 @@
 # Format: year,YYYY-MM-DD,source
 2024,2024-06-16,UAE SCA official
 2025,2025-06-06,UAE SCA official
-2026,2026-05-26,UAE SCA official
+2026,2026-05-27,UAE SCA official
 # 2027–2055: Umm al-Qura tabular projection; verify against official announcements
 2027,2027-05-15,Umm al-Qura projection
 2028,2028-05-04,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-sa.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-sa.csv
@@ -14,7 +14,7 @@
 # Format: year,YYYY-MM-DD,source
 2024,2024-06-16,Tadawul official
 2025,2025-06-06,Tadawul official
-2026,2026-05-26,Tadawul official
+2026,2026-05-27,Tadawul official
 # 2027–2055: Umm al-Qura tabular projection; verify against official announcements
 2027,2027-05-15,Umm al-Qura projection
 2028,2028-05-04,Umm al-Qura projection

--- a/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
+++ b/holiday-calendar-mena/src/main/resources/org/holiday/calendar/observance/islamic/mena/eid-al-adha-tr.csv
@@ -19,11 +19,13 @@
 #              Verify against Diyanet and BIST official announcements as each year is published.
 #              Corrections require a new JAR release — no runtime update mechanism exists.
 #
-# KNOWN DIVERGENCE — 2026: Diyanet declared 10 Dhu al-Hijjah 1447 as 27 May 2026,
-# one day later than the UAE SCA-confirmed date of 26 May 2026 (see eid-al-adha-ae.csv).
-# Both tiers are officially confirmed (not projections) — this is the canonical example
-# of ilmi takvim vs. Umm al-Qura / moon-sighting divergence. (A previously-recorded 2025
-# divergence in this file was found to be a data error — 2025-06-05 is Arefe, the eve of
+# NOTE — 2026: An earlier version of this comment claimed a 2026 divergence between
+# Diyanet (27 May 2026) and UAE SCA (26 May 2026). That claim was based on an error in
+# eid-al-adha-ae.csv, which had recorded Arafat Day's date (26 May 2026, 9 Dhu al-Hijjah)
+# mislabeled as Eid al-Adha's first day. Once corrected (see issue #322), UAE SCA, Saudi
+# Arabia, and Diyanet all agree: Eid al-Adha 2026 first day is 27 May 2026. There is no
+# genuine ilmi takvim vs. Umm al-Qura divergence for 2026. (A previously-recorded 2025
+# divergence in this file was likewise a data error — 2025-06-05 is Arefe, the eve of
 # Bayram, not the 1st day; Diyanet's own published 1st day is 2025-06-06, matching AE.)
 #
 # NOTE — 2039: Gregorian year 2039 contains two 10 Dhu al-Hijjah occurrences

--- a/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
+++ b/holiday-calendar-mena/src/test/java/org/holiday/calendar/observance/islamic/mena/EidAlAdhaTest.java
@@ -105,7 +105,7 @@ public class EidAlAdhaTest {
         return List.of(
             new Object[]{2024, LocalDate.of(2024, Month.JUNE, 16)},
             new Object[]{2025, LocalDate.of(2025, Month.JUNE, 6)},
-            new Object[]{2026, LocalDate.of(2026, Month.MAY, 27)},  // one day later than AE/SA — see below
+            new Object[]{2026, LocalDate.of(2026, Month.MAY, 27)},  // matches AE/SA — see testTR2026MatchesAE()
             new Object[]{2027, LocalDate.of(2027, Month.MAY, 16)},
             new Object[]{2035, LocalDate.of(2035, Month.FEBRUARY, 18)},
             // 2036-2055 are IlmiTakvimCalculator projections (Diyanet has not yet
@@ -123,20 +123,12 @@ public class EidAlAdhaTest {
                 "Eid al-Adha " + year + " per Diyanet must be " + expected);
     }
 
-    // Canonical Diyanet vs. Umm al-Qura/UAE divergence: 2026 Eid al-Adha.
-    // (A previously-recorded 2025 divergence was a data error: 2025-06-05 is Arefe,
-    // the eve of Bayram, not the actual 1st day — Diyanet's published 1st day is
-    // 2025-06-06, matching AE/SA. No divergence exists in 2025.)
+    // 2026 no longer diverges once the Arafat-Day/Eid-day data error in eid-al-adha-ae.csv
+    // is corrected (see issue #322) — UAE SCA, Saudi Arabia, and Diyanet all agree on 27 May 2026.
     @Test
-    public void testTR2026DiffersFromAE() {
-        LocalDate trDate = new EidAlAdha("TR").apply(2026);
-        LocalDate aeDate = new EidAlAdha("AE").apply(2026);
-        assertEquals(trDate, LocalDate.of(2026, Month.MAY, 27),
-                "Diyanet Eid al-Adha 2026 must be May 27");
-        assertEquals(aeDate, LocalDate.of(2026, Month.MAY, 26),
-                "UAE SCA Eid al-Adha 2026 must be May 26");
-        assertNotEquals(trDate, aeDate,
-                "Diyanet and UAE SCA Eid al-Adha 2026 must differ by one day");
+    public void testTR2026MatchesAE() {
+        assertEquals(new EidAlAdha("TR").apply(2026), new EidAlAdha("AE").apply(2026),
+                "Eid al-Adha 2026: Diyanet (TR) and UAE SCA (AE) must agree on May 27");
     }
 
     // 2025 no longer diverges once the Arefe/Bayram-day data error is corrected


### PR DESCRIPTION
### #322 Fix UAE/SA Eid al-Adha 2026 dates recording Arafat Day instead

**Description**

- `eid-al-adha-ae.csv`'s 2026 row (`2026-05-26`) had recorded Arafat Day's date instead of Eid al-Adha's first day. Confirmed against UAE Fatwa Council, Khaleej Times, Gulf News, and Gulf Business — the actual UAE-announced Eid al-Adha 2026 first day is 2026-05-27.
- The identical swap was independently found in `eid-al-adha-sa.csv` (Saudi Arabia / Tadawul) during research and fixed in the same PR, confirmed against Saudi Supreme Court's own May 27 announcement.
- `eid-al-adha-tr.csv`'s "KNOWN DIVERGENCE — 2026" comment cited the wrong AE value as evidence of a real Diyanet/Umm-al-Qura divergence; rewritten to explain the divergence was illusory — UAE, Saudi Arabia, and Turkish Diyanet all agree on May 27, 2026.
- `EidAlAdhaTest.java`'s `testTR2026DiffersFromAE()` asserted the now-false divergence; replaced with `testTR2026MatchesAE()`, mirroring this repo's own precedent for the analogous 2025 TR/AE fix (#180).
- Added a `[Unreleased]` CHANGELOG.md entry.

**Related Issue**

- #322

**Type of Change**

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally (`mvn clean install`; 1166 mena tests, 25 `EidAlAdhaTest` tests, 169 `HolidayCalendar30YearIT` tests all pass)
- [x] Documentation has been updated, if needed (CHANGELOG.md)
- [ ] Screenshots or additional notes added, if needed

**Scope note:** Two other CSVs (`eid-al-adha-eg.csv`, `eid-al-adha-qa.csv`) show the same suspicious 2026-05-26 value but were left unchanged — unverified against primary sources, recommend separate follow-up issues rather than guessing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)