### PR TITLE
#327 Merge stray Unreleased CHANGELOG entry into 2.1.0 section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Fixed
-
-- Corrected UAE (`AE`) and Saudi Arabia (`SA`) Eid al-Adha 2026 dates — the CSV rows had recorded Arafat Day's date (26 May 2026) instead of Eid al-Adha's first day (27 May 2026); also corrected the now-inaccurate "known divergence" comment in `eid-al-adha-tr.csv`, since UAE, Saudi Arabia, and Diyanet all agree on 27 May 2026 (#322)
-
 ## [2.1.0] - 2026-08-03
 
 > **Breaking changes** — see [MIGRATION.md](MIGRATION.md) for the full upgrade guide from v1.4.0.
@@ -25,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - New `HolidayCalendarServiceXNYS`, `XTSE`, `XLON`, `XASX`, `XPAR`, `XSWX`, `XETR` (western) and `XSES` (apac) market calendar implementations
+
+### Fixed
+
+- Corrected UAE (`AE`) and Saudi Arabia (`SA`) Eid al-Adha 2026 dates — the CSV rows had recorded Arafat Day's date (26 May 2026) instead of Eid al-Adha's first day (27 May 2026); also corrected the now-inaccurate "known divergence" comment in `eid-al-adha-tr.csv`, since UAE, Saudi Arabia, and Diyanet all agree on 27 May 2026 (#322)
 
 ## [2.0.0] - 2026-08-01
 


### PR DESCRIPTION
### Title of the PR

**Description**

- `CHANGELOG.md` had a `## [2.1.0] - 2026-08-03` section that was dated before the release was actually cut — no `v2.1.0` tag exists yet and `pom.xml` is still `2.1.0-SNAPSHOT`. The subsequent #322 fix (UAE/SA Eid al-Adha 2026 date correction) landed in a new `## [Unreleased]` header above it. This PR folds that fix into the `[2.1.0]` section under a new `### Fixed` subsection and removes the dangling `[Unreleased]` header, so the file is clean ahead of the actual v2.1.0 cut.

**Related Issue**

- [#327](https://github.com/holiday-calendar/holiday-calendar-java/issues/327)

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Other (please describe): CHANGELOG housekeeping ahead of release

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed