### PR TITLE
#329 Add organization element to fix Javadoc footer copyright attribution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
         </license>
     </licenses>
 
+    <organization>
+        <name>Holiday Project Team</name>
+        <url>${project.url}</url>
+    </organization>
+
     <developers>
         <developer>
             <id>davejoyce</id>


### PR DESCRIPTION
### Title of the PR

**Description**

- The published aggregate Javadoc footer (https://holiday-calendar.org/holiday-calendar-java/) reads "Copyright © 2021–2026. All rights reserved." with no attribution of who holds the copyright. This is maven-javadoc-plugin's default `bottom` template rendering with an empty `{organizationName}` slot, since the root `pom.xml` had no `<organization>` element.

- Fix: add an `<organization>` element (name: "Holiday Project Team", url: `${project.url}`) to the root POM. No `maven-javadoc-plugin` configuration change is needed — the plugin's default template picks up the org name automatically.

- Verified locally by running `mvn org.apache.maven.plugins:maven-javadoc-plugin:aggregate`; the generated footer now reads:

  > Copyright © 2021–2026 [Holiday Project Team](https://github.com/holiday-calendar/holiday-calendar-java). All rights reserved.

**Related Issue**

- [#329](https://github.com/holiday-calendar/holiday-calendar-java/issues/329)

**Type of Change**

- [x] Bug fix
- [ ] New feature
- [ ] Code refactor
- [ ] Other (please describe):

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [ ] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed