### PR TITLE
chore: bump to 2.2.0-SNAPSHOT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.1.0] - 2026-08-03
+## [Unreleased]
+
+## [2.1.0] - 2026-08-07
 
 > **Breaking changes** — see [MIGRATION.md](MIGRATION.md) for the full upgrade guide from v1.4.0.
 

--- a/README.md
+++ b/README.md
@@ -105,28 +105,28 @@ Then add the modules you need:
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-core</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
 </dependency>
 
 <!-- Western calendars: US, USD, CA, CAD, UK, GBP, CH, CHF, DE, EUR, FR, AU, AUD -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-western</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
 </dependency>
 
 <!-- APAC calendars: SG, SGD, JP, JPY, CN, CNY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-apac</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
 </dependency>
 
 <!-- MENA calendars: AE, AED, BH, BHD, EG, EGP, IL, ILS, JO, JOD, KW, KWD, MA, MAD, QA, QAR, SA, SAR, TR, TRY -->
 <dependency>
   <groupId>org.holiday.calendar</groupId>
   <artifactId>holiday-calendar-mena</artifactId>
-  <version>2.1.0-SNAPSHOT</version>
+  <version>2.2.0-SNAPSHOT</version>
 </dependency>
 ```
 

--- a/holiday-calendar-apac/pom.xml
+++ b/holiday-calendar-apac/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-core/pom.xml
+++ b/holiday-calendar-core/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-core</artifactId>

--- a/holiday-calendar-mena/pom.xml
+++ b/holiday-calendar-mena/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/holiday-calendar-western/pom.xml
+++ b/holiday-calendar-western/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>holiday-calendar-western</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
     <groupId>org.holiday.calendar</groupId>
     <artifactId>holiday-calendar-java</artifactId>
     <packaging>pom</packaging>
-    <version>2.1.0-SNAPSHOT</version>
+    <version>2.2.0-SNAPSHOT</version>
 
     <name>Holiday Calendar</name>
     <description>Holiday Calendar Library for Java</description>

--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <artifactId>holiday-calendar-java</artifactId>
         <groupId>org.holiday.calendar</groupId>
-        <version>2.1.0-SNAPSHOT</version>
+        <version>2.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>tests</artifactId>


### PR DESCRIPTION
### Title of the PR

**Description**

- Post-release housekeeping following the v2.1.0 cut (tag pushed at merge commit 76ecbd2 on `main`). Bumps version `2.1.0` → `2.2.0-SNAPSHOT` across all modules, regenerates `README.md` dependency versions, updates the CHANGELOG `[2.1.0]` date to the actual release date (2026-08-07, matching what shipped on `main`), and opens a new empty `[Unreleased]` section for post-2.1.0 work.
- `mvn clean install` passes locally: 190/190 tests green.

**Related Issue**

- N/A (release housekeeping)

**Type of Change**

- [ ] Bug fix
- [ ] New feature
- [ ] Code refactor
- [x] Other (please describe): Post-release version bump

**Checklist**

- [x] Code is properly formatted and linted
- [x] All tests have passed locally
- [x] Documentation has been updated, if needed
- [ ] Screenshots or additional notes added, if needed