### PR TITLE
Add early-close usage examples and skip-v2.0.0 pointer to README

### DIFF
--- a/.claude/skills/ship-issue/SKILL.md
+++ b/.claude/skills/ship-issue/SKILL.md
@@ -1,0 +1,77 @@
+---
+name: ship-issue
+description: Commit pending changes with an issue-number prefix, push the branch, and open a PR against develop using the org-level PULL_REQUEST_TEMPLATE.md, assigned to the invoker with holiday-calendar/dev as reviewer. Use when the user asks to commit and create/open a PR for the current issue/branch, or says something like "ship this", "commit and push and open a PR", or names an issue number to associate a commit/PR with.
+---
+
+# Ship issue PR
+
+Commits the current change set, pushes, and opens a PR against `develop` —
+this repo's PRs never target `main`. Works for any issue number; nothing
+here is specific to one issue.
+
+## 1. Determine the issue number
+
+Run `.claude/skills/ship-issue/scripts/infer-issue-number.sh`. It prints
+the leading number from the current branch name (e.g. branch
+`227-add-early-close-api-usage` → `227`), or `NONE` if the branch name
+doesn't start with a number.
+
+- If it prints a number and the user didn't specify one, use it.
+- If it prints `NONE`, or the user explicitly gave a different issue number,
+  ask which issue to associate this with before proceeding — don't guess.
+
+## 2. Commit
+
+Run `git status` first and review what's changed — do not `git add -A`
+blindly. Stage the files that are actually part of this change (ask the user
+if it's ambiguous which pending changes belong in this commit).
+
+Match this repo's existing commit style (see `git log` for more examples):
+
+```
+#<issue-number> <concise summary, imperative mood>
+
+<optional body: why, not what, if the change needs context>
+
+Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
+```
+
+Never use `--no-verify` or otherwise skip hooks. If a hook fails, fix the
+underlying issue and create a new commit — don't amend past a hook failure.
+
+## 3. Push
+
+`git push`, adding `-u origin <branch>` if the branch has no upstream yet.
+Never force-push.
+
+## 4. Fetch the org PR template
+
+Run `.claude/skills/ship-issue/scripts/fetch-pr-template.sh`. This pulls
+`PULL_REQUEST_TEMPLATE.md` live from the `holiday-calendar/.github` repo
+root — fetch it fresh each time rather than assuming a cached copy, since the
+org can change it. Fill in its fields yourself (don't just paste it back
+unfilled):
+
+- **Description** — what changed and why, written for a reviewer.
+- **Related Issue** — link to `https://github.com/holiday-calendar/holiday-calendar-java/issues/<issue-number>`.
+- **Type of Change** — check the box(es) that actually apply.
+- **Checklist** — check off what's genuinely true (tests run locally, docs
+  updated if needed, etc.); don't check boxes you haven't verified.
+
+## 5. Open the PR
+
+```bash
+gh pr create --base develop --head <branch> \
+  --assignee "@me" --reviewer "holiday-calendar/dev" \
+  --title "<title>" --body "<filled-in template>"
+```
+
+- Base is always `develop`, never `main`.
+- If `gh pr create` fails because a PR already exists for this branch, print
+  `PR #<number> already exists, editing instead`, then use `gh pr edit` to
+  update title/body/assignee/reviewer instead of erroring out.
+
+## 6. Report back
+
+Give the user the PR URL. Don't summarize the whole diff again — they just
+watched it happen.

--- a/.claude/skills/ship-issue/scripts/fetch-pr-template.sh
+++ b/.claude/skills/ship-issue/scripts/fetch-pr-template.sh
@@ -1,0 +1,8 @@
+#!/usr/bin/env bash
+# Fetches the org-level PR template. Lives at the repo ROOT of
+# holiday-calendar/.github, not inside a .github/ subfolder within it --
+# don't "fix" this path without checking, it's been a point of confusion
+# before.
+set -euo pipefail
+
+gh api repos/holiday-calendar/.github/contents/PULL_REQUEST_TEMPLATE.md --jq '.content' | base64 -d

--- a/.claude/skills/ship-issue/scripts/infer-issue-number.sh
+++ b/.claude/skills/ship-issue/scripts/infer-issue-number.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Prints the leading issue number from the current branch name (e.g.
+# "227-add-early-close-api-usage" -> "227"), or "NONE" if the branch name
+# doesn't start with one.
+set -euo pipefail
+
+branch="$(git branch --show-current)"
+
+if [[ "$branch" =~ ^([0-9]+) ]]; then
+  echo "${BASH_REMATCH[1]}"
+else
+  echo "NONE"
+fi

--- a/.gitignore
+++ b/.gitignore
@@ -248,3 +248,5 @@ gradle-app.setting
 .claude/skills/*
 !.claude/skills/region-calendar-issue-plan/
 !.claude/skills/region-calendar-issue-plan/**
+!.claude/skills/ship-issue/
+!.claude/skills/ship-issue/**

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ A Java library for defining and calculating holiday calendars. Provides an exten
 
 > **Upgrading from v1.4.0 or earlier?** v2.0.0 introduced the `EarlyCloseHoliday`
 > API, and v2.1.0 separates national holiday calendars from equities-exchange
-> market calendars. See [MIGRATION.md](MIGRATION.md) for the full breaking-changes
-> guide.
+> market calendars. **Skip v2.0.0 and upgrade straight to v2.1.0 or later** — see
+> [MIGRATION.md](MIGRATION.md) for the full breaking-changes guide.
 
 > **Porting to another language?** See [docs/PORTING_GUIDE.md](docs/PORTING_GUIDE.md) for the core abstractions, design patterns, and data formats needed to build a compatible implementation in JavaScript, Python, Go, or any other language.
 
@@ -80,7 +80,7 @@ applicable (e.g. `ILS` for TASE, `TRY` for BIST).
 | Morocco | `MA` | `MAD` CSE/BAM | — |
 | Jordan | `JO` | `JOD` ASE/CBJ | — |
 
-For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
+For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md). For per-exchange early-close times, time zones, weekend-roll behavior, and primary-source citations, see the [calendar reference docs](docs/calendars/README.md).
 
 ## Installation
 
@@ -170,6 +170,51 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 ```java
 List<String> codes = factory.listAvailableCodes();
 // ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JO", "JOD", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+```
+
+### Retrieve early close holidays
+
+`EarlyCloseHoliday` entries represent partial trading days — e.g. NYSE's 1:00pm ET
+close the day after Thanksgiving. They are excluded from `calculate()` and must be
+retrieved separately via `calculateEarlyCloses(int)`. Use an exchange MIC code such
+as `XNYS` — national codes no longer carry early closes (with the sole exception of
+`TR`; see [Supported Calendars](#supported-calendars)).
+
+```java
+import org.holiday.calendar.EarlyCloseHoliday;
+
+HolidayCalendar xnysCalendar = factory.create("XNYS");
+
+for (HolidayDate hd : xnysCalendar.calculateEarlyCloses(2026)) {
+    EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+    System.out.printf("%s  %s closes at %s %s%n",
+        hd.getDate(), earlyClose.getName(), earlyClose.getCloseTime(), earlyClose.getZoneId());
+}
+```
+
+`hasEarlyCloses()` is a cheap, year-independent check for whether a calendar has any
+early-close entries at all, useful for branching without computing a specific year.
+
+```java
+if (xnysCalendar.hasEarlyCloses()) {
+    System.out.println("This calendar publishes early-close trading days.");
+}
+```
+
+To get a single chronologically-sorted view of both full closures and early closes for
+a year, merge the two result lists and re-sort — `HolidayDate` is not `Comparable`, so
+sort with an explicit `Comparator`:
+
+```java
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+List<HolidayDate> allDates2026 = Stream.concat(
+        xnysCalendar.calculate(2026).stream(),
+        xnysCalendar.calculateEarlyCloses(2026).stream())
+    .sorted(Comparator.comparing(HolidayDate::getDate))
+    .toList();
 ```
 
 ### Define a custom holiday calendar

--- a/src/readme/README.md
+++ b/src/readme/README.md
@@ -8,8 +8,8 @@ A Java library for defining and calculating holiday calendars. Provides an exten
 
 > **Upgrading from v1.4.0 or earlier?** v2.0.0 introduced the `EarlyCloseHoliday`
 > API, and v2.1.0 separates national holiday calendars from equities-exchange
-> market calendars. See [MIGRATION.md](MIGRATION.md) for the full breaking-changes
-> guide.
+> market calendars. **Skip v2.0.0 and upgrade straight to v2.1.0 or later** — see
+> [MIGRATION.md](MIGRATION.md) for the full breaking-changes guide.
 
 > **Porting to another language?** See [docs/PORTING_GUIDE.md](docs/PORTING_GUIDE.md) for the core abstractions, design patterns, and data formats needed to build a compatible implementation in JavaScript, Python, Go, or any other language.
 
@@ -80,7 +80,7 @@ applicable (e.g. `ILS` for TASE, `TRY` for BIST).
 | Morocco | `MA` | `MAD` CSE/BAM | — |
 | Jordan | `JO` | `JOD` ASE/CBJ | — |
 
-For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md).
+For information on adding new calendars or maintaining existing ones, see the [Contributing Guide](CONTRIBUTING.md). For per-exchange early-close times, time zones, weekend-roll behavior, and primary-source citations, see the [calendar reference docs](docs/calendars/README.md).
 
 ## Installation
 
@@ -170,6 +170,51 @@ List<HolidayDate> combined2025 = combined.calculate(2025);
 ```java
 List<String> codes = factory.listAvailableCodes();
 // ["AE", "AED", "AU", "AUD", "BH", "BHD", "CA", "CAD", "CH", "CHF", "CN", "CNY", "DE", "EUR", "FR", "GBP", "IL", "ILS", "JO", "JOD", "JP", "JPY", "KW", "KWD", "MA", "MAD", "QA", "QAR", "SA", "SAR", "SG", "SGD", "TR", "TRY", "UK", "US", "USD"]
+```
+
+### Retrieve early close holidays
+
+`EarlyCloseHoliday` entries represent partial trading days — e.g. NYSE's 1:00pm ET
+close the day after Thanksgiving. They are excluded from `calculate()` and must be
+retrieved separately via `calculateEarlyCloses(int)`. Use an exchange MIC code such
+as `XNYS` — national codes no longer carry early closes (with the sole exception of
+`TR`; see [Supported Calendars](#supported-calendars)).
+
+```java
+import org.holiday.calendar.EarlyCloseHoliday;
+
+HolidayCalendar xnysCalendar = factory.create("XNYS");
+
+for (HolidayDate hd : xnysCalendar.calculateEarlyCloses(2026)) {
+    EarlyCloseHoliday earlyClose = (EarlyCloseHoliday) hd.getHoliday();
+    System.out.printf("%s  %s closes at %s %s%n",
+        hd.getDate(), earlyClose.getName(), earlyClose.getCloseTime(), earlyClose.getZoneId());
+}
+```
+
+`hasEarlyCloses()` is a cheap, year-independent check for whether a calendar has any
+early-close entries at all, useful for branching without computing a specific year.
+
+```java
+if (xnysCalendar.hasEarlyCloses()) {
+    System.out.println("This calendar publishes early-close trading days.");
+}
+```
+
+To get a single chronologically-sorted view of both full closures and early closes for
+a year, merge the two result lists and re-sort — `HolidayDate` is not `Comparable`, so
+sort with an explicit `Comparator`:
+
+```java
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+
+List<HolidayDate> allDates2026 = Stream.concat(
+        xnysCalendar.calculate(2026).stream(),
+        xnysCalendar.calculateEarlyCloses(2026).stream())
+    .sorted(Comparator.comparing(HolidayDate::getDate))
+    .toList();
 ```
 
 ### Define a custom holiday calendar


### PR DESCRIPTION
### Title of the PR

Add early-close usage examples and skip-v2.0.0 pointer to README

**Description**

- Adds a `### Retrieve early close holidays` subsection under `## Usage`, with examples for `calculateEarlyCloses()`, `hasEarlyCloses()`, and merging early closes with `calculate()` results, all verified to compile against the current API.
- Links the `### Supported Calendars` section to the per-exchange reference docs in `docs/calendars/` (close times, time zones, weekend-roll behavior, primary-source citations) rather than duplicating that data into a new README table.
- Adds a one-sentence "skip v2.0.0, go straight to v2.1.0+" callout to the existing upgrade blockquote, consistent with `MIGRATION.md`'s existing warning.

**Related Issue**

- [#227](https://github.com/holiday-calendar/holiday-calendar-java/issues/227)

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [x] Code refactor
- [x] Other (please describe): Documentation only — no source code changes

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed